### PR TITLE
Improve latencies by reducing the topNSecondHop pools per second hop

### DIFF
--- a/lib/handlers/router-entities/aws-metrics-logger.ts
+++ b/lib/handlers/router-entities/aws-metrics-logger.ts
@@ -11,4 +11,8 @@ export class AWSMetricsLogger implements IMetric {
   public putMetric(key: string, value: number, unit?: MetricLoggerUnit): void {
     this.awsMetricLogger.putMetric(key, value, unit)
   }
+
+  public setProperty(key: string, value: unknown): void {
+    this.awsMetricLogger.setProperty(key, value)
+  }
 }

--- a/lib/handlers/shared.ts
+++ b/lib/handlers/shared.ts
@@ -6,7 +6,7 @@ import {
   ITokenProvider,
   MapWithLowerCaseKey,
   NATIVE_NAMES_BY_ID,
-  nativeOnChain
+  nativeOnChain,
 } from '@uniswap/smart-order-router'
 import Logger from 'bunyan'
 
@@ -81,7 +81,7 @@ export const DEFAULT_ROUTING_CONFIG_BY_CHAIN = (chainId: ChainId): AlphaRouterCo
           topNTokenInOut: 3,
           topNSecondHop: 1,
           topNSecondHopForTokenAddress: new MapWithLowerCaseKey<number>([
-            ['0x5f98805a4e8be255a32880fdec7f6728c6568ba0', 2] // LUSD
+            ['0x5f98805a4e8be255a32880fdec7f6728c6568ba0', 2], // LUSD
           ]),
           topNWithEachBaseToken: 3,
           topNWithBaseToken: 5,

--- a/lib/handlers/shared.ts
+++ b/lib/handlers/shared.ts
@@ -4,8 +4,9 @@ import {
   ChainId,
   ITokenListProvider,
   ITokenProvider,
-  nativeOnChain,
+  MapWithLowerCaseKey,
   NATIVE_NAMES_BY_ID,
+  nativeOnChain
 } from '@uniswap/smart-order-router'
 import Logger from 'bunyan'
 
@@ -26,7 +27,7 @@ export const DEFAULT_ROUTING_CONFIG_BY_CHAIN = (chainId: ChainId): AlphaRouterCo
           topN: 2,
           topNDirectSwaps: 2,
           topNTokenInOut: 2,
-          topNSecondHop: 2,
+          topNSecondHop: 1,
           topNWithEachBaseToken: 3,
           topNWithBaseToken: 3,
         },
@@ -54,7 +55,7 @@ export const DEFAULT_ROUTING_CONFIG_BY_CHAIN = (chainId: ChainId): AlphaRouterCo
           topN: 2,
           topNDirectSwaps: 2,
           topNTokenInOut: 2,
-          topNSecondHop: 2,
+          topNSecondHop: 1,
           topNWithEachBaseToken: 3,
           topNWithBaseToken: 2,
         },
@@ -78,7 +79,10 @@ export const DEFAULT_ROUTING_CONFIG_BY_CHAIN = (chainId: ChainId): AlphaRouterCo
           topN: 2,
           topNDirectSwaps: 2,
           topNTokenInOut: 3,
-          topNSecondHop: 2,
+          topNSecondHop: 1,
+          topNSecondHopForTokenAddress: new MapWithLowerCaseKey<number>([
+            ['0x5f98805a4e8be255a32880fdec7f6728c6568ba0', 2] // LUSD
+          ]),
           topNWithEachBaseToken: 3,
           topNWithBaseToken: 5,
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@uniswap/permit2-sdk": "^1.2.0",
         "@uniswap/router-sdk": "^1.3.0",
         "@uniswap/sdk-core": "^3.0.1",
-        "@uniswap/smart-order-router": "^3.7.0",
+        "@uniswap/smart-order-router": "^3.10.0",
         "@uniswap/token-lists": "^1.0.0-beta.24",
         "@uniswap/universal-router-sdk": "^1.3.0",
         "@uniswap/v3-periphery": "^1.1.0",
@@ -3071,9 +3071,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.7.0.tgz",
-      "integrity": "sha512-pdBNIFOVKo7pXtWkkEqPfrzKFxfsUAaYnO2tastPTJeWcHJwFPJSSM7bIQVQ/aeh0RVA5EznH5m0C/hekrOpfA==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.10.0.tgz",
+      "integrity": "sha512-lgSaZpJKtAH/HJCRCkdP2e5um2tPn3A8/DUvd8XtsuqlX1bR6KK1BnZJCT7kbPS6Nqi7PdExkGrzJCcZeN97YA==",
       "dependencies": {
         "@uniswap/default-token-list": "^2.0.0",
         "@uniswap/permit2-sdk": "^1.2.0",
@@ -23311,9 +23311,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.7.0.tgz",
-      "integrity": "sha512-pdBNIFOVKo7pXtWkkEqPfrzKFxfsUAaYnO2tastPTJeWcHJwFPJSSM7bIQVQ/aeh0RVA5EznH5m0C/hekrOpfA==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.10.0.tgz",
+      "integrity": "sha512-lgSaZpJKtAH/HJCRCkdP2e5um2tPn3A8/DUvd8XtsuqlX1bR6KK1BnZJCT7kbPS6Nqi7PdExkGrzJCcZeN97YA==",
       "requires": {
         "@uniswap/default-token-list": "^2.0.0",
         "@uniswap/permit2-sdk": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@uniswap/permit2-sdk": "^1.2.0",
     "@uniswap/router-sdk": "^1.3.0",
     "@uniswap/sdk-core": "^3.0.1",
-    "@uniswap/smart-order-router": "^3.7.0",
+    "@uniswap/smart-order-router": "^3.10.0",
     "@uniswap/token-lists": "^1.0.0-beta.24",
     "@uniswap/universal-router-sdk": "^1.3.0",
     "@uniswap/v3-periphery": "^1.1.0",


### PR DESCRIPTION
In a previous deployment we fixed an issue with LUSD not being used as a pool for routing but it came with the cost of higher latencies overall.
This branch attempts to reduce the latencies while keeping the fix for LUSD working.
