### PR TITLE
modify linter to use nvm

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,11 +15,9 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@v2
 
-      - name: Set up node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 16.x
-          registry-url: https://registry.npmjs.org
+      - name: Set the correct Node version using nvm
+        shell: bash -l {0} 
+        run: nvm install
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## What?
[routing-api](https://github.com/Uniswap/routing-api) contains nvm after the linter workflow. Linter is hardcoded to use node 16, but we want to make it consistent with the nvm managed version.

## Why?
We want to minimize the node version discrepancy across the [routing-api](https://github.com/Uniswap/routing-api) project.

## How?
Start with [routing-api](https://github.com/Uniswap/routing-api), instead of having the usual hard-coded node version(s) to be installed, we use nvm to install the node.

## Testing?
We will check whether the linter workflow passes. 

## Screenshots (optional)
N/A

## Anything Else?
At some point. we should check all the node projects to 1) patch with nvm, if missing 2) update the workflow(s) to use nvm instead.