### PR TITLE
Update Response Validation for QuoteToRatio

### DIFF
--- a/lib/handlers/quote-to-ratio/schema/quote-to-ratio-schema.ts
+++ b/lib/handlers/quote-to-ratio/schema/quote-to-ratio-schema.ts
@@ -114,7 +114,7 @@ export const QuotetoRatioResponseSchemaJoi = QuoteResponseSchemaJoi.keys({
       chainId: Joi.number()
         .valid(...SUPPORTED_CHAINS.values())
         .required(),
-      symbol: Joi.string().alphanum().required(),
+      symbol: Joi.string().required(),
       decimals: Joi.number().required(),
     }),
     tokenOut: Joi.object({
@@ -122,7 +122,7 @@ export const QuotetoRatioResponseSchemaJoi = QuoteResponseSchemaJoi.keys({
       chainId: Joi.number()
         .valid(...SUPPORTED_CHAINS.values())
         .required(),
-      symbol: Joi.string().alphanum().required(),
+      symbol: Joi.string().required(),
       decimals: Joi.number().required(),
     }),
     sqrtRatioX96: Joi.string().alphanum().required(),


### PR DESCRIPTION
## Why this change?
Circle has issued a new USDC coin natively on Arbitrum which got renamed from USDC to USDC.e, this change triggered our validation in the quoteToRatio response endpoint (not used in production) for only allowing alphanumeric symbols.

This is an incorrect assumption, so I'm removing this validation in order to unblock the release queue
