### PR TITLE
[fix] fix ETH<->ETH swap test setup

### DIFF
--- a/test/integ/quote.test.ts
+++ b/test/integ/quote.test.ts
@@ -557,7 +557,7 @@ describe('quote', function () {
               amount:
                 type == 'exactIn'
                   ? await getAmount(1, type, 'ETH', 'UNI', '10')
-                  : await getAmount(1, type, 'ETH', 'UNI', '10000'),
+                  : await getAmount(1, type, 'ETH', 'UNI', '1000'),
               type,
               recipient: alice.address,
               slippageTolerance: SLIPPAGE,
@@ -585,7 +585,7 @@ describe('quote', function () {
               expect(tokenInBefore.subtract(tokenInAfter).greaterThan(parseAmount('10', Ether.onChain(1)))).to.be.true
               checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(UNI_MAINNET, data.quote))
             } else {
-              expect(tokenOutAfter.subtract(tokenOutBefore).toExact()).to.equal('10000')
+              expect(tokenOutAfter.subtract(tokenOutBefore).toExact()).to.equal('1000')
               // Can't easily check slippage for ETH due to gas costs effecting ETH balance.
             }
           })
@@ -599,7 +599,7 @@ describe('quote', function () {
               amount:
                 type == 'exactIn'
                   ? await getAmount(1, type, 'ETH', 'UNI', '10')
-                  : await getAmount(1, type, 'ETH', 'UNI', '10000'),
+                  : await getAmount(1, type, 'ETH', 'UNI', '1000'),
               type,
               recipient: alice.address,
               slippageTolerance: SLIPPAGE,
@@ -628,7 +628,7 @@ describe('quote', function () {
               expect(tokenInBefore.subtract(tokenInAfter).greaterThan(parseAmount('10', Ether.onChain(1)))).to.be.true
               checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(UNI_MAINNET, data.quote))
             } else {
-              expect(tokenOutAfter.subtract(tokenOutBefore).toExact()).to.equal('10000')
+              expect(tokenOutAfter.subtract(tokenOutBefore).toExact()).to.equal('1000')
               // Can't easily check slippage for ETH due to gas costs effecting ETH balance.
             }
           })

