### PR TITLE
Create a new option for fetching the last N cachedRoutes and reducing it into 1

### DIFF
--- a/lib/handlers/router-entities/route-caching/cached-routes-configuration.ts
+++ b/lib/handlers/router-entities/route-caching/cached-routes-configuration.ts
@@ -69,60 +69,6 @@ export const CACHED_ROUTES_CONFIGURATION: Map<string, CachedRoutesStrategy> = ne
     }),
   ],
   /**
-   * WETH/USDC - Arbitrum
-   */
-  [
-    new PairTradeTypeChainId({
-      tokenIn: '0x82af49447d8a07e3bd95bd0d56f35241523fbab1', // WETH
-      tokenOut: '0xff970a61a04b1ca14834a43f5de4533ebddb5cc8', // USDC
-      tradeType: TradeType.EXACT_INPUT,
-      chainId: ChainId.ARBITRUM_ONE,
-    }).toString(),
-    new CachedRoutesStrategy({
-      pair: 'WETH/USDC',
-      tradeType: TradeType.EXACT_INPUT,
-      chainId: ChainId.ARBITRUM_ONE,
-      buckets: [
-        new CachedRoutesBucket({ bucket: 0.2, cacheMode: CacheMode.Tapcompare, blocksToLive: 50 }),
-        new CachedRoutesBucket({ bucket: 1, cacheMode: CacheMode.Tapcompare, blocksToLive: 50 }),
-        new CachedRoutesBucket({ bucket: 3, cacheMode: CacheMode.Tapcompare, blocksToLive: 50 }),
-        new CachedRoutesBucket({ bucket: 5, cacheMode: CacheMode.Tapcompare, blocksToLive: 50 }),
-        new CachedRoutesBucket({ bucket: 8, cacheMode: CacheMode.Tapcompare, blocksToLive: 50 }),
-        new CachedRoutesBucket({ bucket: 13, cacheMode: CacheMode.Tapcompare, blocksToLive: 50 }),
-        new CachedRoutesBucket({ bucket: 21, cacheMode: CacheMode.Tapcompare, blocksToLive: 50 }),
-        new CachedRoutesBucket({ bucket: 34, cacheMode: CacheMode.Tapcompare, blocksToLive: 50 }),
-        new CachedRoutesBucket({ bucket: 55, cacheMode: CacheMode.Tapcompare, blocksToLive: 50 }),
-      ],
-    }),
-  ],
-  /**
-   * USDC/WETH - Arbitrum
-   */
-  [
-    new PairTradeTypeChainId({
-      tokenIn: '0xff970a61a04b1ca14834a43f5de4533ebddb5cc8', // USDC
-      tokenOut: '0x82af49447d8a07e3bd95bd0d56f35241523fbab1', // WETH
-      tradeType: TradeType.EXACT_INPUT,
-      chainId: ChainId.ARBITRUM_ONE,
-    }).toString(),
-    new CachedRoutesStrategy({
-      pair: 'USDC/WETH',
-      tradeType: TradeType.EXACT_INPUT,
-      chainId: ChainId.ARBITRUM_ONE,
-      buckets: [
-        new CachedRoutesBucket({ bucket: 500, cacheMode: CacheMode.Tapcompare, blocksToLive: 50 }),
-        new CachedRoutesBucket({ bucket: 1_000, cacheMode: CacheMode.Tapcompare, blocksToLive: 50 }),
-        new CachedRoutesBucket({ bucket: 3_000, cacheMode: CacheMode.Tapcompare, blocksToLive: 50 }),
-        new CachedRoutesBucket({ bucket: 8_000, cacheMode: CacheMode.Tapcompare, blocksToLive: 50 }),
-        new CachedRoutesBucket({ bucket: 13_000, cacheMode: CacheMode.Tapcompare, blocksToLive: 50 }),
-        new CachedRoutesBucket({ bucket: 21_000, cacheMode: CacheMode.Tapcompare, blocksToLive: 50 }),
-        new CachedRoutesBucket({ bucket: 34_000, cacheMode: CacheMode.Tapcompare, blocksToLive: 50 }),
-        new CachedRoutesBucket({ bucket: 55_000, cacheMode: CacheMode.Tapcompare, blocksToLive: 50 }),
-        new CachedRoutesBucket({ bucket: 89_000, cacheMode: CacheMode.Tapcompare, blocksToLive: 50 }),
-      ],
-    }),
-  ],
-  /**
    * WETH/USDT - Mainnet
    */
   [
@@ -188,17 +134,17 @@ export const CACHED_ROUTES_CONFIGURATION: Map<string, CachedRoutesStrategy> = ne
       tradeType: TradeType.EXACT_INPUT,
       chainId: ChainId.MAINNET,
       buckets: [
-        new CachedRoutesBucket({ bucket: 0.0025, cacheMode: CacheMode.Tapcompare, maxSplits: 1 }),
-        new CachedRoutesBucket({ bucket: 0.006, cacheMode: CacheMode.Tapcompare, maxSplits: 1 }),
-        new CachedRoutesBucket({ bucket: 0.025, cacheMode: CacheMode.Tapcompare, maxSplits: 1 }),
-        new CachedRoutesBucket({ bucket: 0.06, cacheMode: CacheMode.Tapcompare, maxSplits: 1 }),
-        new CachedRoutesBucket({ bucket: 0.25, cacheMode: CacheMode.Tapcompare, maxSplits: 2 }),
-        new CachedRoutesBucket({ bucket: 0.6, cacheMode: CacheMode.Tapcompare, maxSplits: 2 }),
-        new CachedRoutesBucket({ bucket: 1, cacheMode: CacheMode.Tapcompare, maxSplits: 2 }),
-        new CachedRoutesBucket({ bucket: 2, cacheMode: CacheMode.Tapcompare, maxSplits: 2 }),
-        new CachedRoutesBucket({ bucket: 3, cacheMode: CacheMode.Tapcompare, maxSplits: 2 }),
-        new CachedRoutesBucket({ bucket: 4, cacheMode: CacheMode.Tapcompare }),
-        new CachedRoutesBucket({ bucket: 5, cacheMode: CacheMode.Tapcompare }),
+        new CachedRoutesBucket({ bucket: 0.0025, cacheMode: CacheMode.Tapcompare, withLastNCachedRoutes: 3 }),
+        new CachedRoutesBucket({ bucket: 0.006, cacheMode: CacheMode.Tapcompare, withLastNCachedRoutes: 3 }),
+        new CachedRoutesBucket({ bucket: 0.025, cacheMode: CacheMode.Tapcompare, withLastNCachedRoutes: 3 }),
+        new CachedRoutesBucket({ bucket: 0.06, cacheMode: CacheMode.Tapcompare, withLastNCachedRoutes: 3 }),
+        new CachedRoutesBucket({ bucket: 0.25, cacheMode: CacheMode.Tapcompare, withLastNCachedRoutes: 3 }),
+        new CachedRoutesBucket({ bucket: 0.6, cacheMode: CacheMode.Tapcompare, withLastNCachedRoutes: 3 }),
+        new CachedRoutesBucket({ bucket: 1, cacheMode: CacheMode.Tapcompare, withLastNCachedRoutes: 3 }),
+        new CachedRoutesBucket({ bucket: 2, cacheMode: CacheMode.Tapcompare, withLastNCachedRoutes: 3 }),
+        new CachedRoutesBucket({ bucket: 3, cacheMode: CacheMode.Tapcompare, withLastNCachedRoutes: 3 }),
+        new CachedRoutesBucket({ bucket: 4, cacheMode: CacheMode.Tapcompare, withLastNCachedRoutes: 3 }),
+        new CachedRoutesBucket({ bucket: 5, cacheMode: CacheMode.Tapcompare, withLastNCachedRoutes: 3 }),
       ],
     }),
   ],

