### PR TITLE
chore: adjust 2xx alarm evaluation period

### DIFF
--- a/bin/stacks/routing-api-stack.ts
+++ b/bin/stacks/routing-api-stack.ts
@@ -346,7 +346,7 @@ export class RoutingAPIStack extends cdk.Stack {
             metricName: `GET_QUOTE_REQUESTED_CHAINID: ${chainId.toString()}`,
             dimensionsMap: { Service: 'RoutingAPI' },
             unit: aws_cloudwatch.Unit.COUNT,
-            period: Duration.minutes(5),
+            period: Duration.minutes(30),
             statistic: 'sum',
           }),
           response200: new aws_cloudwatch.Metric({
@@ -354,7 +354,7 @@ export class RoutingAPIStack extends cdk.Stack {
             metricName: `GET_QUOTE_200_CHAINID: ${chainId.toString()}`,
             dimensionsMap: { Service: 'RoutingAPI' },
             unit: aws_cloudwatch.Unit.COUNT,
-            period: Duration.minutes(5),
+            period: Duration.minutes(30),
             statistic: 'sum',
           }),
         },


### PR DESCRIPTION
This PR adjust's the `GET /quote` endpoint's 2xx alarm, specifically changing the evaluation period from 5 minutes to 30.