### PR TITLE
Split PoolCacheToS3Lambda to multiple lambdas by chain and protocol

### DIFF
--- a/bin/stacks/routing-api-stack.ts
+++ b/bin/stacks/routing-api-stack.ts
@@ -69,6 +69,7 @@ export class RoutingAPIStack extends cdk.Stack {
       poolCacheBucket,
       poolCacheBucket2,
       poolCacheKey,
+      poolCacheLambdaNameArray,
       tokenListCacheBucket,
       ipfsPoolCachingLambda,
     } = new RoutingCachingStack(this, 'RoutingCachingStack', {
@@ -185,6 +186,7 @@ export class RoutingAPIStack extends cdk.Stack {
     new RoutingDashboardStack(this, 'RoutingDashboardStack', {
       apiName: api.restApiName,
       routingLambdaName: routingLambda.functionName,
+      poolCacheLambdaNameArray,
       ipfsPoolCacheLambdaName: ipfsPoolCachingLambda ? ipfsPoolCachingLambda.functionName : undefined,
     })
 

--- a/bin/stacks/routing-api-stack.ts
+++ b/bin/stacks/routing-api-stack.ts
@@ -70,7 +70,6 @@ export class RoutingAPIStack extends cdk.Stack {
       poolCacheBucket2,
       poolCacheKey,
       tokenListCacheBucket,
-      poolCacheLambda,
       ipfsPoolCachingLambda,
     } = new RoutingCachingStack(this, 'RoutingCachingStack', {
       chatbotSNSArn,
@@ -186,7 +185,6 @@ export class RoutingAPIStack extends cdk.Stack {
     new RoutingDashboardStack(this, 'RoutingDashboardStack', {
       apiName: api.restApiName,
       routingLambdaName: routingLambda.functionName,
-      poolCacheLambdaName: poolCacheLambda.functionName,
       ipfsPoolCacheLambdaName: ipfsPoolCachingLambda ? ipfsPoolCachingLambda.functionName : undefined,
     })
 

--- a/bin/stacks/routing-caching-stack.ts
+++ b/bin/stacks/routing-caching-stack.ts
@@ -1,3 +1,4 @@
+import { Protocol } from '@uniswap/router-sdk'
 import * as cdk from 'aws-cdk-lib'
 import { Duration } from 'aws-cdk-lib'
 import * as aws_cloudwatch from 'aws-cdk-lib/aws-cloudwatch'
@@ -129,8 +130,8 @@ export class RoutingCachingStack extends cdk.NestedStack {
             }),
           },
         }),
-        threshold: 75,
-        evaluationPeriods: 1,
+        threshold: protocol===Protocol.V3 ? 50 : 85,
+        evaluationPeriods: protocol===Protocol.V3 ? 1 : 5,
       })
       const lambdaThrottlesErrorRate = new aws_cloudwatch.Alarm(this, `RoutingAPI-PoolCacheToS3LambdaThrottles-ChainId${chainId}-Protocol${protocol}`, {
         metric: lambda.metricThrottles({

--- a/bin/stacks/routing-caching-stack.ts
+++ b/bin/stacks/routing-caching-stack.ts
@@ -131,7 +131,7 @@ export class RoutingCachingStack extends cdk.NestedStack {
           },
         }),
         threshold: protocol===Protocol.V3 ? 50 : 85,
-        evaluationPeriods: protocol===Protocol.V3 ? 1 : 5,
+        evaluationPeriods: protocol===Protocol.V3 ? 6 : 30,
       })
       const lambdaThrottlesErrorRate = new aws_cloudwatch.Alarm(this, `RoutingAPI-PoolCacheToS3LambdaThrottles-ChainId${chainId}-Protocol${protocol}`, {
         metric: lambda.metricThrottles({

--- a/bin/stacks/routing-caching-stack.ts
+++ b/bin/stacks/routing-caching-stack.ts
@@ -33,6 +33,7 @@ export class RoutingCachingStack extends cdk.NestedStack {
   public readonly tokenListCacheBucket: aws_s3.Bucket
   public readonly ipfsPoolCachingLambda: aws_lambda_nodejs.NodejsFunction
   public readonly ipfsCleanPoolCachingLambda: aws_lambda_nodejs.NodejsFunction
+  public readonly poolCacheLambdaNameArray: string[]
 
   constructor(scope: Construct, name: string, props: RoutingCachingStackProps) {
     super(scope, name, props)
@@ -145,6 +146,7 @@ export class RoutingCachingStack extends cdk.NestedStack {
         lambdaAlarmErrorRate.addAlarmAction(new aws_cloudwatch_actions.SnsAction(chatBotTopic))
         lambdaThrottlesErrorRate.addAlarmAction(new aws_cloudwatch_actions.SnsAction(chatBotTopic))
       }
+      this.poolCacheLambdaNameArray.push(lambda.functionName)
     }
 
     if (stage == STAGE.BETA || stage == STAGE.PROD) {

--- a/bin/stacks/routing-caching-stack.ts
+++ b/bin/stacks/routing-caching-stack.ts
@@ -33,17 +33,14 @@ export class RoutingCachingStack extends cdk.NestedStack {
   public readonly tokenListCacheBucket: aws_s3.Bucket
   public readonly ipfsPoolCachingLambda: aws_lambda_nodejs.NodejsFunction
   public readonly ipfsCleanPoolCachingLambda: aws_lambda_nodejs.NodejsFunction
-  public readonly poolCacheLambdaNameArray: string[]
+  public readonly poolCacheLambdaNameArray: string[] = []
 
   constructor(scope: Construct, name: string, props: RoutingCachingStackProps) {
     super(scope, name, props)
 
     const { chatbotSNSArn } = props
 
-    let chatBotTopic: cdk.aws_sns.ITopic | undefined
-    if(chatbotSNSArn) {
-      chatBotTopic = aws_sns.Topic.fromTopicArn(this, 'ChatbotTopic', chatbotSNSArn)
-    }
+    const chatBotTopic = chatbotSNSArn ? aws_sns.Topic.fromTopicArn(this, 'ChatbotTopic', chatbotSNSArn) : undefined
 
     // TODO: Remove and swap to the new bucket below. Kept around for the rollout, but all requests will go to bucket 2.
     this.poolCacheBucket = new aws_s3.Bucket(this, 'PoolCacheBucket')

--- a/bin/stacks/routing-caching-stack.ts
+++ b/bin/stacks/routing-caching-stack.ts
@@ -1,6 +1,8 @@
+import { Protocol } from '@uniswap/router-sdk'
 import * as cdk from 'aws-cdk-lib'
 import { Duration } from 'aws-cdk-lib'
 import * as aws_cloudwatch from 'aws-cdk-lib/aws-cloudwatch'
+import { MathExpression } from 'aws-cdk-lib/aws-cloudwatch'
 import * as aws_cloudwatch_actions from 'aws-cdk-lib/aws-cloudwatch-actions'
 import * as aws_events from 'aws-cdk-lib/aws-events'
 import * as aws_events_targets from 'aws-cdk-lib/aws-events-targets'
@@ -12,6 +14,7 @@ import * as aws_s3 from 'aws-cdk-lib/aws-s3'
 import * as aws_sns from 'aws-cdk-lib/aws-sns'
 import { Construct } from 'constructs'
 import * as path from 'path'
+import { chainProtocols } from '../../lib/cron/cache-config'
 import { STAGE } from '../../lib/util/stage'
 
 export interface RoutingCachingStackProps extends cdk.NestedStackProps {
@@ -28,7 +31,6 @@ export class RoutingCachingStack extends cdk.NestedStack {
   public readonly poolCacheBucket2: aws_s3.Bucket
   public readonly poolCacheKey: string
   public readonly tokenListCacheBucket: aws_s3.Bucket
-  public readonly poolCacheLambda: aws_lambda_nodejs.NodejsFunction
   public readonly ipfsPoolCachingLambda: aws_lambda_nodejs.NodejsFunction
   public readonly ipfsCleanPoolCachingLambda: aws_lambda_nodejs.NodejsFunction
 
@@ -36,6 +38,11 @@ export class RoutingCachingStack extends cdk.NestedStack {
     super(scope, name, props)
 
     const { chatbotSNSArn } = props
+
+    let chatBotTopic: cdk.aws_sns.ITopic | undefined
+    if(chatbotSNSArn) {
+      chatBotTopic = aws_sns.Topic.fromTopicArn(this, 'ChatbotTopic', chatbotSNSArn)
+    }
 
     // TODO: Remove and swap to the new bucket below. Kept around for the rollout, but all requests will go to bucket 2.
     this.poolCacheBucket = new aws_s3.Bucket(this, 'PoolCacheBucket')
@@ -72,40 +79,75 @@ export class RoutingCachingStack extends cdk.NestedStack {
 
     const region = cdk.Stack.of(this).region
 
-    this.poolCacheLambda = new aws_lambda_nodejs.NodejsFunction(this, 'PoolCacheLambda', {
-      role: lambdaRole,
-      runtime: aws_lambda.Runtime.NODEJS_14_X,
-      entry: path.join(__dirname, '../../lib/cron/cache-pools.ts'),
-      handler: 'handler',
-      timeout: Duration.seconds(900),
-      memorySize: 1024,
-      bundling: {
-        minify: true,
-        sourceMap: true,
-      },
-      description: 'Pool Cache Lambda',
-      layers: [
-        aws_lambda.LayerVersion.fromLayerVersionArn(
-          this,
-          'InsightsLayerPools',
-          `arn:aws:lambda:${region}:580247275435:layer:LambdaInsightsExtension:14`
-        ),
-      ],
-      tracing: aws_lambda.Tracing.ACTIVE,
-      environment: {
-        POOL_CACHE_BUCKET: this.poolCacheBucket.bucketName,
-        POOL_CACHE_BUCKET_2: this.poolCacheBucket2.bucketName,
-        POOL_CACHE_KEY: this.poolCacheKey,
-      },
-    })
+    const lambdaLayerVersion = aws_lambda.LayerVersion.fromLayerVersionArn(
+      this,
+      'InsightsLayerPools',
+      `arn:aws:lambda:${region}:580247275435:layer:LambdaInsightsExtension:14`
+    )
 
-    this.poolCacheBucket.grantReadWrite(this.poolCacheLambda)
-    this.poolCacheBucket2.grantReadWrite(this.poolCacheLambda)
-
-    new aws_events.Rule(this, 'SchedulePoolCache', {
-      schedule: aws_events.Schedule.rate(Duration.minutes(15)),
-      targets: [new aws_events_targets.LambdaFunction(this.poolCacheLambda)],
-    })
+    // Spin up a new pool cache lambda for each config in chain X protocol
+    for(let i=0; i<chainProtocols.length; i++) {
+      const { protocol, chainId, timeout } = chainProtocols[i]
+      const lambda = new aws_lambda_nodejs.NodejsFunction(this, `PoolCacheLambda-ChainId${chainId}-Protocol${protocol}`, {
+        role: lambdaRole,
+        runtime: aws_lambda.Runtime.NODEJS_14_X,
+        entry: path.join(__dirname, '../../lib/cron/cache-pools.ts'),
+        handler: 'handler',
+        timeout: Duration.seconds(900),
+        memorySize: 1024,
+        bundling: {
+          minify: true,
+          sourceMap: true,
+        },
+        description: `Pool Cache Lambda for Chain with ChainId ${chainId} and Protocol ${protocol}`,
+        layers: [lambdaLayerVersion],
+        tracing: aws_lambda.Tracing.ACTIVE,
+        environment: {
+          POOL_CACHE_BUCKET: this.poolCacheBucket.bucketName,
+          POOL_CACHE_BUCKET_2: this.poolCacheBucket2.bucketName,
+          POOL_CACHE_KEY: this.poolCacheKey,
+          chainId: chainId.toString(),
+          protocol,
+          timeout: timeout.toString(),
+        },
+      })
+      new aws_events.Rule(this, `SchedulePoolCache-ChainId${chainId}-Protocol${protocol}`, {
+        schedule: aws_events.Schedule.rate(Duration.minutes(15)),
+        targets: [new aws_events_targets.LambdaFunction(lambda)],
+      })
+      this.poolCacheBucket2.grantReadWrite(lambda)
+      const lambdaThrottlesErrorRate = new aws_cloudwatch.Alarm(this, `RoutingAPI-PoolCacheToS3LambdaThrottles-ChainId${chainId}-Protocol${protocol}`, {
+        metric: lambda.metricThrottles({
+          period: Duration.minutes(5),
+          statistic: 'sum',
+        }),
+        threshold: 5,
+        evaluationPeriods: 1,
+      })
+      if (chatBotTopic) {
+        lambdaThrottlesErrorRate.addAlarmAction(new aws_cloudwatch_actions.SnsAction(chatBotTopic))
+        if(protocol !== Protocol.V2) {
+          const lambdaAlarmErrorRate = new aws_cloudwatch.Alarm(this, `RoutingAPI-PoolCacheToS3LambdaErrorRate-ChainId${chainId}-Protocol${protocol}`, {
+            metric: new MathExpression({
+              expression: '100*(errors/invocations)',
+              usingMetrics: {
+                invocations: lambda.metricInvocations({
+                  period: Duration.minutes(60),
+                  statistic: 'sum',
+                }),
+                errors: lambda.metricErrors({
+                  period: Duration.minutes(60),
+                  statistic: 'sum',
+                }),
+              },
+            }),
+            threshold: 50,
+            evaluationPeriods: 1,
+          })
+          lambdaAlarmErrorRate.addAlarmAction(new aws_cloudwatch_actions.SnsAction(chatBotTopic))
+        }
+      }
+    }
 
     if (stage == STAGE.BETA || stage == STAGE.PROD) {
       this.ipfsPoolCachingLambda = new aws_lambda_nodejs.NodejsFunction(this, 'IpfsPoolCacheLambda', {
@@ -177,34 +219,10 @@ export class RoutingCachingStack extends cdk.NestedStack {
       })
     }
 
-    const lambdaAlarmErrorRate = new aws_cloudwatch.Alarm(this, 'RoutingAPI-PoolCacheToS3LambdaError', {
-      metric: this.poolCacheLambda.metricErrors({
-        period: Duration.minutes(60),
-        statistic: 'sum',
-      }),
-      threshold: 9,
-      evaluationPeriods: 1,
-    })
-
-    const lambdaThrottlesErrorRate = new aws_cloudwatch.Alarm(this, 'RoutingAPI-PoolCacheToS3LambdaThrottles', {
-      metric: this.poolCacheLambda.metricThrottles({
-        period: Duration.minutes(5),
-        statistic: 'sum',
-      }),
-      threshold: 5,
-      evaluationPeriods: 1,
-    })
-
-    if (chatbotSNSArn) {
-      const chatBotTopic = aws_sns.Topic.fromTopicArn(this, 'ChatbotTopic', chatbotSNSArn)
-
-      lambdaAlarmErrorRate.addAlarmAction(new aws_cloudwatch_actions.SnsAction(chatBotTopic))
-
-      lambdaThrottlesErrorRate.addAlarmAction(new aws_cloudwatch_actions.SnsAction(chatBotTopic))
-
+    if (chatBotTopic) {
       if (stage == 'beta' || stage == 'prod') {
         const lambdaIpfsAlarmErrorRate = new aws_cloudwatch.Alarm(this, 'RoutingAPI-PoolCacheToIPFSLambdaError', {
-          metric: this.poolCacheLambda.metricErrors({
+          metric: this.ipfsPoolCachingLambda.metricErrors({
             period: Duration.minutes(60),
             statistic: 'sum',
           }),

--- a/bin/stacks/routing-caching-stack.ts
+++ b/bin/stacks/routing-caching-stack.ts
@@ -129,7 +129,7 @@ export class RoutingCachingStack extends cdk.NestedStack {
             }),
           },
         }),
-        threshold: 50,
+        threshold: 75,
         evaluationPeriods: 1,
       })
       const lambdaThrottlesErrorRate = new aws_cloudwatch.Alarm(this, `RoutingAPI-PoolCacheToS3LambdaThrottles-ChainId${chainId}-Protocol${protocol}`, {

--- a/bin/stacks/routing-caching-stack.ts
+++ b/bin/stacks/routing-caching-stack.ts
@@ -131,7 +131,7 @@ export class RoutingCachingStack extends cdk.NestedStack {
           },
         }),
         threshold: protocol===Protocol.V3 ? 50 : 85,
-        evaluationPeriods: protocol===Protocol.V3 ? 6 : 30,
+        evaluationPeriods: protocol===Protocol.V3 ? 12 : 60,
       })
       const lambdaThrottlesErrorRate = new aws_cloudwatch.Alarm(this, `RoutingAPI-PoolCacheToS3LambdaThrottles-ChainId${chainId}-Protocol${protocol}`, {
         metric: lambda.metricThrottles({

--- a/bin/stacks/routing-dashboard-stack.ts
+++ b/bin/stacks/routing-dashboard-stack.ts
@@ -78,40 +78,39 @@ export class RoutingDashboardStack extends cdk.NestedStack {
       },
     })
 
-    const poolCacheLambdaWidgetArray: LambdaWidget[] = []
+    const poolCacheLambdaMetrics: string[][] = []
     poolCacheLambdaNameArray.forEach(poolCacheLambdaName => {
-      poolCacheLambdaWidgetArray.push({
-        type: 'metric',
-        x: 0,
-        y: 66,
-        width: 24,
-        height: 9,
-        properties: {
-          view: 'timeSeries',
-          stacked: false,
-          metrics: [
-            ['AWS/Lambda', 'Errors', 'FunctionName', poolCacheLambdaName],
-            ['.', 'Invocations', '.', '.'],
-            ...(ipfsPoolCacheLambdaName
-              ? [
-                  ['AWS/Lambda', 'Errors', 'FunctionName', ipfsPoolCacheLambdaName],
-                  ['.', 'Invocations', '.', '.'],
-                ]
-              : []),
-          ],
-          region: region,
-          title: 'Pool Cache Lambda Error/Invocations | 5min',
-          stat: 'Sum',
-        },
-      },)
-    });
-
+      poolCacheLambdaMetrics.push(['AWS/Lambda', `${poolCacheLambdaName}Errors`, 'FunctionName', poolCacheLambdaName])
+      poolCacheLambdaMetrics.push(['.', `${poolCacheLambdaName}Invocations`, '.', '.'])
+    })
     new aws_cloudwatch.CfnDashboard(this, 'RoutingAPIDashboard', {
       dashboardName: `RoutingDashboard`,
       dashboardBody: JSON.stringify({
         periodOverride: 'inherit',
         widgets: [
-          ...poolCacheLambdaWidgetArray,
+          {
+            type: 'metric',
+            x: 0,
+            y: 66,
+            width: 24,
+            height: 9,
+            properties: {
+              view: 'timeSeries',
+              stacked: false,
+              metrics: [
+                ...poolCacheLambdaMetrics,
+                ...(ipfsPoolCacheLambdaName
+                  ? [
+                      ['AWS/Lambda', 'Errors', 'FunctionName', ipfsPoolCacheLambdaName],
+                      ['.', 'Invocations', '.', '.'],
+                    ]
+                  : []),
+              ],
+              region: region,
+              title: 'Pool Cache Lambda Error/Invocations | 5min',
+              stat: 'Sum',
+            },
+          },
           {
             height: 6,
             width: 24,

--- a/bin/stacks/routing-dashboard-stack.ts
+++ b/bin/stacks/routing-dashboard-stack.ts
@@ -7,7 +7,14 @@ import { SUPPORTED_CHAINS } from '../../lib/handlers/injector-sor'
 
 export const NAMESPACE = 'Uniswap'
 
-export type LambdaWidget = { type: string; x: number; y: number; width: number; height: number; properties: { view: string; stacked: boolean; metrics: string[][]; region: string; title: string; stat: string } }
+export type LambdaWidget = {
+  type: string
+  x: number
+  y: number
+  width: number
+  height: number
+  properties: { view: string; stacked: boolean; metrics: string[][]; region: string; title: string; stat: string }
+}
 
 export interface RoutingDashboardProps extends cdk.NestedStackProps {
   apiName: string
@@ -79,7 +86,7 @@ export class RoutingDashboardStack extends cdk.NestedStack {
     })
 
     const poolCacheLambdaMetrics: string[][] = []
-    poolCacheLambdaNameArray.forEach(poolCacheLambdaName => {
+    poolCacheLambdaNameArray.forEach((poolCacheLambdaName) => {
       poolCacheLambdaMetrics.push(['AWS/Lambda', `${poolCacheLambdaName}Errors`, 'FunctionName', poolCacheLambdaName])
       poolCacheLambdaMetrics.push(['.', `${poolCacheLambdaName}Invocations`, '.', '.'])
     })

--- a/bin/stacks/routing-dashboard-stack.ts
+++ b/bin/stacks/routing-dashboard-stack.ts
@@ -10,7 +10,6 @@ export const NAMESPACE = 'Uniswap'
 export interface RoutingDashboardProps extends cdk.NestedStackProps {
   apiName: string
   routingLambdaName: string
-  poolCacheLambdaName: string
   ipfsPoolCacheLambdaName?: string
 }
 
@@ -18,7 +17,7 @@ export class RoutingDashboardStack extends cdk.NestedStack {
   constructor(scope: Construct, name: string, props: RoutingDashboardProps) {
     super(scope, name, props)
 
-    const { apiName, routingLambdaName, poolCacheLambdaName, ipfsPoolCacheLambdaName } = props
+    const { apiName, routingLambdaName } = props
     const region = cdk.Stack.of(this).region
 
     // No CDK resource exists for contributor insights at the moment so use raw CloudFormation.
@@ -399,30 +398,6 @@ export class RoutingDashboardStack extends cdk.NestedStack {
               region: region,
               title: 'Routing Lambda Provisioned Concurrency | 5min',
               stat: 'Average',
-            },
-          },
-          {
-            type: 'metric',
-            x: 0,
-            y: 66,
-            width: 24,
-            height: 9,
-            properties: {
-              view: 'timeSeries',
-              stacked: false,
-              metrics: [
-                ['AWS/Lambda', 'Errors', 'FunctionName', poolCacheLambdaName],
-                ['.', 'Invocations', '.', '.'],
-                ...(ipfsPoolCacheLambdaName
-                  ? [
-                      ['AWS/Lambda', 'Errors', 'FunctionName', ipfsPoolCacheLambdaName],
-                      ['.', 'Invocations', '.', '.'],
-                    ]
-                  : []),
-              ],
-              region: region,
-              title: 'Pool Cache Lambda Error/Invocations | 5min',
-              stat: 'Sum',
             },
           },
         ],

--- a/lib/cron/cache-config.ts
+++ b/lib/cron/cache-config.ts
@@ -33,7 +33,7 @@ export const chainProtocols = [
   {
     protocol: Protocol.V2,
     chainId: ChainId.MAINNET,
-    timeout: 600000,
-    provider: new V2SubgraphProvider(ChainId.MAINNET, 3, 800000),
+    timeout: 800000,
+    provider: new V2SubgraphProvider(ChainId.MAINNET, 1, 800000),
   },
 ]

--- a/lib/cron/cache-config.ts
+++ b/lib/cron/cache-config.ts
@@ -6,39 +6,35 @@ export const chainProtocols = [
   {
     protocol: Protocol.V3,
     chainId: ChainId.MAINNET,
+    timeout: 90000,
     provider: new V3SubgraphProvider(ChainId.MAINNET, 3, 90000),
   },
   {
     protocol: Protocol.V3,
-    chainId: ChainId.RINKEBY,
-    provider: new V3SubgraphProvider(ChainId.RINKEBY, 3, 90000),
-  },
-  {
-    protocol: Protocol.V3,
     chainId: ChainId.ARBITRUM_ONE,
+    timeout: 90000,
     provider: new V3SubgraphProvider(ChainId.ARBITRUM_ONE, 3, 90000),
   },
   {
     protocol: Protocol.V3,
     chainId: ChainId.POLYGON,
+    timeout: 90000,
     provider: new V3SubgraphProvider(ChainId.POLYGON, 3, 90000),
   },
   {
     protocol: Protocol.V3,
-    chainId: ChainId.GÖRLI,
-    provider: new V3SubgraphProvider(ChainId.GÖRLI, 3, 90000),
-  },
-  {
-    protocol: Protocol.V3,
     chainId: ChainId.CELO,
+    timeout: 90000,
     provider: new V3SubgraphProvider(ChainId.CELO, 3, 90000),
   },
-  // Currently there is no working V3 subgraph for Kovan, Optimism, Optimism Kovan, Arbitrum Rinkeby, so we use static providers.
+  // Currently there is no working V3 subgraph for Optimism so we use a static provider.
   // V2.
+
+  // decreased retries from 3 to 1 because lambda timeout is 15 minutes
   {
     protocol: Protocol.V2,
     chainId: ChainId.MAINNET,
-    provider: new V2SubgraphProvider(ChainId.MAINNET, 2, 600000), // Bump from 360_000 (6 min) to 480_000 (8 min) to 600_000 (10 mins)
+    timeout: 600000,
+    provider: new V2SubgraphProvider(ChainId.MAINNET, 1, 600000),
   },
-  // Currently there is no working V2 subgraph for Rinkeby, Ropsten, Gorli or Kovan, so we use static providers.
 ]

--- a/lib/cron/cache-config.ts
+++ b/lib/cron/cache-config.ts
@@ -33,7 +33,7 @@ export const chainProtocols = [
   {
     protocol: Protocol.V2,
     chainId: ChainId.MAINNET,
-    timeout: 800000,
-    provider: new V2SubgraphProvider(ChainId.MAINNET, 1, 800000),
+    timeout: 840000,
+    provider: new V2SubgraphProvider(ChainId.MAINNET, 0, 840000),
   },
 ]

--- a/lib/cron/cache-config.ts
+++ b/lib/cron/cache-config.ts
@@ -30,11 +30,10 @@ export const chainProtocols = [
   // Currently there is no working V3 subgraph for Optimism so we use a static provider.
   // V2.
 
-  // decreased retries from 3 to 1 because lambda timeout is 15 minutes
   {
     protocol: Protocol.V2,
     chainId: ChainId.MAINNET,
     timeout: 600000,
-    provider: new V2SubgraphProvider(ChainId.MAINNET, 1, 600000),
+    provider: new V2SubgraphProvider(ChainId.MAINNET, 3, 800000),
   },
 ]

--- a/lib/cron/cache-pools.ts
+++ b/lib/cron/cache-pools.ts
@@ -14,7 +14,6 @@ const handler: ScheduledHandler = async (event: EventBridgeEvent<string, void>) 
   const provider = chainProtocols.find(
     (element) => element.protocol == protocol && element.chainId == chainId
   )!.provider
-  protocol === Protocol.V3 ? new V3SubgraphProvider(chainId, 3, timeout) : new V2SubgraphProvider(chainId, 0, timeout)
   const log: Logger = bunyan.createLogger({
     name: 'RoutingLambda',
     serializers: bunyan.stdSerializers,

--- a/lib/cron/cache-pools.ts
+++ b/lib/cron/cache-pools.ts
@@ -4,14 +4,15 @@ import { EventBridgeEvent, ScheduledHandler } from 'aws-lambda'
 import { S3 } from 'aws-sdk'
 import { default as bunyan, default as Logger } from 'bunyan'
 import { S3_POOL_CACHE_KEY } from '../util/pool-cache-key'
+import { chainProtocols } from './cache-config'
 
 const handler: ScheduledHandler = async (event: EventBridgeEvent<string, void>) => {
   const chainId: ChainId = parseInt(process.env.chainId!)
   const protocol = process.env.protocol! as Protocol
   const timeout = parseInt(process.env.timeout!)
   // Don't retry for V2 as it will timeout and throw 500
-  const provider =
-    protocol === Protocol.V3 ? new V3SubgraphProvider(chainId, 3, timeout) : new V2SubgraphProvider(chainId, 1, timeout)
+  const provider = chainProtocols.find(element => (element.protocol == protocol && element.chainId == chainId))!.provider
+    protocol === Protocol.V3 ? new V3SubgraphProvider(chainId, 3, timeout) : new V2SubgraphProvider(chainId, 0, timeout)
   const log: Logger = bunyan.createLogger({
     name: 'RoutingLambda',
     serializers: bunyan.stdSerializers,

--- a/lib/cron/cache-pools.ts
+++ b/lib/cron/cache-pools.ts
@@ -1,5 +1,5 @@
 import { Protocol } from '@uniswap/router-sdk'
-import { ChainId, V2SubgraphProvider, V3SubgraphProvider } from '@uniswap/smart-order-router'
+import { ChainId } from '@uniswap/smart-order-router'
 import { EventBridgeEvent, ScheduledHandler } from 'aws-lambda'
 import { S3 } from 'aws-sdk'
 import { default as bunyan, default as Logger } from 'bunyan'
@@ -9,7 +9,6 @@ import { chainProtocols } from './cache-config'
 const handler: ScheduledHandler = async (event: EventBridgeEvent<string, void>) => {
   const chainId: ChainId = parseInt(process.env.chainId!)
   const protocol = process.env.protocol! as Protocol
-  const timeout = parseInt(process.env.timeout!)
   // Don't retry for V2 as it will timeout and throw 500
   const provider = chainProtocols.find(
     (element) => element.protocol == protocol && element.chainId == chainId

--- a/lib/cron/cache-pools.ts
+++ b/lib/cron/cache-pools.ts
@@ -9,8 +9,9 @@ const handler: ScheduledHandler = async (event: EventBridgeEvent<string, void>) 
   const chainId: ChainId = parseInt(process.env.chainId!)
   const protocol = process.env.protocol! as Protocol
   const timeout = parseInt(process.env.timeout!)
+  // Don't retry for V2 as it will timeout and throw 500
   const provider =
-    protocol === Protocol.V3 ? new V3SubgraphProvider(chainId, 3, timeout) : new V2SubgraphProvider(chainId, 3, timeout)
+    protocol === Protocol.V3 ? new V3SubgraphProvider(chainId, 3, timeout) : new V2SubgraphProvider(chainId, 1, timeout)
   const log: Logger = bunyan.createLogger({
     name: 'RoutingLambda',
     serializers: bunyan.stdSerializers,

--- a/lib/cron/cache-pools.ts
+++ b/lib/cron/cache-pools.ts
@@ -1,11 +1,16 @@
+import { Protocol } from '@uniswap/router-sdk'
+import { ChainId, V2SubgraphProvider, V3SubgraphProvider } from '@uniswap/smart-order-router'
 import { EventBridgeEvent, ScheduledHandler } from 'aws-lambda'
 import { S3 } from 'aws-sdk'
 import { default as bunyan, default as Logger } from 'bunyan'
-import _ from 'lodash'
 import { S3_POOL_CACHE_KEY } from '../util/pool-cache-key'
-import { chainProtocols } from './cache-config'
 
 const handler: ScheduledHandler = async (event: EventBridgeEvent<string, void>) => {
+  const chainId: ChainId = parseInt(process.env.chainId!)
+  const protocol = process.env.protocol! as Protocol
+  const timeout = parseInt(process.env.timeout!)
+  const provider =
+    protocol === Protocol.V3 ? new V3SubgraphProvider(chainId, 3, timeout) : new V2SubgraphProvider(chainId, 3, timeout)
   const log: Logger = bunyan.createLogger({
     name: 'RoutingLambda',
     serializers: bunyan.stdSerializers,
@@ -15,40 +20,36 @@ const handler: ScheduledHandler = async (event: EventBridgeEvent<string, void>) 
 
   const s3 = new S3()
 
-  await Promise.all(
-    _.map(chainProtocols, async ({ protocol, chainId, provider }) => {
-      log.info(`Getting pools for ${protocol} on ${chainId}`)
+  log.info(`Getting pools for ${protocol} on ${chainId}`)
 
-      let pools
-      try {
-        pools = await provider.getPools()
-      } catch (err) {
-        log.error({ err }, `Failed to get pools for ${protocol} on ${chainId}`)
-        throw new Error(`Failed to get pools for ${protocol} on ${chainId}`)
-      }
+  let pools
+  try {
+    pools = await provider.getPools()
+  } catch (err) {
+    log.error({ err }, `Failed to get pools for ${protocol} on ${chainId}`)
+    throw new Error(`Failed to get pools for ${protocol} on ${chainId}`)
+  }
 
-      if (!pools || pools.length == 0) {
-        log.info(`No ${protocol} pools found from the subgraph for ${chainId.toString()}`)
-        return
-      }
+  if (!pools || pools.length == 0) {
+    log.info(`No ${protocol} pools found from the subgraph for ${chainId.toString()}`)
+    return
+  }
 
-      const key = S3_POOL_CACHE_KEY(process.env.POOL_CACHE_KEY!, chainId, protocol)
+  const key = S3_POOL_CACHE_KEY(process.env.POOL_CACHE_KEY!, chainId, protocol)
 
-      log.info(`Got ${pools.length} ${protocol} pools from the subgraph for ${chainId.toString()}. Saving to ${key}`)
+  log.info(`Got ${pools.length} ${protocol} pools from the subgraph for ${chainId.toString()}. Saving to ${key}`)
 
-      const result = await s3
-        .putObject({
-          Bucket: process.env.POOL_CACHE_BUCKET_2!,
-          Key: key,
-          Body: JSON.stringify(pools),
-        })
-        .promise()
-
-      log.info({ result }, `Done ${protocol} for ${chainId.toString()}`)
+  const result = await s3
+    .putObject({
+      Bucket: process.env.POOL_CACHE_BUCKET_2!,
+      Key: key,
+      Body: JSON.stringify(pools),
     })
-  )
+    .promise()
 
-  log.info('Successfully cached all protocols to S3')
+  log.info({ result }, `Done ${protocol} for ${chainId.toString()}`)
+
+  log.info(`Successfully cached ${chainId} ${protocol} pools to S3`)
 }
 
 module.exports = { handler }

--- a/lib/cron/cache-pools.ts
+++ b/lib/cron/cache-pools.ts
@@ -11,8 +11,10 @@ const handler: ScheduledHandler = async (event: EventBridgeEvent<string, void>) 
   const protocol = process.env.protocol! as Protocol
   const timeout = parseInt(process.env.timeout!)
   // Don't retry for V2 as it will timeout and throw 500
-  const provider = chainProtocols.find(element => (element.protocol == protocol && element.chainId == chainId))!.provider
-    protocol === Protocol.V3 ? new V3SubgraphProvider(chainId, 3, timeout) : new V2SubgraphProvider(chainId, 0, timeout)
+  const provider = chainProtocols.find(
+    (element) => element.protocol == protocol && element.chainId == chainId
+  )!.provider
+  protocol === Protocol.V3 ? new V3SubgraphProvider(chainId, 3, timeout) : new V2SubgraphProvider(chainId, 0, timeout)
   const log: Logger = bunyan.createLogger({
     name: 'RoutingLambda',
     serializers: bunyan.stdSerializers,


### PR DESCRIPTION
https://uniswaplabs.atlassian.net/jira/software/projects/TRD/boards/23?selectedIssue=TRD-105
### Motivation:
https://uniswapteam.slack.com/archives/C02D07EM805/p1665108679405439 alarms like this are flooded eng ops. This is happening because V2 subgraph query keeps timing out and causes the poolCacheLambda to time out, which makes it seem that the whole cron failed, even though it worked for all other chains. After the lambda times out, it is retried. The cloudwatch rule is also configured to run this lambda once every 15 minutes. Because of this predictable failure on V2 and the retry policy, this lambda ends up stacking and running 4x concurrently, and spamming eng-ops with alerts.
<img width="1280" alt="Screen Shot 2022-10-06 at 2 07 32 PM" src="https://user-images.githubusercontent.com/106625855/194472641-d581514c-66bc-4a02-9014-86b1dd55c4ee.png">
<img width="1280" alt="Screen Shot 2022-10-06 at 11 33 46 AM" src="https://user-images.githubusercontent.com/106625855/194472832-b00b5d4d-bfa6-4adb-ad19-e1bde1c0915f.png">

### Solution:
Separate the pool cache lambda into multiple lambdas, one for each ChainId - Protocol pairing. Remove the pool cache lambda from the routing dashboard stack since it no longer exists. Separate the alerts. Reduce retries for V2 because the way its currently set up (10 minutes * 3 retries = 30 minutes) is double the lambda maximum duration of 15 minutes. Increase the timeout for V2 to 12 minutes to give it some extra time for the 1 and only retry it has. Change the Mainnet V2 alarm to be triggered if more than 85 percent of invocations error in an hour for 5 hours in a row (5 minute intervals) since it times out so often. Change all other alarms to be triggered if more than 50 percent of invocations error for 1 hour in a row.

<img width="1280" alt="Screen Shot 2022-10-07 at 1 17 38 AM" src="https://user-images.githubusercontent.com/106625855/194473075-c26eea4e-fc86-4890-8397-aa3e61d14c6f.png">

### Testing:
Chain and Protocol specific lambdas and alarms are created locally. V2 alarm still triggers, but all other ChainId-Protocol pairings work fine.

<img width="1280" alt="Screen Shot 2022-10-07 at 9 05 06 AM" src="https://user-images.githubusercontent.com/106625855/194560579-eafb9ba4-19d6-4350-adf1-27ed77412caf.png">

<img width="952" alt="Screen Shot 2022-10-07 at 2 11 24 AM" src="https://user-images.githubusercontent.com/106625855/194479696-41d0f8bc-ead6-4647-aa22-0de08a413d58.png">


Also, removed deprecated testnets rinkeby and goerli.