### PR TITLE
Bump SOR to 3.11.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@uniswap/permit2-sdk": "^1.2.0",
         "@uniswap/router-sdk": "^1.3.0",
         "@uniswap/sdk-core": "^3.0.1",
-        "@uniswap/smart-order-router": "^3.11.4",
+        "@uniswap/smart-order-router": "^3.11.5",
         "@uniswap/token-lists": "^1.0.0-beta.24",
         "@uniswap/universal-router-sdk": "^1.3.0",
         "@uniswap/v2-sdk": "^3.0.0",
@@ -3074,9 +3074,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.11.4",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.11.4.tgz",
-      "integrity": "sha512-l/l+ZqMxYGHUsmLZ6fIQ78cnntqFO5cHCDMulZ5YmXczl+xS1tvvrp/0+olCwWpjqggBR7LrWy22Zzq8uSLu5g==",
+      "version": "3.11.5",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.11.5.tgz",
+      "integrity": "sha512-+BR6oNovhUDHQKvwEAIrqa5r/OftCpsS9saIAj5tfMxxlEYBXRbIDxTh7kQZpB8/weCs2LwAdrmhi5XmecafKw==",
       "dependencies": {
         "@uniswap/default-token-list": "^2.0.0",
         "@uniswap/permit2-sdk": "^1.2.0",
@@ -23407,9 +23407,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.11.4",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.11.4.tgz",
-      "integrity": "sha512-l/l+ZqMxYGHUsmLZ6fIQ78cnntqFO5cHCDMulZ5YmXczl+xS1tvvrp/0+olCwWpjqggBR7LrWy22Zzq8uSLu5g==",
+      "version": "3.11.5",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.11.5.tgz",
+      "integrity": "sha512-+BR6oNovhUDHQKvwEAIrqa5r/OftCpsS9saIAj5tfMxxlEYBXRbIDxTh7kQZpB8/weCs2LwAdrmhi5XmecafKw==",
       "requires": {
         "@uniswap/default-token-list": "^2.0.0",
         "@uniswap/permit2-sdk": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@uniswap/permit2-sdk": "^1.2.0",
     "@uniswap/router-sdk": "^1.3.0",
     "@uniswap/sdk-core": "^3.0.1",
-    "@uniswap/smart-order-router": "^3.11.4",
+    "@uniswap/smart-order-router": "^3.11.5",
     "@uniswap/token-lists": "^1.0.0-beta.24",
     "@uniswap/universal-router-sdk": "^1.3.0",
     "@uniswap/v2-sdk": "^3.0.0",


### PR DESCRIPTION
This version of SOR implements some changes with how we resolve tokens that were previously impossible to resolve (due to symbol returning bytes32 instead of string)