--- a/test/integ/quote.test.ts
+++ b/test/integ/quote.test.ts
@@ -52,7 +52,7 @@ if (!process.env.UNISWAP_ROUTING_API || !process.env.ARCHIVE_NODE_RPC) {
 
 const API = `${process.env.UNISWAP_ROUTING_API!}quote`
 
-const SLIPPAGE = '5'
+const SLIPPAGE = '30'
 
 const axios = axiosStatic.create()
 axiosRetry(axios, {
@@ -599,7 +599,7 @@ describe('quote', function () {
               amount:
                 type == 'exactIn'
                   ? await getAmount(1, type, 'ETH', 'UNI', '10')
-                  : await getAmount(1, type, 'ETH', 'UNI', '1000'),
+                  : await getAmount(1, type, 'ETH', 'UNI', '10000'),
               type,
               recipient: alice.address,
               slippageTolerance: SLIPPAGE,
@@ -628,7 +628,7 @@ describe('quote', function () {
               expect(tokenInBefore.subtract(tokenInAfter).greaterThan(parseAmount('10', Ether.onChain(1)))).to.be.true
               checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(UNI_MAINNET, data.quote))
             } else {
-              expect(tokenOutAfter.subtract(tokenOutBefore).toExact()).to.equal('1000')
+              expect(tokenOutAfter.subtract(tokenOutBefore).toExact()).to.equal('10000')
               // Can't easily check slippage for ETH due to gas costs effecting ETH balance.
             }
           })

--- a/test/integ/quote.test.ts
+++ b/test/integ/quote.test.ts
@@ -557,7 +557,7 @@ describe('quote', function () {
               amount:
                 type == 'exactIn'
                   ? await getAmount(1, type, 'ETH', 'UNI', '10')
-                  : await getAmount(1, type, 'ETH', 'UNI', '1000'),
+                  : await getAmount(1, type, 'ETH', 'UNI', '10000'),
               type,
               recipient: alice.address,
               slippageTolerance: SLIPPAGE,
@@ -585,7 +585,7 @@ describe('quote', function () {
               expect(tokenInBefore.subtract(tokenInAfter).greaterThan(parseAmount('10', Ether.onChain(1)))).to.be.true
               checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(UNI_MAINNET, data.quote))
             } else {
-              expect(tokenOutAfter.subtract(tokenOutBefore).toExact()).to.equal('1000')
+              expect(tokenOutAfter.subtract(tokenOutBefore).toExact()).to.equal('10000')
               // Can't easily check slippage for ETH due to gas costs effecting ETH balance.
             }
           })


### PR DESCRIPTION
## What?
We were getting ETH<->UNI swap test failures:
```
     Error: cannot estimate gas; transaction may fail or may require manual gas limit [ See: https://links.ethers.org/v5-errors-UNPREDICTABLE_GAS_LIMIT ] (reason="VM Exception while processing transaction: reverted with an unrecognized custom error", method="estimateGas", transaction={"from":"0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266","gasPrice":{"type":"BigNumber","hex":"0x01d1a94a2000"},"to":"0xEf1c6E67703c7BD7107eed8303Fbe6EC2554BF6B","value":{"type":"BigNumber","hex":"0x0162dddd86586f7bad"},"data":"0x3593564c000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000648764ca00000000000000000000000000000000000000000000000000000000000000050b0101010c000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000500000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000220000000000000000000000000000000000000000000000000000000000000036000000000000000000000000000000000000000000000000000000000000004a00000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000162dddd86586f7bad0000000000000000000000000000000000000000000000000000000000000100000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb922660000000000000000000000000000000000000000000001e7e4171bf4d3a000000000000000000000000000000000000000000000000000013f58ce3a2f3f239a00000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002b1f9840a85d5af5bf1d1762f925bdaddc4201f984000bb8c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000120000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb9226600000000000000000000000000000000000000000000001b1ae4d6e2ef50000000000000000000000000000000000000000000000000000011c82c21b111def100000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000421f9840a85d5af5bf1d1762f925bdaddc4201f984000bb82260fac5e5542a773aa44fbcfedf7c193bc2c5990001f4c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000120000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb9226600000000000000000000000000000000000000000000001b1ae4d6e2ef50000000000000000000000000000000000000000000000000000011bce32a781e792100000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000421f9840a85d5af5bf1d1762f925bdaddc4201f984000bb8dac17f958d2ee523a2206206994597c13d831ec7000bb8c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb922660000000000000000000000000000000000000000000000000000000000000000","type":1,"accessList":null}, error={"stackTrace":[{"type":2,"address":{"type":"Buffer","data":[239,28,110,103,112,60,123,215,16,126,237,131,3,251,230,236,37,84,191,107]}},{"type":2,"address":{"type":"Buffer","data":[143,12,179,124,223,243,126,0,78,0,136,245,99,229,254,57,224,92,204,91]}},{"type":2,"address":{"type":"Buffer","data":[239,28,110,103,112,60,123,215,16,126,237,131,3,251,230,236,37,84,191,107]}},{"type":2,"address":{"type":"Buffer","data":[69,133,254,119,34,91,65,182,151,201,56,176,24,226,172,103,172,90,32,192]}},{"type":18,"address":{"type":"Buffer","data":[239,28,110,103,112,60,123,215,16,126,237,131,3,251,230,236,37,84,191,107]},"message":{"value":{"type":"Buffer","data":[115,157,190,82]},"_selector":"739dbe52"},"isInvalidOpcodeError":false}],"data":"0x739dbe52"}, code=UNPREDICTABLE_GAS_LIMIT, version=providers/5.7.2)
``` 

## Why?
Possibly due to the market condition change. If we deserialize the data from the payload, we will see TooMuchRequested error, indicative of slippage. 

## How?
We increase the slippage to up the swap success chance.

## Testing?
- All unit tests and integ tests passed.

## Screenshots (optional)

## Anything Else?
It's kinda weird to see a 60k trade failed, indicative of insufficient liquidity in the pool. If we have extra time, we may look into why insufficient liquidity.