### PR TITLE
[fix] [ROUTE-9] fix the lambda not grant access to v3 cached pool dynamo table

### DIFF
--- a/bin/stacks/routing-api-stack.ts
+++ b/bin/stacks/routing-api-stack.ts
@@ -102,7 +102,7 @@ export class RoutingAPIStack extends cdk.Stack {
         tenderlyProject,
         tenderlyAccessKey,
         cachedRoutesDynamoDb,
-        cachedV3PoolsDynamoDb
+        cachedV3PoolsDynamoDb,
       }
     )
 

--- a/bin/stacks/routing-api-stack.ts
+++ b/bin/stacks/routing-api-stack.ts
@@ -84,7 +84,7 @@ export class RoutingAPIStack extends cdk.Stack {
       hosted_zone,
     })
 
-    const { cachedRoutesDynamoDb } = new RoutingDatabaseStack(this, 'RoutingDatabaseStack', {})
+    const { cachedRoutesDynamoDb, cachedV3PoolsDynamoDb } = new RoutingDatabaseStack(this, 'RoutingDatabaseStack', {})
 
     const { routingLambda, routingLambdaAlias, routeToRatioLambda } = new RoutingLambdaStack(
       this,
@@ -102,6 +102,7 @@ export class RoutingAPIStack extends cdk.Stack {
         tenderlyProject,
         tenderlyAccessKey,
         cachedRoutesDynamoDb,
+        cachedV3PoolsDynamoDb
       }
     )
 


### PR DESCRIPTION
## What?
I was investigating why v3 cached pool dynamo table has 0% hit rate. Some were due to the missing block number getting passed down, but there's small portion of traffic due to entry not in the table. This means the block number actually got passed down. Looking further into the [logs](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:log-groups/log-group/$252Faws$252Flambda$252FRoutingAPIStack-RoutingLamb-RoutingLambda2C4DF0900-xxMl8mSwRJxq/log-events/2023$252F06$252F09$252F$255B20$255Db3f05ebce5f64d56a65c5f92a9beb161$3FfilterPattern$3DCached+pool+failed+to+insert),  I finally realized that all the dynamo insertion failed: 
 
<img width="1192" alt="Dynamo Insertion Failed log" src="https://github.com/Uniswap/routing-api/assets/91580504/b62ba765-4f15-4462-a74a-edf2ddc01394">

Then I wanted to double confirm by checking the routing lambda role IAM [policies](https://us-east-1.console.aws.amazon.com/iamv2/home?region=us-east-2#/roles/details/prod-us-east-2-RoutingAPI-RoutingLambdaRole270B091-13PXEH0APARC6?section=permissions), and indeed the V3PoolsCachingDB was not there:
<img width="1508" alt="Prod Routing Lambda Role" src="https://github.com/Uniswap/routing-api/assets/91580504/396ce606-4fe5-4839-933a-d612f5b7c9b1">

## Why?
Because without granting Lambda role the V3PoolsCachingDB read/write access, we won't be able to cache the v3 pools.

## How?
We do so by programmatically grant Lambda role to the V3PoolsCachingDB

## Testing?
- All unit tests and integ tests passed.
- cdk deploy via personal aws account succeeded. Can see the difference in IAM policy.

## Screenshots (optional)

<img width="1512" alt="Routing Lambda Role - Missing PoolCaching Dynamo" src="https://github.com/Uniswap/routing-api/assets/91580504/07d4eb86-ebe8-4845-88ec-f1a63d834dac">
<img width="1511" alt="Routing Lambda Role - Deployed PoolCaching Dynamo" src="https://github.com/Uniswap/routing-api/assets/91580504/18e57834-67b8-4092-9bcb-2853774cd04d">


## Anything Else?

- Since in PR [211](https://github.com/Uniswap/routing-api/pull/211) we have 0% traffic toward dynamo pool caching, there is zero impact in prod routing traffics. In addition, we have 1% shadow sampling into dynamo pool caching, so we can verify this change without impacting prod success rate.

- By re-running integ-test, we see there is zero cache miss due to not in the table. This is indicative of successful dynamo look write & read:
<img width="1511" alt="Dynamo Pool Caching Hit:Miss" src="https://github.com/Uniswap/routing-api/assets/91580504/db07b7b1-fb74-4d06-be90-d587975fe330">

