### PR TITLE
Bump SOR version to 2.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@uniswap/default-token-list": "^4.1.0",
         "@uniswap/router-sdk": "^1.0.5",
         "@uniswap/sdk-core": "^3.0.1",
-        "@uniswap/smart-order-router": "^2.6.0",
+        "@uniswap/smart-order-router": "^2.6.1",
         "@uniswap/token-lists": "^1.0.0-beta.24",
         "@uniswap/v3-periphery": "^1.1.0",
         "@uniswap/v3-sdk": "^3.7.1",
@@ -2572,9 +2572,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-2.6.0.tgz",
-      "integrity": "sha512-4SvzVLJXB8/cJEKY8XicPkUPTRx7ojGLcJcqNwS+gSh3uIk+xYRjC1Vh2BKYC7Q5gjfcAFW+Z7mPL00DKrGgQQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-2.6.1.tgz",
+      "integrity": "sha512-pIWMy/y0lodPWFacBY/F1xSqAGwS5qpd3LELWb3J3O0jgPBg8QoRHMg/rBemAe+Gw+BWZoZ2z4UScYdrMhny2Q==",
       "dependencies": {
         "@nomiclabs/hardhat-ethers": "^2.0.6",
         "@types/async-retry": "^1.4.2",
@@ -22400,9 +22400,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-2.6.0.tgz",
-      "integrity": "sha512-4SvzVLJXB8/cJEKY8XicPkUPTRx7ojGLcJcqNwS+gSh3uIk+xYRjC1Vh2BKYC7Q5gjfcAFW+Z7mPL00DKrGgQQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-2.6.1.tgz",
+      "integrity": "sha512-pIWMy/y0lodPWFacBY/F1xSqAGwS5qpd3LELWb3J3O0jgPBg8QoRHMg/rBemAe+Gw+BWZoZ2z4UScYdrMhny2Q==",
       "requires": {
         "@nomiclabs/hardhat-ethers": "^2.0.6",
         "@types/async-retry": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@uniswap/default-token-list": "^4.1.0",
     "@uniswap/router-sdk": "^1.0.5",
     "@uniswap/sdk-core": "^3.0.1",
-    "@uniswap/smart-order-router": "^2.6.0",
+    "@uniswap/smart-order-router": "^2.6.1",
     "@uniswap/token-lists": "^1.0.0-beta.24",
     "@uniswap/v3-periphery": "^1.1.0",
     "@uniswap/v3-sdk": "^3.7.1",


### PR DESCRIPTION
To update cloudflare pool list and return a new attribute from the v2 subgraph query