--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -5,7 +5,7 @@ import {
   ChainId,
   IRouteCachingProvider,
   log,
-  routeToString
+  routeToString,
 } from '@uniswap/smart-order-router'
 import { DynamoDB } from 'aws-sdk'
 import { Currency, CurrencyAmount, Token, TradeType } from '@uniswap/sdk-core'
@@ -167,7 +167,7 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
             blockNumber,
             tradeType: first.tradeType,
             originalAmount,
-            blocksToLive: first.blocksToLive
+            blocksToLive: first.blocksToLive,
           })
 
           log.info({ cachedRoutes }, `[DynamoRouteCachingProvider] Returning the cached and unmarshalled route.`)

--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -5,7 +5,7 @@ import {
   ChainId,
   IRouteCachingProvider,
   log,
-  routeToString,
+  routeToString
 } from '@uniswap/smart-order-router'
 import { DynamoDB } from 'aws-sdk'
 import { Currency, CurrencyAmount, Token, TradeType } from '@uniswap/sdk-core'
@@ -286,7 +286,9 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
         }/${tradeType}/${chainId}`
       )
 
-      return cachingParameters.cacheMode
+      // TODO(mcervera): Reenable after testing
+      // return cachingParameters.cacheMode
+      return CacheMode.Tapcompare // Disabling live caches while testing a significant change
     } else {
       log.info(
         {

--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -155,7 +155,7 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
             blockNumber = Math.max(blockNumber, cachedRoutes.blockNumber)
             // Keep track of all the originalAmounts
             originalAmount =
-              originalAmount == '' ? cachedRoutes.originalAmount : `${originalAmount}, ${cachedRoutes.originalAmount}`
+              originalAmount === '' ? cachedRoutes.originalAmount : `${originalAmount}, ${cachedRoutes.originalAmount}`
           })
 
           const first = cachedRoutesArr[0]

--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -146,13 +146,15 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
 
           cachedRoutesArr.forEach((cachedRoutes) => {
             cachedRoutes.routes.forEach((cachedRoute) => {
-              // Using a map to remove duplicates (NOTE: This might still retain duplicated routes with different percent split)
-              routesMap.set(this.cachedRouteId(cachedRoute), cachedRoute)
+              // we use the stringified route as identifier
+              const routeId = routeToString(cachedRoute.route)
+              // Using a map to remove duplicates, we will the different percents of different routes.
+              if (!routesMap.has(routeId)) routesMap.set(routeId, cachedRoute)
             })
             // Find the latest blockNumber
             blockNumber = Math.max(blockNumber, cachedRoutes.blockNumber)
             // Keep track of all the originalAmounts
-            originalAmount = `${originalAmount}, ${cachedRoutes.originalAmount}`
+            originalAmount = originalAmount == '' ? cachedRoutes.originalAmount :`${originalAmount}, ${cachedRoutes.originalAmount}`
           })
 
           const first = cachedRoutesArr[0]
@@ -183,11 +185,6 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
 
     // We only get here if we didn't find a cachedRoutes
     return undefined
-  }
-
-  // TODO(mcervera): This could be a method inside the `CachedRoute` class in SOR.
-  private cachedRouteId(cachedRoute: CachedRoute<V3Route | V2Route | MixedRoute>): string {
-    return `[${cachedRoute.percent}%] ${routeToString(cachedRoute.route)}`
   }
 
   /**

--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -5,7 +5,7 @@ import {
   ChainId,
   IRouteCachingProvider,
   log,
-  routeToString
+  routeToString,
 } from '@uniswap/smart-order-router'
 import { DynamoDB } from 'aws-sdk'
 import { Currency, CurrencyAmount, Token, TradeType } from '@uniswap/sdk-core'
@@ -154,7 +154,8 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
             // Find the latest blockNumber
             blockNumber = Math.max(blockNumber, cachedRoutes.blockNumber)
             // Keep track of all the originalAmounts
-            originalAmount = originalAmount == '' ? cachedRoutes.originalAmount :`${originalAmount}, ${cachedRoutes.originalAmount}`
+            originalAmount =
+              originalAmount == '' ? cachedRoutes.originalAmount : `${originalAmount}, ${cachedRoutes.originalAmount}`
           })
 
           const first = cachedRoutesArr[0]

--- a/lib/handlers/router-entities/route-caching/model/cached-routes-bucket.ts
+++ b/lib/handlers/router-entities/route-caching/model/cached-routes-bucket.ts
@@ -33,7 +33,13 @@ export class CachedRoutesBucket {
   public readonly maxSplits: number
   public readonly withLastNCachedRoutes: number
 
-  constructor({ bucket, blocksToLive = 1, cacheMode, maxSplits = 0, withLastNCachedRoutes = 1}: CachedRoutesBucketsArgs) {
+  constructor({
+    bucket,
+    blocksToLive = 1,
+    cacheMode,
+    maxSplits = 0,
+    withLastNCachedRoutes = 1,
+  }: CachedRoutesBucketsArgs) {
     this.bucket = bucket
     this.blocksToLive = blocksToLive // by default this value is 1, which means it's only cached in the current block.
     this.cacheMode = cacheMode

--- a/lib/handlers/router-entities/route-caching/model/cached-routes-bucket.ts
+++ b/lib/handlers/router-entities/route-caching/model/cached-routes-bucket.ts
@@ -19,6 +19,11 @@ interface CachedRoutesBucketsArgs {
    * A value of 1 indicates that at most there can only be 1 split in the route in order to be cached.
    */
   maxSplits?: number
+  /**
+   * When fetching the CachedRoutes, we could opt for using the last N routes, from the last N blocks
+   * This way we would query the price for all the recent routes that have been cached as the best routes
+   */
+  withLastNCachedRoutes?: number
 }
 
 export class CachedRoutesBucket {
@@ -26,11 +31,13 @@ export class CachedRoutesBucket {
   public readonly blocksToLive: number
   public readonly cacheMode: CacheMode
   public readonly maxSplits: number
+  public readonly withLastNCachedRoutes: number
 
-  constructor({ bucket, blocksToLive = 1, cacheMode, maxSplits = 0 }: CachedRoutesBucketsArgs) {
+  constructor({ bucket, blocksToLive = 1, cacheMode, maxSplits = 0, withLastNCachedRoutes = 1}: CachedRoutesBucketsArgs) {
     this.bucket = bucket
     this.blocksToLive = blocksToLive // by default this value is 1, which means it's only cached in the current block.
     this.cacheMode = cacheMode
     this.maxSplits = maxSplits // by default this value is 0, which means that any number of splits are allowed
+    this.withLastNCachedRoutes = withLastNCachedRoutes
   }
 }


### PR DESCRIPTION
The idea behind this change is that, for pairs that have fragmented and low liquidity, we could get the N last best routes, then run the algorithm for finding the best route using these routes as candidates

I'm also removing the `maxSplits` filter from the Wildcard pairs, I have the theory that with this new algorithm of fetching the routes of the last N block, then limiting by a number of MaxSplits is not necessary.
