### PR TITLE
bump sor to 3.12.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@uniswap/permit2-sdk": "^1.2.0",
         "@uniswap/router-sdk": "^1.3.0",
         "@uniswap/sdk-core": "^3.0.1",
-        "@uniswap/smart-order-router": "3.12.5",
+        "@uniswap/smart-order-router": "3.12.6",
         "@uniswap/token-lists": "^1.0.0-beta.24",
         "@uniswap/universal-router-sdk": "^1.3.0",
         "@uniswap/v2-sdk": "^3.0.0",
@@ -3074,9 +3074,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.12.5",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.12.5.tgz",
-      "integrity": "sha512-80agp3clBpRBso0EpllsVN9OMRWtcMkym3e1E8bbNR1Vcqa1s19QERwZp121g2fc7YkxaIjCeWz2YXmZaHsQvw==",
+      "version": "3.12.6",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.12.6.tgz",
+      "integrity": "sha512-HDmEZUY3cnEGj6A+PRYq2aUQoTXgvYSWJ+RMTHgYTNBxw0NdFambtSLyPBQGGo3yzLMANQmUQ1XFxznOS6jTBQ==",
       "dependencies": {
         "@uniswap/default-token-list": "^2.0.0",
         "@uniswap/permit2-sdk": "^1.2.0",
@@ -23407,9 +23407,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.12.5",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.12.5.tgz",
-      "integrity": "sha512-80agp3clBpRBso0EpllsVN9OMRWtcMkym3e1E8bbNR1Vcqa1s19QERwZp121g2fc7YkxaIjCeWz2YXmZaHsQvw==",
+      "version": "3.12.6",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.12.6.tgz",
+      "integrity": "sha512-HDmEZUY3cnEGj6A+PRYq2aUQoTXgvYSWJ+RMTHgYTNBxw0NdFambtSLyPBQGGo3yzLMANQmUQ1XFxznOS6jTBQ==",
       "requires": {
         "@uniswap/default-token-list": "^2.0.0",
         "@uniswap/permit2-sdk": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@uniswap/permit2-sdk": "^1.2.0",
     "@uniswap/router-sdk": "^1.3.0",
     "@uniswap/sdk-core": "^3.0.1",
-    "@uniswap/smart-order-router": "3.12.5",
+    "@uniswap/smart-order-router": "3.12.6",
     "@uniswap/token-lists": "^1.0.0-beta.24",
     "@uniswap/universal-router-sdk": "^1.3.0",
     "@uniswap/v2-sdk": "^3.0.0",


### PR DESCRIPTION
## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Current 3.12.5

- 3.12.6: https://github.com/Uniswap/smart-order-router/pull/253

New 3.12.6