### PR TITLE
Revert to Tapcompare to investigate potential bug with V2 routes

### DIFF
--- a/lib/handlers/router-entities/route-caching/cached-routes-configuration.ts
+++ b/lib/handlers/router-entities/route-caching/cached-routes-configuration.ts
@@ -26,8 +26,8 @@ export const CACHED_ROUTES_CONFIGURATION: Map<string, CachedRoutesStrategy> = ne
       tradeType: TradeType.EXACT_INPUT,
       chainId: ChainId.MAINNET,
       buckets: [
-        new CachedRoutesBucket({ bucket: 1, blocksToLive: 1, cacheMode: CacheMode.Livemode }),
-        new CachedRoutesBucket({ bucket: 2, blocksToLive: 1, cacheMode: CacheMode.Livemode }),
+        new CachedRoutesBucket({ bucket: 1, blocksToLive: 1, cacheMode: CacheMode.Tapcompare }),
+        new CachedRoutesBucket({ bucket: 2, blocksToLive: 1, cacheMode: CacheMode.Tapcompare }),
         new CachedRoutesBucket({ bucket: 3, blocksToLive: 1, cacheMode: CacheMode.Tapcompare }),
         new CachedRoutesBucket({ bucket: 5, blocksToLive: 1, cacheMode: CacheMode.Tapcompare }),
         new CachedRoutesBucket({ bucket: 8, blocksToLive: 1, cacheMode: CacheMode.Tapcompare }),


### PR DESCRIPTION
While looking at some metrics I realized that we might have a bug with V2 routes, and I would like to revert these live caches to tap compare while I investigate

