### PR TITLE
Update alarm thresholds, add new metrics+alarms for each individual chain, comment out goerli integ-tests

### DIFF
--- a/bin/stacks/routing-api-stack.ts
+++ b/bin/stacks/routing-api-stack.ts
@@ -268,7 +268,7 @@ export class RoutingAPIStack extends cdk.Stack {
     const simulationAlarmSev2 = new aws_cloudwatch.Alarm(this, 'RoutingAPI-SEV2-Simulation', {
       alarmName: 'RoutingAPI-SEV2-Simulation',
       metric: new MathExpression({
-        expression: "100*(simulationFailed/simulationRequested)",
+        expression: '100*(simulationFailed/simulationRequested)',
         usingMetrics: {
           simulationRequested: new aws_cloudwatch.Metric({
             namespace: 'Uniswap',
@@ -276,7 +276,7 @@ export class RoutingAPIStack extends cdk.Stack {
             dimensionsMap: { Service: 'RoutingAPI' },
             unit: aws_cloudwatch.Unit.COUNT,
             period: Duration.minutes(5),
-            statistic: 'sum'
+            statistic: 'sum',
           }),
           simulationFailed: new aws_cloudwatch.Metric({
             namespace: 'Uniswap',
@@ -284,9 +284,9 @@ export class RoutingAPIStack extends cdk.Stack {
             dimensionsMap: { Service: 'RoutingAPI' },
             unit: aws_cloudwatch.Unit.COUNT,
             period: Duration.minutes(5),
-            statistic: 'sum'
+            statistic: 'sum',
           }),
-        }
+        },
       }),
       threshold: 40,
       evaluationPeriods: 2,
@@ -295,7 +295,7 @@ export class RoutingAPIStack extends cdk.Stack {
     const simulationAlarmSev3 = new aws_cloudwatch.Alarm(this, 'RoutingAPI-SEV3-Simulation', {
       alarmName: 'RoutingAPI-SEV3-Simulation',
       metric: new MathExpression({
-        expression: "100*(simulationFailed/simulationRequested)",
+        expression: '100*(simulationFailed/simulationRequested)',
         usingMetrics: {
           simulationRequested: new aws_cloudwatch.Metric({
             namespace: 'Uniswap',
@@ -303,7 +303,7 @@ export class RoutingAPIStack extends cdk.Stack {
             dimensionsMap: { Service: 'RoutingAPI' },
             unit: aws_cloudwatch.Unit.COUNT,
             period: Duration.minutes(5),
-            statistic: 'sum'
+            statistic: 'sum',
           }),
           simulationFailed: new aws_cloudwatch.Metric({
             namespace: 'Uniswap',
@@ -311,9 +311,9 @@ export class RoutingAPIStack extends cdk.Stack {
             dimensionsMap: { Service: 'RoutingAPI' },
             unit: aws_cloudwatch.Unit.COUNT,
             period: Duration.minutes(5),
-            statistic: 'sum'
+            statistic: 'sum',
           }),
-        }
+        },
       }),
       threshold: 20,
       evaluationPeriods: 2,
@@ -321,10 +321,10 @@ export class RoutingAPIStack extends cdk.Stack {
 
     // Alarms for 200 rate being too low for each chain
     const percent2XXByChainAlarm: cdk.aws_cloudwatch.Alarm[] = []
-    SUPPORTED_CHAINS.forEach(chainId => {
+    SUPPORTED_CHAINS.forEach((chainId) => {
       const alarmName = `RoutingAPI-SEV3-2XXAlarm-ChainId: ${chainId.toString()}`
       const metric = new MathExpression({
-        expression: "100*(response200/invocations)",
+        expression: '100*(response200/invocations)',
         usingMetrics: {
           invocations: new aws_cloudwatch.Metric({
             namespace: 'Uniswap',
@@ -332,7 +332,7 @@ export class RoutingAPIStack extends cdk.Stack {
             dimensionsMap: { Service: 'RoutingAPI' },
             unit: aws_cloudwatch.Unit.COUNT,
             period: Duration.minutes(5),
-            statistic: 'sum'
+            statistic: 'sum',
           }),
           response200: new aws_cloudwatch.Metric({
             namespace: 'Uniswap',
@@ -340,36 +340,36 @@ export class RoutingAPIStack extends cdk.Stack {
             dimensionsMap: { Service: 'RoutingAPI' },
             unit: aws_cloudwatch.Unit.COUNT,
             period: Duration.minutes(5),
-            statistic: 'sum'
+            statistic: 'sum',
           }),
-        }
+        },
       })
       const alarm = new aws_cloudwatch.Alarm(this, alarmName, {
         alarmName,
         metric,
         threshold: 20,
         evaluationPeriods: 2,
-        comparisonOperator: aws_cloudwatch.ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD
+        comparisonOperator: aws_cloudwatch.ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
       })
       percent2XXByChainAlarm.push(alarm)
     })
 
     // Alarms for high 400 error rate for each chain
     const percent4XXByChainAlarm: cdk.aws_cloudwatch.Alarm[] = []
-    SUPPORTED_CHAINS.forEach(chainId => {
+    SUPPORTED_CHAINS.forEach((chainId) => {
       const alarmName = `RoutingAPI-SEV3-4XXAlarm-ChainId: ${chainId.toString()}`
       const metric = new MathExpression({
-        expression: "100*(response400/invocations)",
+        expression: '100*(response400/invocations)',
         usingMetrics: {
           invocations: api.metric(`GET_QUOTE_REQUESTED_CHAINID: ${chainId.toString()}`, {
             period: Duration.minutes(5),
-            statistic: 'sum'
+            statistic: 'sum',
           }),
           response400: api.metric(`GET_QUOTE_400_CHAINID: ${chainId.toString()}`, {
             period: Duration.minutes(5),
-            statistic: 'sum'
-          })
-        }
+            statistic: 'sum',
+          }),
+        },
       })
       const alarm = new aws_cloudwatch.Alarm(this, alarmName, {
         alarmName,
@@ -391,10 +391,10 @@ export class RoutingAPIStack extends cdk.Stack {
       simulationAlarmSev2.addAlarmAction(new aws_cloudwatch_actions.SnsAction(chatBotTopic))
       simulationAlarmSev3.addAlarmAction(new aws_cloudwatch_actions.SnsAction(chatBotTopic))
 
-      percent2XXByChainAlarm.forEach(alarm => {
+      percent2XXByChainAlarm.forEach((alarm) => {
         alarm.addAlarmAction(new aws_cloudwatch_actions.SnsAction(chatBotTopic))
       })
-      percent4XXByChainAlarm.forEach(alarm => {
+      percent4XXByChainAlarm.forEach((alarm) => {
         alarm.addAlarmAction(new aws_cloudwatch_actions.SnsAction(chatBotTopic))
       })
     }

--- a/bin/stacks/routing-api-stack.ts
+++ b/bin/stacks/routing-api-stack.ts
@@ -328,7 +328,7 @@ export class RoutingAPIStack extends cdk.Stack {
         usingMetrics: {
           invocations: new aws_cloudwatch.Metric({
             namespace: 'Uniswap',
-            metricName: `GET_Quote_Requested_ChainId: ${chainId.toString()}`,
+            metricName: `GET_QUOTE_REQUESTED_CHAINID: ${chainId.toString()}`,
             dimensionsMap: { Service: 'RoutingAPI' },
             unit: aws_cloudwatch.Unit.COUNT,
             period: Duration.minutes(5),
@@ -336,7 +336,7 @@ export class RoutingAPIStack extends cdk.Stack {
           }),
           response200: new aws_cloudwatch.Metric({
             namespace: 'Uniswap',
-            metricName: `GET_Quote_200_ChainId: ${chainId.toString()}`,
+            metricName: `GET_QUOTE_200_CHAINID: ${chainId.toString()}`,
             dimensionsMap: { Service: 'RoutingAPI' },
             unit: aws_cloudwatch.Unit.COUNT,
             period: Duration.minutes(5),
@@ -361,7 +361,7 @@ export class RoutingAPIStack extends cdk.Stack {
       const metric = new MathExpression({
         expression: "100*(response400/invocations)",
         usingMetrics: {
-          invocations: api.metric(`GET_Quote_Requested_ChainId: ${chainId.toString()}`, {
+          invocations: api.metric(`GET_QUOTE_REQUESTED_CHAINID: ${chainId.toString()}`, {
             period: Duration.minutes(5),
             statistic: 'sum'
           }),

--- a/bin/stacks/routing-api-stack.ts
+++ b/bin/stacks/routing-api-stack.ts
@@ -359,16 +359,16 @@ export class RoutingAPIStack extends cdk.Stack {
     SUPPORTED_CHAINS.forEach(chainId => {
       const alarmName = `RoutingAPI-SEV3-4XXAlarm-ChainId: ${chainId.toString()}`
       const metric = new MathExpression({
-        expression: "100*(response200/invocations)",
+        expression: "100*(response400/invocations)",
         usingMetrics: {
-          invocations: api.metric(`GET_Quote_400_ChainId: ${chainId.toString()}`, {
+          invocations: api.metric(`GET_Quote_Requested_ChainId: ${chainId.toString()}`, {
             period: Duration.minutes(5),
             statistic: 'sum'
           }),
-          response200: api.metric(`GET_Quote_Requested_ChainId: ${chainId.toString()}`, {
+          response400: api.metric(`GET_Quote_400_ChainId: ${chainId.toString()}`, {
             period: Duration.minutes(5),
             statistic: 'sum'
-          }),
+          })
         }
       })
       const alarm = new aws_cloudwatch.Alarm(this, alarmName, {

--- a/bin/stacks/routing-api-stack.ts
+++ b/bin/stacks/routing-api-stack.ts
@@ -365,7 +365,7 @@ export class RoutingAPIStack extends cdk.Stack {
             period: Duration.minutes(5),
             statistic: 'sum'
           }),
-          response400: api.metric(`GET_Quote_400_ChainId: ${chainId.toString()}`, {
+          response400: api.metric(`GET_QUOTE_400_CHAINID: ${chainId.toString()}`, {
             period: Duration.minutes(5),
             statistic: 'sum'
           })

--- a/bin/stacks/routing-api-stack.ts
+++ b/bin/stacks/routing-api-stack.ts
@@ -1,8 +1,10 @@
+import { SUPPORTED_CHAINS } from '@uniswap/smart-order-router'
 import * as cdk from 'aws-cdk-lib'
 import { CfnOutput, Duration } from 'aws-cdk-lib'
 import * as aws_apigateway from 'aws-cdk-lib/aws-apigateway'
 import { MethodLoggingLevel } from 'aws-cdk-lib/aws-apigateway'
 import * as aws_cloudwatch from 'aws-cdk-lib/aws-cloudwatch'
+import { MathExpression } from 'aws-cdk-lib/aws-cloudwatch'
 import * as aws_cloudwatch_actions from 'aws-cdk-lib/aws-cloudwatch-actions'
 import * as aws_logs from 'aws-cdk-lib/aws-logs'
 import * as aws_sns from 'aws-cdk-lib/aws-sns'
@@ -206,7 +208,7 @@ export class RoutingAPIStack extends cdk.Stack {
         // For this metric 'avg' represents error rate.
         statistic: 'avg',
       }),
-      threshold: 0.25,
+      threshold: 0.05,
       // Beta has much less traffic so is more susceptible to transient errors.
       evaluationPeriods: stage == STAGE.BETA ? 5 : 3,
     })
@@ -227,7 +229,7 @@ export class RoutingAPIStack extends cdk.Stack {
         period: Duration.minutes(5),
         statistic: 'p90',
       }),
-      threshold: 12000,
+      threshold: 8500,
       evaluationPeriods: 3,
     })
 
@@ -238,7 +240,7 @@ export class RoutingAPIStack extends cdk.Stack {
         // For this metric 'avg' represents error rate.
         statistic: 'avg',
       }),
-      threshold: 0.05,
+      threshold: 0.03,
       // Beta has much less traffic so is more susceptible to transient errors.
       evaluationPeriods: stage == STAGE.BETA ? 5 : 3,
     })
@@ -259,22 +261,123 @@ export class RoutingAPIStack extends cdk.Stack {
         period: Duration.minutes(5),
         statistic: 'p90',
       }),
-      threshold: 7500,
+      threshold: 5500,
       evaluationPeriods: 3,
     })
 
     const simulationAlarmSev2 = new aws_cloudwatch.Alarm(this, 'RoutingAPI-SEV2-Simulation', {
       alarmName: 'RoutingAPI-SEV2-Simulation',
-      metric: api.metric('SimulationFailed'),
-      threshold: 3,
-      evaluationPeriods: 3,
+      metric: new MathExpression({
+        expression: "100*(simulationFailed/simulationRequested)",
+        usingMetrics: {
+          simulationRequested: new aws_cloudwatch.Metric({
+            namespace: 'Uniswap',
+            metricName: `Simulation Requested`,
+            dimensionsMap: { Service: 'RoutingAPI' },
+            unit: aws_cloudwatch.Unit.COUNT,
+            period: Duration.minutes(5),
+            statistic: 'sum'
+          }),
+          simulationFailed: new aws_cloudwatch.Metric({
+            namespace: 'Uniswap',
+            metricName: `SimulationFailed`,
+            dimensionsMap: { Service: 'RoutingAPI' },
+            unit: aws_cloudwatch.Unit.COUNT,
+            period: Duration.minutes(5),
+            statistic: 'sum'
+          }),
+        }
+      }),
+      threshold: 40,
+      evaluationPeriods: 2,
     })
 
     const simulationAlarmSev3 = new aws_cloudwatch.Alarm(this, 'RoutingAPI-SEV3-Simulation', {
       alarmName: 'RoutingAPI-SEV3-Simulation',
-      metric: api.metric('SimulationFailed'),
-      threshold: 2,
-      evaluationPeriods: 3,
+      metric: new MathExpression({
+        expression: "100*(simulationFailed/simulationRequested)",
+        usingMetrics: {
+          simulationRequested: new aws_cloudwatch.Metric({
+            namespace: 'Uniswap',
+            metricName: `Simulation Requested`,
+            dimensionsMap: { Service: 'RoutingAPI' },
+            unit: aws_cloudwatch.Unit.COUNT,
+            period: Duration.minutes(5),
+            statistic: 'sum'
+          }),
+          simulationFailed: new aws_cloudwatch.Metric({
+            namespace: 'Uniswap',
+            metricName: `SimulationFailed`,
+            dimensionsMap: { Service: 'RoutingAPI' },
+            unit: aws_cloudwatch.Unit.COUNT,
+            period: Duration.minutes(5),
+            statistic: 'sum'
+          }),
+        }
+      }),
+      threshold: 20,
+      evaluationPeriods: 2,
+    })
+
+    // Alarms for 200 rate being too low for each chain
+    const percent2XXByChainAlarm: cdk.aws_cloudwatch.Alarm[] = []
+    SUPPORTED_CHAINS.forEach(chainId => {
+      const alarmName = `RoutingAPI-SEV3-2XXAlarm-ChainId: ${chainId.toString()}`
+      const metric = new MathExpression({
+        expression: "100*(response200/invocations)",
+        usingMetrics: {
+          invocations: new aws_cloudwatch.Metric({
+            namespace: 'Uniswap',
+            metricName: `GET_Quote_Requested_ChainId: ${chainId.toString()}`,
+            dimensionsMap: { Service: 'RoutingAPI' },
+            unit: aws_cloudwatch.Unit.COUNT,
+            period: Duration.minutes(5),
+            statistic: 'sum'
+          }),
+          response200: new aws_cloudwatch.Metric({
+            namespace: 'Uniswap',
+            metricName: `GET_Quote_200_ChainId: ${chainId.toString()}`,
+            dimensionsMap: { Service: 'RoutingAPI' },
+            unit: aws_cloudwatch.Unit.COUNT,
+            period: Duration.minutes(5),
+            statistic: 'sum'
+          }),
+        }
+      })
+      const alarm = new aws_cloudwatch.Alarm(this, alarmName, {
+        alarmName,
+        metric,
+        threshold: 20,
+        evaluationPeriods: 2,
+        comparisonOperator: aws_cloudwatch.ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD
+      })
+      percent2XXByChainAlarm.push(alarm)
+    })
+
+    // Alarms for high 400 error rate for each chain
+    const percent4XXByChainAlarm: cdk.aws_cloudwatch.Alarm[] = []
+    SUPPORTED_CHAINS.forEach(chainId => {
+      const alarmName = `RoutingAPI-SEV3-4XXAlarm-ChainId: ${chainId.toString()}`
+      const metric = new MathExpression({
+        expression: "100*(response200/invocations)",
+        usingMetrics: {
+          invocations: api.metric(`GET_Quote_400_ChainId: ${chainId.toString()}`, {
+            period: Duration.minutes(5),
+            statistic: 'sum'
+          }),
+          response200: api.metric(`GET_Quote_Requested_ChainId: ${chainId.toString()}`, {
+            period: Duration.minutes(5),
+            statistic: 'sum'
+          }),
+        }
+      })
+      const alarm = new aws_cloudwatch.Alarm(this, alarmName, {
+        alarmName,
+        metric,
+        threshold: 80,
+        evaluationPeriods: 2,
+      })
+      percent4XXByChainAlarm.push(alarm)
     })
 
     if (chatbotSNSArn) {
@@ -287,6 +390,13 @@ export class RoutingAPIStack extends cdk.Stack {
       apiAlarmLatencySev3.addAlarmAction(new aws_cloudwatch_actions.SnsAction(chatBotTopic))
       simulationAlarmSev2.addAlarmAction(new aws_cloudwatch_actions.SnsAction(chatBotTopic))
       simulationAlarmSev3.addAlarmAction(new aws_cloudwatch_actions.SnsAction(chatBotTopic))
+
+      percent2XXByChainAlarm.forEach(alarm => {
+        alarm.addAlarmAction(new aws_cloudwatch_actions.SnsAction(chatBotTopic))
+      })
+      percent4XXByChainAlarm.forEach(alarm => {
+        alarm.addAlarmAction(new aws_cloudwatch_actions.SnsAction(chatBotTopic))
+      })
     }
 
     this.url = new CfnOutput(this, 'Url', {

--- a/bin/stacks/routing-caching-stack.ts
+++ b/bin/stacks/routing-caching-stack.ts
@@ -182,7 +182,7 @@ export class RoutingCachingStack extends cdk.NestedStack {
         period: Duration.minutes(60),
         statistic: 'sum',
       }),
-      threshold: 5,
+      threshold: 9,
       evaluationPeriods: 1,
     })
 
@@ -208,7 +208,7 @@ export class RoutingCachingStack extends cdk.NestedStack {
             period: Duration.minutes(60),
             statistic: 'sum',
           }),
-          threshold: 5,
+          threshold: 9,
           evaluationPeriods: 1,
         })
 

--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -63,7 +63,7 @@ export class QuoteHandler extends APIGLambdaHandler<
         metric,
       },
     } = params
-    metric.putMetric(`GET_Quote_Requested_ChainId: ${chainId}`, 1, MetricLoggerUnit.Count)
+    metric.putMetric(`GET_QUOTE_REQUESTED_CHAINID: ${chainId}`, 1, MetricLoggerUnit.Count)
 
     // Parse user provided token address/symbol to Currency object.
     let before = Date.now()
@@ -87,7 +87,7 @@ export class QuoteHandler extends APIGLambdaHandler<
     metric.putMetric('TokenInOutStrToToken', Date.now() - before, MetricLoggerUnit.Milliseconds)
 
     if (!currencyIn) {
-      metric.putMetric(`GET_Quote_400_ChainId: ${chainId}`, 1, MetricLoggerUnit.Count)
+      metric.putMetric(`GET_QUOTE_400_CHAINID: ${chainId}`, 1, MetricLoggerUnit.Count)
       return {
         statusCode: 400,
         errorCode: 'TOKEN_IN_INVALID',
@@ -96,7 +96,7 @@ export class QuoteHandler extends APIGLambdaHandler<
     }
 
     if (!currencyOut) {
-      metric.putMetric(`GET_Quote_400_ChainId: ${chainId}`, 1, MetricLoggerUnit.Count)
+      metric.putMetric(`GET_QUOTE_400_CHAINID: ${chainId}`, 1, MetricLoggerUnit.Count)
       return {
         statusCode: 400,
         errorCode: 'TOKEN_OUT_INVALID',
@@ -105,7 +105,7 @@ export class QuoteHandler extends APIGLambdaHandler<
     }
 
     if (tokenInChainId != tokenOutChainId) {
-      metric.putMetric(`GET_Quote_400_ChainId: ${chainId}`, 1, MetricLoggerUnit.Count)
+      metric.putMetric(`GET_QUOTE_400_CHAINID: ${chainId}`, 1, MetricLoggerUnit.Count)
       return {
         statusCode: 400,
         errorCode: 'TOKEN_CHAINS_DIFFERENT',
@@ -114,7 +114,7 @@ export class QuoteHandler extends APIGLambdaHandler<
     }
 
     if (currencyIn.equals(currencyOut)) {
-      metric.putMetric(`GET_Quote_400_ChainId: ${chainId}`, 1, MetricLoggerUnit.Count)
+      metric.putMetric(`GET_QUOTE_400_CHAINID: ${chainId}`, 1, MetricLoggerUnit.Count)
       return {
         statusCode: 400,
         errorCode: 'TOKEN_IN_OUT_SAME',
@@ -390,7 +390,7 @@ export class QuoteHandler extends APIGLambdaHandler<
       quoteId,
     }
 
-    metric.putMetric(`GET_Quote_200_ChainId: ${chainId}`, 1, MetricLoggerUnit.Count)
+    metric.putMetric(`GET_QUOTE_200_CHAINID: ${chainId}`, 1, MetricLoggerUnit.Count)
     return {
       statusCode: 200,
       body: result,

--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -63,6 +63,7 @@ export class QuoteHandler extends APIGLambdaHandler<
         metric,
       },
     } = params
+    metric.putMetric(`GET_Quote_Requested_ChainId: ${chainId}`, 1, MetricLoggerUnit.Count)
 
     // Parse user provided token address/symbol to Currency object.
     let before = Date.now()
@@ -86,6 +87,7 @@ export class QuoteHandler extends APIGLambdaHandler<
     metric.putMetric('TokenInOutStrToToken', Date.now() - before, MetricLoggerUnit.Milliseconds)
 
     if (!currencyIn) {
+      metric.putMetric(`GET_Quote_400_ChainId: ${chainId}`, 1, MetricLoggerUnit.Count)
       return {
         statusCode: 400,
         errorCode: 'TOKEN_IN_INVALID',
@@ -94,6 +96,7 @@ export class QuoteHandler extends APIGLambdaHandler<
     }
 
     if (!currencyOut) {
+      metric.putMetric(`GET_Quote_400_ChainId: ${chainId}`, 1, MetricLoggerUnit.Count)
       return {
         statusCode: 400,
         errorCode: 'TOKEN_OUT_INVALID',
@@ -102,6 +105,7 @@ export class QuoteHandler extends APIGLambdaHandler<
     }
 
     if (tokenInChainId != tokenOutChainId) {
+      metric.putMetric(`GET_Quote_400_ChainId: ${chainId}`, 1, MetricLoggerUnit.Count)
       return {
         statusCode: 400,
         errorCode: 'TOKEN_CHAINS_DIFFERENT',
@@ -110,6 +114,7 @@ export class QuoteHandler extends APIGLambdaHandler<
     }
 
     if (currencyIn.equals(currencyOut)) {
+      metric.putMetric(`GET_Quote_400_ChainId: ${chainId}`, 1, MetricLoggerUnit.Count)
       return {
         statusCode: 400,
         errorCode: 'TOKEN_IN_OUT_SAME',
@@ -384,6 +389,8 @@ export class QuoteHandler extends APIGLambdaHandler<
       routeString: routeAmountsToString(route),
       quoteId,
     }
+
+    metric.putMetric(`GET_Quote_200_ChainId: ${chainId}`, 1, MetricLoggerUnit.Count)
 
     return {
       statusCode: 200,

--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -391,7 +391,6 @@ export class QuoteHandler extends APIGLambdaHandler<
     }
 
     metric.putMetric(`GET_Quote_200_ChainId: ${chainId}`, 1, MetricLoggerUnit.Count)
-
     return {
       statusCode: 200,
       body: result,

--- a/test/integ/quote.test.ts
+++ b/test/integ/quote.test.ts
@@ -1547,7 +1547,11 @@ describe('quote', function () {
   // TODO: Find valid pools/tokens on optimistic kovan and polygon mumbai. We skip those tests for now.
   for (const chain of _.filter(
     SUPPORTED_CHAINS,
-    (c) => c != ChainId.OPTIMISTIC_KOVAN && c != ChainId.POLYGON_MUMBAI && c != ChainId.ARBITRUM_RINKEBY && c != ChainId.GÖRLI
+    (c) =>
+      c != ChainId.OPTIMISTIC_KOVAN &&
+      c != ChainId.POLYGON_MUMBAI &&
+      c != ChainId.ARBITRUM_RINKEBY &&
+      c != ChainId.GÖRLI
   )) {
     for (const type of ['exactIn', 'exactOut']) {
       const erc1 = TEST_ERC20_1[chain]

--- a/test/integ/quote.test.ts
+++ b/test/integ/quote.test.ts
@@ -1547,7 +1547,7 @@ describe('quote', function () {
   // TODO: Find valid pools/tokens on optimistic kovan and polygon mumbai. We skip those tests for now.
   for (const chain of _.filter(
     SUPPORTED_CHAINS,
-    (c) => c != ChainId.OPTIMISTIC_KOVAN && c != ChainId.POLYGON_MUMBAI && c != ChainId.ARBITRUM_RINKEBY && c != ChainId.GÖRLI
+    (c) => c != ChainId.OPTIMISTIC_KOVAN && c != ChainId.POLYGON_MUMBAI && c != ChainId.ARBITRUM_RINKEBY
   )) {
     for (const type of ['exactIn', 'exactOut']) {
       const erc1 = TEST_ERC20_1[chain]

--- a/test/integ/quote.test.ts
+++ b/test/integ/quote.test.ts
@@ -1547,7 +1547,7 @@ describe('quote', function () {
   // TODO: Find valid pools/tokens on optimistic kovan and polygon mumbai. We skip those tests for now.
   for (const chain of _.filter(
     SUPPORTED_CHAINS,
-    (c) => c != ChainId.OPTIMISTIC_KOVAN && c != ChainId.POLYGON_MUMBAI && c != ChainId.ARBITRUM_RINKEBY
+    (c) => c != ChainId.OPTIMISTIC_KOVAN && c != ChainId.POLYGON_MUMBAI && c != ChainId.ARBITRUM_RINKEBY && c != ChainId.GÖRLI
   )) {
     for (const type of ['exactIn', 'exactOut']) {
       const erc1 = TEST_ERC20_1[chain]


### PR DESCRIPTION
* Lowered threshold for 5XX and Latency alarms so they get triggered more
* Increased threshold for poolcachetolambda and poolcachetoipfs alarms so they get triggered less
* Added metrics and Sev3 alarms for each chain for 200 Error % and 400 Error % 
* Improved tenderly simulation metrics and alarms
* Gorli integ tests failing due to lack of liquidity, temporarily commented it out

https://uniswaplabs.atlassian.net/jira/software/projects/TRD/boards/23?selectedIssue=TRD-105