### PR TITLE
Normalize order of protocols in sortKey

### DIFF
--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -84,7 +84,7 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
 
     if (cachingParameters) {
       const partitionKey = `${tokenIn.address}/${tokenOut.address}/${tradeType}/${chainId}`
-      const partialSortKey = `${protocols}/${cachingParameters.bucket}/`
+      const partialSortKey = `${protocols.sort()}/${cachingParameters.bucket}/`
 
       const queryParams = {
         TableName: this.tableName,
@@ -160,7 +160,7 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
         TableName: this.tableName,
         Item: {
           pairTradeTypeChainId: `${cachedRoutes.tokenIn.address}/${cachedRoutes.tokenOut.address}/${cachedRoutes.tradeType}/${cachedRoutes.chainId}`,
-          protocolsBucketBlockNumber: `${cachedRoutes.protocolsCovered}/${cachingParameters.bucket}/${cachedRoutes.blockNumber}`,
+          protocolsBucketBlockNumber: `${cachedRoutes.protocolsCovered.sort()}/${cachingParameters.bucket}/${cachedRoutes.blockNumber}`,
           item: binaryCachedRoutes,
           ttl: ttl,
         },

--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -160,7 +160,9 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
         TableName: this.tableName,
         Item: {
           pairTradeTypeChainId: `${cachedRoutes.tokenIn.address}/${cachedRoutes.tokenOut.address}/${cachedRoutes.tradeType}/${cachedRoutes.chainId}`,
-          protocolsBucketBlockNumber: `${cachedRoutes.protocolsCovered.sort()}/${cachingParameters.bucket}/${cachedRoutes.blockNumber}`,
+          protocolsBucketBlockNumber: `${cachedRoutes.protocolsCovered.sort()}/${cachingParameters.bucket}/${
+            cachedRoutes.blockNumber
+          }`,
           item: binaryCachedRoutes,
           ttl: ttl,
         },


### PR DESCRIPTION
It appears like the order of the protocols is different in the setCachedRoute vs the getCachedRoutes function.

This change will allow us to test that theory in a quick and simple code change
