### PR TITLE
[ROUTE-9] Reduce the v3 pool TTL to 1 minute

### DIFF
--- a/lib/handlers/pools/pool-caching/v3/dynamo-caching-pool-provider.ts
+++ b/lib/handlers/pools/pool-caching/v3/dynamo-caching-pool-provider.ts
@@ -10,7 +10,7 @@ export class DynamoDBCachingV3PoolProvider implements IV3PoolProvider {
   private readonly POOL_CACHE_KEY = (chainId: ChainId, address: string) => `pool-${chainId}-${address}`
 
   constructor(protected chainId: ChainId, protected poolProvider: IV3PoolProvider, tableName: string) {
-    this.dynamoCache = new DynamoCachingV3Pool({ tableName })
+    this.dynamoCache = new DynamoCachingV3Pool({ tableName, ttlMinutes: 1 })
   }
 
   public getPoolAddress(


### PR DESCRIPTION
We decided to reduce the TTL to 1 minute to begin with. The average block settlement time is between 10-15 seconds. We can adjust down as appropriate once we launch the distributed pools cache.