### PR TITLE
Remove hashed route metric

### DIFF
--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -523,11 +523,6 @@ export class QuoteHandler extends APIGLambdaHandler<
       const routeStringHash = Math.abs(
         routeString.split('').reduce((s, c) => (Math.imul(31, s) + c.charCodeAt(0)) | 0, 0)
       )
-      metric.putMetric(
-        `GET_QUOTE_AMOUNT_${tradingPair}_${tradeType.toUpperCase()}_CHAIN_${chainId}_BUCKET_${routeStringHash}`,
-        Number(amount.toExact()),
-        MetricLoggerUnit.None
-      )
       // Log the chose route
       log.info(
         {


### PR DESCRIPTION
As predicted by @willpote, there are so many routes that the metrics are not being helpful.

It will be easier to query logs, so I'm removing the metrics to avoid the cost of them.