### PR TITLE
Add cron for cleaning old IPFS pool caches

### DIFF
--- a/lib/cron/cache-pools-ipfs.ts
+++ b/lib/cron/cache-pools-ipfs.ts
@@ -15,7 +15,7 @@ const pinata = pinataSDK(process.env.PINATA_API_KEY!, process.env.PINATA_API_SEC
 
 const handler: ScheduledHandler = async (event: EventBridgeEvent<string, void>) => {
   const log: Logger = bunyan.createLogger({
-    name: 'RoutingLambda',
+    name: 'IPFSPoolCacheLambda',
     serializers: bunyan.stdSerializers,
     level: 'info',
     requestId: event.id,

--- a/lib/cron/clean-pools-ipfs.ts
+++ b/lib/cron/clean-pools-ipfs.ts
@@ -21,7 +21,7 @@ const handler: ScheduledHandler = async (event: EventBridgeEvent<string, void>) 
     level: 'info',
     requestId: event.id,
   })
-  
+
   const now = new Date()
   const startDate = new Date(now.getFullYear(), now.getMonth() - START_MONTHS_AGO, now.getDate())
   const endDate = new Date(now.getFullYear(), now.getMonth() - END_MONTHS_AGO, now.getDate())

--- a/lib/cron/clean-pools-ipfs.ts
+++ b/lib/cron/clean-pools-ipfs.ts
@@ -1,0 +1,90 @@
+import pinataSDK from '@pinata/sdk'
+import { EventBridgeEvent, ScheduledHandler } from 'aws-lambda'
+import { default as bunyan, default as Logger } from 'bunyan'
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+const START_MONTHS_AGO = 2
+const END_MONTHS_AGO = 1
+
+const PAGE_SIZE = 1000
+const DRY_RUN = true
+
+const pinata = pinataSDK(process.env.PINATA_API_KEY!, process.env.PINATA_API_SECRET!)
+
+const handler: ScheduledHandler = async (event: EventBridgeEvent<string, void>) => {
+  const log: Logger = bunyan.createLogger({
+    name: 'CleanIPFSPoolCacheLambda',
+    serializers: bunyan.stdSerializers,
+    level: 'info',
+    requestId: event.id,
+  })
+  
+  const now = new Date()
+  const startDate = new Date(now.getFullYear(), now.getMonth() - START_MONTHS_AGO, now.getDate())
+  const endDate = new Date(now.getFullYear(), now.getMonth() - END_MONTHS_AGO, now.getDate())
+
+  let unpinned = 0
+  let count = 1
+
+  while (unpinned < count) {
+    const filters = {
+      status: 'pinned',
+      pinStart: startDate.toISOString(),
+      pinEnd: endDate.toISOString(),
+      // retrieve only the pool data (called temp for now)
+      metadata: { name: 'temp', keyvalues: {} },
+      pageLimit: PAGE_SIZE,
+      // Do not need to change offset, getting new data from pinList each time.
+      pageOffset: 0,
+    }
+
+    try {
+      const result = await pinata.pinList(filters)
+      // 3 requests per second is max allowed by Pinata API. We ensure we do not exceed 2 requests per second to give a buffer.
+      await delay(500)
+
+      if (count == 1) {
+        // set count
+        count = result.count
+        log.info(
+          { startDate, endDate },
+          `Overall pins count between ${startDate.toDateString()} and ${endDate.toDateString()}: ${count}`
+        )
+      }
+
+      for (let i = 0; i < result.rows.length; i += 1) {
+        const { ipfs_pin_hash: hash } = result.rows[i]
+
+        if (DRY_RUN) {
+          log.info({ r: result.rows[i] }, `DRY_RUN: Would have unpinned ${result.rows[i]}`)
+          continue
+        }
+
+        try {
+          const response = await pinata.unpin(hash)
+
+          // 3 requests per second is max allowed by Pinata API. We ensure we do not exceed 2 requests per second to give a buffer.
+          await delay(500)
+
+          unpinned += 1
+          log.info({ response, hash }, `Unpinned: ${hash}`)
+        } catch (err) {
+          log.error({ err }, `Error. Unpinned ${unpinned} so far. Waiting one minute.`)
+          await delay(60000)
+          // set i back one since it was an unsuccessful unpin
+          i -= 1
+        }
+        log.info(`Unpinned ${unpinned} out of ${result.rows.length} from current page.`)
+      }
+    } catch (err) {
+      log.error(`Error ${err}`)
+      await delay(60000)
+    }
+  }
+
+  log.info(`Unpinned all ${unpinned} pins out of ${count} in the date range.`)
+}
+module.exports = { handler }


### PR DESCRIPTION
Plan is to push it out with dryRun set to true, check logs, then remove the flag in a subsequent PR

One note, the Lambda may timeout (lambdas have max 15 min duration). I think this is fine, we can just let it timeout, and schedule the lambda to run a few times a week