### PR TITLE
Turn off Livemode cache to collect metrics

### DIFF
--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -5,7 +5,7 @@ import {
   ChainId,
   IRouteCachingProvider,
   log,
-  routeToString
+  routeToString,
 } from '@uniswap/smart-order-router'
 import { DynamoDB } from 'aws-sdk'
 import { Currency, CurrencyAmount, Token, TradeType } from '@uniswap/sdk-core'

--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -5,7 +5,7 @@ import {
   ChainId,
   IRouteCachingProvider,
   log,
-  routeToString,
+  routeToString
 } from '@uniswap/smart-order-router'
 import { DynamoDB } from 'aws-sdk'
 import { Currency, CurrencyAmount, Token, TradeType } from '@uniswap/sdk-core'
@@ -290,7 +290,10 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
         }/${tradeType}/${chainId}`
       )
 
-      return cachingParameters.cacheMode
+      // TODO(mcervera): Re-enable cache after collecting metrics
+      // return cachingParameters.cacheMode
+      // We will collect metrics on latency improvements for a few hours, so we will force every cache to be Tapcompare
+      return CacheMode.Tapcompare
     } else {
       log.info(
         {


### PR DESCRIPTION
This PR is forcing all Livemode caches to be Tapcompare. This will only be done for a few hours as a way to collect metrics on the latency improvements