### PR TITLE
Create a ChainId dimension for routing-api metrics

### DIFF
--- a/bin/stacks/routing-api-stack.ts
+++ b/bin/stacks/routing-api-stack.ts
@@ -342,15 +342,15 @@ export class RoutingAPIStack extends cdk.Stack {
         usingMetrics: {
           invocations: new aws_cloudwatch.Metric({
             namespace: 'Uniswap',
-            metricName: `GET_QUOTE_REQUESTED_CHAINID: ${chainId.toString()}`,
-            dimensionsMap: { Service: 'RoutingAPI' },
+            metricName: "GET_QUOTE_REQUESTED",
+            dimensionsMap: { Service: 'RoutingAPI', ChainId: chainId.toString()},
             unit: aws_cloudwatch.Unit.COUNT,
             statistic: 'sum',
           }),
           response200: new aws_cloudwatch.Metric({
             namespace: 'Uniswap',
-            metricName: `GET_QUOTE_200_CHAINID: ${chainId.toString()}`,
-            dimensionsMap: { Service: 'RoutingAPI' },
+            metricName: "GET_QUOTE_200",
+            dimensionsMap: { Service: 'RoutingAPI', ChainId: chainId.toString() },
             unit: aws_cloudwatch.Unit.COUNT,
             statistic: 'sum',
           }),
@@ -376,12 +376,14 @@ export class RoutingAPIStack extends cdk.Stack {
       const metric = new MathExpression({
         expression: '100*(response400/invocations)',
         usingMetrics: {
-          invocations: api.metric(`GET_QUOTE_REQUESTED_CHAINID: ${chainId.toString()}`, {
+          invocations: api.metric("GET_QUOTE_REQUESTED", {
             period: Duration.minutes(5),
+            dimensionsMap: { Service: 'RoutingAPI', ChainId: chainId.toString() },
             statistic: 'sum',
           }),
-          response400: api.metric(`GET_QUOTE_400_CHAINID: ${chainId.toString()}`, {
+          response400: api.metric("GET_QUOTE_400", {
             period: Duration.minutes(5),
+            dimensionsMap: { Service: 'RoutingAPI', ChainId: chainId.toString() },
             statistic: 'sum',
           }),
         },

--- a/bin/stacks/routing-api-stack.ts
+++ b/bin/stacks/routing-api-stack.ts
@@ -342,14 +342,14 @@ export class RoutingAPIStack extends cdk.Stack {
         usingMetrics: {
           invocations: new aws_cloudwatch.Metric({
             namespace: 'Uniswap',
-            metricName: "GET_QUOTE_REQUESTED",
-            dimensionsMap: { Service: 'RoutingAPI', ChainId: chainId.toString()},
+            metricName: 'GET_QUOTE_REQUESTED',
+            dimensionsMap: { Service: 'RoutingAPI', ChainId: chainId.toString() },
             unit: aws_cloudwatch.Unit.COUNT,
             statistic: 'sum',
           }),
           response200: new aws_cloudwatch.Metric({
             namespace: 'Uniswap',
-            metricName: "GET_QUOTE_200",
+            metricName: 'GET_QUOTE_200',
             dimensionsMap: { Service: 'RoutingAPI', ChainId: chainId.toString() },
             unit: aws_cloudwatch.Unit.COUNT,
             statistic: 'sum',
@@ -376,12 +376,12 @@ export class RoutingAPIStack extends cdk.Stack {
       const metric = new MathExpression({
         expression: '100*(response400/invocations)',
         usingMetrics: {
-          invocations: api.metric("GET_QUOTE_REQUESTED", {
+          invocations: api.metric('GET_QUOTE_REQUESTED', {
             period: Duration.minutes(5),
             dimensionsMap: { Service: 'RoutingAPI', ChainId: chainId.toString() },
             statistic: 'sum',
           }),
-          response400: api.metric("GET_QUOTE_400", {
+          response400: api.metric('GET_QUOTE_400', {
             period: Duration.minutes(5),
             dimensionsMap: { Service: 'RoutingAPI', ChainId: chainId.toString() },
             statistic: 'sum',

--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -75,9 +75,9 @@ export class QuoteHandler extends APIGLambdaHandler<
       },
     } = params
     // Sets ChainId Dimension for metrics
-    metric.putDimensions({ChainId: `${chainId}`})
+    metric.putDimensions({ ChainId: `${chainId}` })
 
-    metric.putMetric("GET_QUOTE_REQUESTED", 1, MetricLoggerUnit.Count)
+    metric.putMetric('GET_QUOTE_REQUESTED', 1, MetricLoggerUnit.Count)
 
     // Parse user provided token address/symbol to Currency object.
     let before = Date.now()
@@ -101,7 +101,7 @@ export class QuoteHandler extends APIGLambdaHandler<
     metric.putMetric('TokenInOutStrToToken', Date.now() - before, MetricLoggerUnit.Milliseconds)
 
     if (!currencyIn) {
-      metric.putMetric("GET_QUOTE_400", 1, MetricLoggerUnit.Count)
+      metric.putMetric('GET_QUOTE_400', 1, MetricLoggerUnit.Count)
       return {
         statusCode: 400,
         errorCode: 'TOKEN_IN_INVALID',
@@ -110,7 +110,7 @@ export class QuoteHandler extends APIGLambdaHandler<
     }
 
     if (!currencyOut) {
-      metric.putMetric("GET_QUOTE_400", 1, MetricLoggerUnit.Count)
+      metric.putMetric('GET_QUOTE_400', 1, MetricLoggerUnit.Count)
       return {
         statusCode: 400,
         errorCode: 'TOKEN_OUT_INVALID',
@@ -119,7 +119,7 @@ export class QuoteHandler extends APIGLambdaHandler<
     }
 
     if (tokenInChainId != tokenOutChainId) {
-      metric.putMetric("GET_QUOTE_400", 1, MetricLoggerUnit.Count)
+      metric.putMetric('GET_QUOTE_400', 1, MetricLoggerUnit.Count)
       return {
         statusCode: 400,
         errorCode: 'TOKEN_CHAINS_DIFFERENT',
@@ -128,7 +128,7 @@ export class QuoteHandler extends APIGLambdaHandler<
     }
 
     if (currencyIn.equals(currencyOut)) {
-      metric.putMetric("GET_QUOTE_400", 1, MetricLoggerUnit.Count)
+      metric.putMetric('GET_QUOTE_400', 1, MetricLoggerUnit.Count)
       return {
         statusCode: 400,
         errorCode: 'TOKEN_IN_OUT_SAME',
@@ -466,7 +466,7 @@ export class QuoteHandler extends APIGLambdaHandler<
       quoteId,
     }
 
-    metric.putMetric("GET_QUOTE_200", 1, MetricLoggerUnit.Count)
+    metric.putMetric('GET_QUOTE_200', 1, MetricLoggerUnit.Count)
     return {
       statusCode: 200,
       body: result,

--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -75,8 +75,7 @@ export class QuoteHandler extends APIGLambdaHandler<
       },
     } = params
     // Sets ChainId Dimension for metrics
-    metric.putDimensions({"ChainId": `${chainId}`})
-    metric.putMetric("Count", 1, MetricLoggerUnit.Count)
+    metric.putDimensions({ChainId: `${chainId}`})
 
     metric.putMetric("GET_QUOTE_REQUESTED", 1, MetricLoggerUnit.Count)
 
@@ -136,9 +135,6 @@ export class QuoteHandler extends APIGLambdaHandler<
         detail: `tokenIn and tokenOut must be different`,
       }
     }
-
-    // Track pairs
-    metric.putMetric(`${currencyIn.symbol}->${currencyOut.symbol}`, 1, MetricLoggerUnit.Count)
 
     let protocols: Protocol[] = []
     if (protocolsStr) {

--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -75,7 +75,7 @@ export class QuoteHandler extends APIGLambdaHandler<
       },
     } = params
     // Sets ChainId Dimension for metrics
-    metric.putDimensions({ ChainId: `${chainId}` })
+    metric.putDimensions({ ChainId: chainId.toString() })
 
     metric.putMetric('GET_QUOTE_REQUESTED', 1, MetricLoggerUnit.Count)
 

--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -103,19 +103,11 @@ export class QuoteHandler extends APIGLambdaHandler<
 
     // Validations
     if (!currencyIn) {
-      return this.getQuoteError(
-        'TOKEN_IN_INVALID',
-        `Could not find token with address "${tokenInAddress}"`,
-        metric
-      )
+      return this.getQuoteError('TOKEN_IN_INVALID', `Could not find token with address "${tokenInAddress}"`, metric)
     }
 
     if (!currencyOut) {
-      return this.getQuoteError(
-        'TOKEN_OUT_INVALID',
-        `Could not find token with address "${tokenOutAddress}"`,
-        metric
-      )
+      return this.getQuoteError('TOKEN_OUT_INVALID', `Could not find token with address "${tokenOutAddress}"`, metric)
     }
 
     if (tokenInChainId != tokenOutChainId) {
@@ -127,11 +119,7 @@ export class QuoteHandler extends APIGLambdaHandler<
     }
 
     if (currencyIn.equals(currencyOut)) {
-      return this.getQuoteError(
-        'TOKEN_IN_OUT_SAME',
-        'tokenIn and tokenOut must be different',
-        metric
-      )
+      return this.getQuoteError('TOKEN_IN_OUT_SAME', 'tokenIn and tokenOut must be different', metric)
     }
 
     let protocols: Protocol[] = []


### PR DESCRIPTION
This is a metrics change where instead of encoding the ChainId in the metric name we instead create a dimension for the metrics.