### PR TITLE
bump SOR, use ethEstimateGas simulator when 'skipTenderlySimulation' flag is passed

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -250,7 +250,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
           process.env.TENDERLY_ACCESS_KEY!,
           v2PoolProvider,
           v3PoolProvider,
-          provider,
+          provider
         )
 
         const ethEstimateGasSimulator = new EthEstimateGasSimulator(chainId, provider, v2PoolProvider, v3PoolProvider)
@@ -259,7 +259,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
           chainId,
           provider,
           tenderlySimulator,
-          ethEstimateGasSimulator,
+          ethEstimateGasSimulator
         )
 
         const [v3SubgraphProvider, v2SubgraphProvider] = await Promise.all([

--- a/lib/handlers/quote/injector.ts
+++ b/lib/handlers/quote/injector.ts
@@ -33,7 +33,16 @@ export class QuoteHandlerInjector extends InjectorSOR<
     const quoteId = requestId.substring(0, 5)
     const logLevel = bunyan.INFO
 
-    const { tokenInAddress, tokenInChainId, tokenOutAddress, amount, type, algorithm, gasPriceWei, skipTenderlySimulation } = requestQueryParams
+    const {
+      tokenInAddress,
+      tokenInChainId,
+      tokenOutAddress,
+      amount,
+      type,
+      algorithm,
+      gasPriceWei,
+      skipTenderlySimulation,
+    } = requestQueryParams
 
     log = log.child({
       serializers: bunyan.stdSerializers,

--- a/lib/handlers/quote/injector.ts
+++ b/lib/handlers/quote/injector.ts
@@ -33,7 +33,7 @@ export class QuoteHandlerInjector extends InjectorSOR<
     const quoteId = requestId.substring(0, 5)
     const logLevel = bunyan.INFO
 
-    const { tokenInAddress, tokenInChainId, tokenOutAddress, amount, type, algorithm, gasPriceWei } = requestQueryParams
+    const { tokenInAddress, tokenInChainId, tokenOutAddress, amount, type, algorithm, gasPriceWei, skipTenderlySimulation } = requestQueryParams
 
     log = log.child({
       serializers: bunyan.stdSerializers,
@@ -77,7 +77,8 @@ export class QuoteHandlerInjector extends InjectorSOR<
       v2QuoteProvider,
       v2SubgraphProvider,
       gasPriceProvider: gasPriceProviderOnChain,
-      simulator,
+      ethEstimateGasSimulator,
+      fallbackTenderlySimulator,
     } = dependencies[chainIdEnum]!
 
     let onChainQuoteProvider = dependencies[chainIdEnum]!.onChainQuoteProvider
@@ -86,6 +87,8 @@ export class QuoteHandlerInjector extends InjectorSOR<
       const gasPriceWeiBN = BigNumber.from(gasPriceWei)
       gasPriceProvider = new StaticGasPriceProvider(gasPriceWeiBN)
     }
+
+    const simulator = skipTenderlySimulation ? ethEstimateGasSimulator : fallbackTenderlySimulator
 
     let router
     switch (algorithm) {

--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -456,7 +456,7 @@ export class QuoteHandler extends APIGLambdaHandler<
       gasUseEstimate: estimatedGasUsed.toString(),
       gasUseEstimateUSD: estimatedGasUsedUSD.toExact(),
       simulationStatus: simulationStatus ? simulationStatusToString(simulationStatus, log) : undefined,
-      simulationError: (simulationStatus === undefined || simulationStatus == SimulationStatus.Succeeded) ? false : true,
+      simulationError: simulationStatus === undefined || simulationStatus == SimulationStatus.Succeeded ? false : true,
       gasPriceWei: gasPriceWei.toString(),
       route: routeResponse,
       routeString: routeAmountsToString(route),

--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -348,7 +348,7 @@ export class QuoteHandler extends APIGLambdaHandler<
     } else if (simulationStatus == SimulationStatus.NotApproved) {
       metric.putMetric('SimulationNotApproved', 1, MetricLoggerUnit.Count)
     } else if (simulationStatus == SimulationStatus.NotSupported) {
-        metric.putMetric('SimulationNotSupported', 1, MetricLoggerUnit.Count)
+      metric.putMetric('SimulationNotSupported', 1, MetricLoggerUnit.Count)
     }
 
     const routeResponse: Array<(V3PoolInRoute | V2PoolInRoute)[]> = []
@@ -455,8 +455,8 @@ export class QuoteHandler extends APIGLambdaHandler<
       gasUseEstimateQuoteDecimals: estimatedGasUsedQuoteToken.toExact(),
       gasUseEstimate: estimatedGasUsed.toString(),
       gasUseEstimateUSD: estimatedGasUsedUSD.toExact(),
-      simulationStatus: simulationStatus? simulationStatusToString(simulationStatus, log): undefined,
-      simulationError: (simulationStatus === undefined || simulationStatus == SimulationStatus.Succeeded) ? false : true,
+      simulationStatus: simulationStatus ? simulationStatusToString(simulationStatus, log) : undefined,
+      simulationError: simulationStatus === undefined || simulationStatus == SimulationStatus.Succeeded ? false : true,
       gasPriceWei: gasPriceWei.toString(),
       route: routeResponse,
       routeString: routeAmountsToString(route),

--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -343,8 +343,12 @@ export class QuoteHandler extends APIGLambdaHandler<
       metric.putMetric('SimulationFailed', 1, MetricLoggerUnit.Count)
     } else if (simulationStatus == SimulationStatus.Succeeded) {
       metric.putMetric('SimulationSuccessful', 1, MetricLoggerUnit.Count)
-    } else if (simulationStatus == SimulationStatus.Unattempted) {
-      metric.putMetric('SimulationUnattempted', 1, MetricLoggerUnit.Count)
+    } else if (simulationStatus == SimulationStatus.InsufficientBalance) {
+      metric.putMetric('SimulationInsufficientBalalnce', 1, MetricLoggerUnit.Count)
+    } else if (simulationStatus == SimulationStatus.NotApproved) {
+      metric.putMetric('SimulationNotApproved', 1, MetricLoggerUnit.Count)
+    } else if (simulationStatus == SimulationStatus.NotSupported) {
+        metric.putMetric('SimulationNotSupported', 1, MetricLoggerUnit.Count)
     }
 
     const routeResponse: Array<(V3PoolInRoute | V2PoolInRoute)[]> = []
@@ -438,8 +442,6 @@ export class QuoteHandler extends APIGLambdaHandler<
       routeResponse.push(curRoute)
     }
 
-    
-
     const result: QuoteResponse = {
       methodParameters,
       blockNumber: blockNumber.toString(),
@@ -453,8 +455,8 @@ export class QuoteHandler extends APIGLambdaHandler<
       gasUseEstimateQuoteDecimals: estimatedGasUsedQuoteToken.toExact(),
       gasUseEstimate: estimatedGasUsed.toString(),
       gasUseEstimateUSD: estimatedGasUsedUSD.toExact(),
-      simulationStatus: simulationStatusToString(simulationStatus, log),
-      simulationError: (simulationStatus == SimulationStatus.Succeeded || simulationStatus == SimulationStatus.Unattempted) ? false : true,
+      simulationStatus: simulationStatus? simulationStatusToString(simulationStatus, log): undefined,
+      simulationError: (simulationStatus === undefined || simulationStatus == SimulationStatus.Succeeded) ? false : true,
       gasPriceWei: gasPriceWei.toString(),
       route: routeResponse,
       routeString: routeAmountsToString(route),

--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -456,7 +456,7 @@ export class QuoteHandler extends APIGLambdaHandler<
       gasUseEstimate: estimatedGasUsed.toString(),
       gasUseEstimateUSD: estimatedGasUsedUSD.toExact(),
       simulationStatus: simulationStatus ? simulationStatusToString(simulationStatus, log) : undefined,
-      simulationError: simulationStatus === undefined || simulationStatus == SimulationStatus.Succeeded ? false : true,
+      simulationError: (simulationStatus === undefined || simulationStatus == SimulationStatus.Succeeded) ? false : true,
       gasPriceWei: gasPriceWei.toString(),
       route: routeResponse,
       routeString: routeAmountsToString(route),

--- a/lib/handlers/quote/schema/quote-schema.ts
+++ b/lib/handlers/quote/schema/quote-schema.ts
@@ -48,6 +48,7 @@ export const QuoteQueryParamsJoi = Joi.object({
   forceMixedRoutes: Joi.boolean().optional(),
   protocols: Joi.stringArray().items(Joi.string().valid('v2', 'v3', 'mixed')).optional(),
   simulateFromAddress: Joi.string().alphanum().max(42).optional(),
+  skipTenderlySimulation: Joi.boolean().optional(),
   permitSignature: Joi.string().optional(),
   permitNonce: Joi.string().optional(),
   permitExpiration: Joi.number().optional(),
@@ -76,6 +77,7 @@ export type QuoteQueryParams = {
   forceMixedRoutes?: boolean
   protocols?: string[] | string
   simulateFromAddress?: string
+  skipTenderlySimulation?: boolean
   permitSignature?: string
   permitNonce?: string
   permitExpiration?: string

--- a/lib/handlers/quote/util/simulation.ts
+++ b/lib/handlers/quote/util/simulation.ts
@@ -7,8 +7,12 @@ export const simulationStatusToString = (simulationStatus: SimulationStatus, log
       return 'SUCCESS'
     case SimulationStatus.Failed:
       return 'FAILED'
-    case SimulationStatus.Unattempted:
-      return 'UNATTEMPTED'
+    case SimulationStatus.NotApproved:
+      return 'NOTAPPROVED'
+    case SimulationStatus.InsufficientBalance:
+      return 'INSUFFICIENTBALANCE'
+    case SimulationStatus.NotSupported:
+      return 'NOTSUPPORTED'
     default:
       log.error(`Unknown simulation status ${simulationStatus}`)
       return ''

--- a/lib/handlers/quote/util/simulation.ts
+++ b/lib/handlers/quote/util/simulation.ts
@@ -8,11 +8,11 @@ export const simulationStatusToString = (simulationStatus: SimulationStatus, log
     case SimulationStatus.Failed:
       return 'FAILED'
     case SimulationStatus.NotApproved:
-      return 'NOTAPPROVED'
+      return 'NOT_APPROVED'
     case SimulationStatus.InsufficientBalance:
-      return 'INSUFFICIENTBALANCE'
+      return 'INSUFFICIENT_BALANCE'
     case SimulationStatus.NotSupported:
-      return 'NOTSUPPORTED'
+      return 'NOT_SUPPORTED'
     default:
       log.error(`Unknown simulation status ${simulationStatus}`)
       return ''

--- a/lib/handlers/quote/util/simulation.ts
+++ b/lib/handlers/quote/util/simulation.ts
@@ -1,5 +1,5 @@
-import { SimulationStatus } from "@uniswap/smart-order-router"
-import Logger from "bunyan"
+import { SimulationStatus } from '@uniswap/smart-order-router'
+import Logger from 'bunyan'
 
 export const simulationStatusToString = (simulationStatus: SimulationStatus, log: Logger) => {
   switch (simulationStatus) {

--- a/lib/handlers/schema.ts
+++ b/lib/handlers/schema.ts
@@ -50,7 +50,7 @@ export const QuoteResponseSchemaJoi = Joi.object().keys({
   gasUseEstimate: Joi.string().required(),
   gasUseEstimateUSD: Joi.string().required(),
   simulationError: Joi.boolean().optional(),
-  simulationStatus: Joi.string().required(),
+  simulationStatus: Joi.string().optional(),
   gasPriceWei: Joi.string().required(),
   blockNumber: Joi.string().required(),
   route: Joi.array().items(Joi.any()).required(),
@@ -75,7 +75,7 @@ export type QuoteResponse = {
   gasUseEstimateQuoteDecimals: string
   gasUseEstimateUSD: string
   simulationError?: boolean
-  simulationStatus: string
+  simulationStatus?: string
   gasPriceWei: string
   blockNumber: string
   route: Array<(V3PoolInRoute | V2PoolInRoute)[]>

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@uniswap/permit2-sdk": "^1.0.0",
         "@uniswap/router-sdk": "^1.3.0",
         "@uniswap/sdk-core": "^3.0.1",
-        "@uniswap/smart-order-router": "^3.0.6",
+        "@uniswap/smart-order-router": "^3.1.0",
         "@uniswap/token-lists": "^1.0.0-beta.24",
         "@uniswap/universal-router-sdk": "^1.1.0",
         "@uniswap/v3-periphery": "^1.1.0",
@@ -3076,9 +3076,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.0.6.tgz",
-      "integrity": "sha512-hKXzAhcA0NNKtY+QEA3brXD2OFx20NrhPJ9Mb9R7aaMF7uVmPjFEe4FVDPxYgY3qTwYG6hUCcvUYErTccZyt5w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.2.0.tgz",
+      "integrity": "sha512-/Uq0UdEtBfRzpSrol/jHqrlUJ84H/IOWy8lcv2tmyHIqOOiN2RCzjhSqmfQ5ga3MSQeJcouL5wX4DwjrC6uKqg==",
       "dependencies": {
         "@uniswap/default-token-list": "^2.0.0",
         "@uniswap/permit2-sdk": "^1.0.0",
@@ -23325,9 +23325,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.0.6.tgz",
-      "integrity": "sha512-hKXzAhcA0NNKtY+QEA3brXD2OFx20NrhPJ9Mb9R7aaMF7uVmPjFEe4FVDPxYgY3qTwYG6hUCcvUYErTccZyt5w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.2.0.tgz",
+      "integrity": "sha512-/Uq0UdEtBfRzpSrol/jHqrlUJ84H/IOWy8lcv2tmyHIqOOiN2RCzjhSqmfQ5ga3MSQeJcouL5wX4DwjrC6uKqg==",
       "requires": {
         "@uniswap/default-token-list": "^2.0.0",
         "@uniswap/permit2-sdk": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@uniswap/permit2-sdk": "^1.0.0",
         "@uniswap/router-sdk": "^1.3.0",
         "@uniswap/sdk-core": "^3.0.1",
-        "@uniswap/smart-order-router": "^3.2.0",
+        "@uniswap/smart-order-router": "^3.1.0",
         "@uniswap/token-lists": "^1.0.0-beta.24",
         "@uniswap/universal-router-sdk": "^1.1.0",
         "@uniswap/v3-periphery": "^1.1.0",
@@ -3076,9 +3076,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.2.0.tgz",
-      "integrity": "sha512-/Uq0UdEtBfRzpSrol/jHqrlUJ84H/IOWy8lcv2tmyHIqOOiN2RCzjhSqmfQ5ga3MSQeJcouL5wX4DwjrC6uKqg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.1.0.tgz",
+      "integrity": "sha512-14Yh36v0c9pHmXkrT3jBmuGUU2+7RxyMf1hh3tfW5B931KiH+Vgi1P+yNgwMyfY1ev83Ik50ZhaTyopiDoqleQ==",
       "dependencies": {
         "@uniswap/default-token-list": "^2.0.0",
         "@uniswap/permit2-sdk": "^1.0.0",
@@ -23325,9 +23325,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.2.0.tgz",
-      "integrity": "sha512-/Uq0UdEtBfRzpSrol/jHqrlUJ84H/IOWy8lcv2tmyHIqOOiN2RCzjhSqmfQ5ga3MSQeJcouL5wX4DwjrC6uKqg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.1.0.tgz",
+      "integrity": "sha512-14Yh36v0c9pHmXkrT3jBmuGUU2+7RxyMf1hh3tfW5B931KiH+Vgi1P+yNgwMyfY1ev83Ik50ZhaTyopiDoqleQ==",
       "requires": {
         "@uniswap/default-token-list": "^2.0.0",
         "@uniswap/permit2-sdk": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@uniswap/permit2-sdk": "^1.0.0",
         "@uniswap/router-sdk": "^1.3.0",
         "@uniswap/sdk-core": "^3.0.1",
-        "@uniswap/smart-order-router": "^3.1.0",
+        "@uniswap/smart-order-router": "^3.2.0",
         "@uniswap/token-lists": "^1.0.0-beta.24",
         "@uniswap/universal-router-sdk": "^1.1.0",
         "@uniswap/v3-periphery": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@uniswap/permit2-sdk": "^1.0.0",
     "@uniswap/router-sdk": "^1.3.0",
     "@uniswap/sdk-core": "^3.0.1",
-    "@uniswap/smart-order-router": "^3.1.0",
+    "@uniswap/smart-order-router": "^3.2.0",
     "@uniswap/token-lists": "^1.0.0-beta.24",
     "@uniswap/universal-router-sdk": "^1.1.0",
     "@uniswap/v3-periphery": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@uniswap/permit2-sdk": "^1.0.0",
     "@uniswap/router-sdk": "^1.3.0",
     "@uniswap/sdk-core": "^3.0.1",
-    "@uniswap/smart-order-router": "^3.0.6",
+    "@uniswap/smart-order-router": "^3.1.0",
     "@uniswap/token-lists": "^1.0.0-beta.24",
     "@uniswap/universal-router-sdk": "^1.1.0",
     "@uniswap/v3-periphery": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@uniswap/permit2-sdk": "^1.0.0",
     "@uniswap/router-sdk": "^1.3.0",
     "@uniswap/sdk-core": "^3.0.1",
-    "@uniswap/smart-order-router": "^3.2.0",
+    "@uniswap/smart-order-router": "^3.1.0",
     "@uniswap/token-lists": "^1.0.0-beta.24",
     "@uniswap/universal-router-sdk": "^1.1.0",
     "@uniswap/v3-periphery": "^1.1.0",

--- a/test/integ/quote.test.ts
+++ b/test/integ/quote.test.ts
@@ -2047,8 +2047,7 @@ describe('quote', function () {
 
   // TODO: Find valid pools/tokens on optimistic kovan and polygon mumbai. We skip those tests for now.
   for (const chain of _.filter(
-    [],
-    //SUPPORTED_CHAINS,
+    SUPPORTED_CHAINS,
     (c) =>
       c != ChainId.OPTIMISTIC_KOVAN &&
       c != ChainId.POLYGON_MUMBAI &&

--- a/test/integ/quote.test.ts
+++ b/test/integ/quote.test.ts
@@ -1510,7 +1510,7 @@ describe('quote', function () {
               const response = await axios.get<QuoteResponse>(`${API}?${queryParams}`)
               const { data, status } = response
               expect(status).to.equal(200)
-              expect(data.simulationStatus).to.equal('NOTAPPROVED')
+              expect(data.simulationStatus).to.equal('NOT_APPROVED')
               expect(data.methodParameters).to.not.be.undefined
 
               const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
@@ -1550,7 +1550,7 @@ describe('quote', function () {
               const response = await axios.get<QuoteResponse>(`${API}?${queryParams}`)
               const { data, status } = response
               expect(status).to.equal(200)
-              expect(data.simulationStatus).to.equal('NOTAPPROVED')
+              expect(data.simulationStatus).to.equal('NOT_APPROVED')
               expect(data.methodParameters).to.not.be.undefined
 
               const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(


### PR DESCRIPTION
* This PR updates the gas fee flow to use ethEstimateGasSimulator when the skipTenderlySimulation flag is passed in.
* When the skipTenderlySimulation flag is not present, the fallback tenderlySimulator is used.
* The plan is for Web to integrate with this new gas fee flow by passing in simulateFromAddress and skipTenderlySimulation=true. This way, Web will get gas limit estimates using ethEstimateGas when possible, but never through Tenderly.
* Added integration tests for the skipTenderlySimulation flag.