### PR TITLE
change cache pools ipfs lambda to be run in parallel for each chain/p…

### DIFF
--- a/bin/stacks/routing-caching-stack.ts
+++ b/bin/stacks/routing-caching-stack.ts
@@ -235,7 +235,7 @@ export class RoutingCachingStack extends cdk.NestedStack {
             period: Duration.minutes(60),
             statistic: 'sum',
           }),
-          threshold: 9,
+          threshold: 13,
           evaluationPeriods: 1,
         })
 


### PR DESCRIPTION
change cache pools ipfs lambda to be run in parallel for each chain/protocol pairing. Before, the handler run sequentially for each pairing, this should be faster and less likely to time out.