### PR TITLE
Add Minimum stat to latency dashboard

### DIFF
--- a/lib/dashboards/cached-routes-widgets-factory.ts
+++ b/lib/dashboards/cached-routes-widgets-factory.ts
@@ -327,6 +327,10 @@ export class CachedRoutesWidgetsFactory implements WidgetsFactory {
               '...',
               { stat: 'Average', label: `${cacheStrategy.pair}/${cacheStrategy.tradeType.toUpperCase()} Average` },
             ],
+            [
+              '...',
+              { stat: 'Minimum', label: `${cacheStrategy.pair}/${cacheStrategy.tradeType.toUpperCase()} Minimum` },
+            ],
           ],
           region: this.region,
           title: `Latency of API for requested pair`,


### PR DESCRIPTION
The dashboard will now display a "Minimum" metric for the latency on quotes
