### PR TITLE
[ROUTE-9] add dynamo pool cache hit/miss metrics

### DIFF
--- a/lib/handlers/pools/pool-caching/v3/cache-dynamo-pool.ts
+++ b/lib/handlers/pools/pool-caching/v3/cache-dynamo-pool.ts
@@ -1,6 +1,6 @@
 import { DynamoCaching, DynamoCachingProps } from '../cache-dynamo'
 import { Pool } from '@uniswap/v3-sdk'
-import { log } from '@uniswap/smart-order-router'
+import { log, metric, MetricLoggerUnit } from '@uniswap/smart-order-router'
 import { PoolMarshaller } from '../../../marshalling/pool-marshaller'
 
 interface DynamoCachingV3PoolProps extends DynamoCachingProps {}
@@ -31,13 +31,16 @@ export class DynamoCachingV3Pool extends DynamoCaching<string, number, Pool> {
       )?.Item?.item
 
       if (cachedPoolBinary) {
+        metric.putMetric('V3_DYNAMO_CACHING_POOL_HIT_IN_TABLE', 1, MetricLoggerUnit.None)
         const cachedPoolBuffer: Buffer = Buffer.from(cachedPoolBinary)
         const marshalledPool = JSON.parse(cachedPoolBuffer.toString())
         return PoolMarshaller.unmarshal(marshalledPool)
       } else {
+        metric.putMetric('V3_DYNAMO_CACHING_POOL_MISS_NOT_IN_TABLE', 1, MetricLoggerUnit.None)
         return undefined
       }
     } else {
+      metric.putMetric('V3_DYNAMO_CACHING_POOL_MISS_NO_BLOCK_NUMBER', 1, MetricLoggerUnit.None)
       return undefined
     }
   }


### PR DESCRIPTION
## What?
Along with [PR](https://github.com/Uniswap/routing-api/pull/211), we also want to start checking the dynamo caching provider's cache hit/miss rate. If the dynamo caching accuracy is higher, but the hit rate is low, then it defeats the purpose of the dynamo caching. 
 
## Why?
I think [v3-quoter.ts](https://github.com/Uniswap/smart-order-router/blob/main/src/routers/alpha-router/quoters/v3-quoter.ts) doesn't pass block number and [mixed-quoter.ts](https://github.com/Uniswap/smart-order-router/blob/main/src/routers/alpha-router/quoters/mixed-quoter.ts) does. We most likely won't see a high hit rate, once we start shadow sampling the traffic.

## How?
Start exporting cache hit/miss metrics.

## Testing?
Rely on existing tests. Since dynamo caching pool is not wired, we won't see metrics getting exported until we merge [PR](https://github.com/Uniswap/routing-api/pull/211)

## Screenshots (optional)
