### PR TITLE
[ROUTE-9] add v3 liquidity accuracy metrics

### DIFF
--- a/lib/handlers/pools/provider-migration/v3/traffic-switch-v3-pool-provider.ts
+++ b/lib/handlers/pools/provider-migration/v3/traffic-switch-v3-pool-provider.ts
@@ -127,14 +127,14 @@ export class TrafficSwitchV3PoolProvider implements IV3PoolProvider {
 
         if (!sameQuote) {
           log.info(`v3 Pool ${pool.token0.symbol} ${pool.token1.symbol} ${pool.fee} quote mismatch: 
-            current ${targetProviderPool.sqrtRatioX96} vs truth ${pool.sqrtRatioX96}.`)
+            target ${targetProviderPool.sqrtRatioX96} vs truth ${pool.sqrtRatioX96}.`)
 
           metric.putMetric('V3_POOL_PROVIDER_POOL_TARGET_QUOTE_MISMATCH', 1, MetricLoggerUnit.None)
         }
 
         if (!sameLiquidity) {
           log.info(`v3 Pool ${pool.token0.symbol} ${pool.token1.symbol} ${pool.fee} liquidity mismatch: 
-            current ${targetProviderPool.liquidity} vs truth ${pool.liquidity}.`)
+            target ${targetProviderPool.liquidity} vs truth ${pool.liquidity}.`)
 
           metric.putMetric('V3_POOL_PROVIDER_POOL_TARGET_LIQUIDITY_MISMATCH', 1, MetricLoggerUnit.None)
         }

--- a/lib/handlers/pools/provider-migration/v3/traffic-switch-v3-pool-provider.ts
+++ b/lib/handlers/pools/provider-migration/v3/traffic-switch-v3-pool-provider.ts
@@ -89,10 +89,24 @@ export class TrafficSwitchV3PoolProvider implements IV3PoolProvider {
         )
       } else {
         const sameQuote = JSBI.equal(currentProviderPool.sqrtRatioX96, pool.sqrtRatioX96)
+        const sameLiquidity = JSBI.equal(currentProviderPool.liquidity, pool.liquidity)
+        const accurate = sameQuote && sameLiquidity
 
         if (!sameQuote) {
           log.info(`v3 Pool ${pool.token0.symbol} ${pool.token1.symbol} ${pool.fee} quote mismatch: 
             current ${currentProviderPool.sqrtRatioX96} vs truth ${pool.sqrtRatioX96}.`)
+
+          metric.putMetric('V3_POOL_PROVIDER_POOL_CURRENT_QUOTE_MISMATCH', 1, MetricLoggerUnit.None)
+        }
+
+        if (!sameLiquidity) {
+          log.info(`v3 Pool ${pool.token0.symbol} ${pool.token1.symbol} ${pool.fee} liquidity mismatch: 
+            current ${currentProviderPool.liquidity} vs truth ${pool.liquidity}.`)
+
+          metric.putMetric('V3_POOL_PROVIDER_POOL_CURRENT_LIQUIDITY_MISMATCH', 1, MetricLoggerUnit.None)
+        }
+
+        if (!accurate) {
           metric.putMetric('V3_POOL_PROVIDER_POOL_CURRENT_ACCURACY_MISMATCH', 1, MetricLoggerUnit.None)
         } else {
           metric.putMetric('V3_POOL_PROVIDER_POOL_CURRENT_ACCURACY_MATCH', 1, MetricLoggerUnit.None)
@@ -108,10 +122,24 @@ export class TrafficSwitchV3PoolProvider implements IV3PoolProvider {
         )
       } else {
         const sameQuote = JSBI.equal(targetProviderPool.sqrtRatioX96, pool.sqrtRatioX96)
+        const sameLiquidity = JSBI.equal(targetProviderPool.liquidity, pool.liquidity)
+        const accurate = sameQuote && sameLiquidity
 
         if (!sameQuote) {
           log.info(`v3 Pool ${pool.token0.symbol} ${pool.token1.symbol} ${pool.fee} quote mismatch: 
-            target ${targetProviderPool.sqrtRatioX96} vs truth ${pool.sqrtRatioX96}.`)
+            current ${targetProviderPool.sqrtRatioX96} vs truth ${pool.sqrtRatioX96}.`)
+
+          metric.putMetric('V3_POOL_PROVIDER_POOL_TARGET_QUOTE_MISMATCH', 1, MetricLoggerUnit.None)
+        }
+
+        if (!sameLiquidity) {
+          log.info(`v3 Pool ${pool.token0.symbol} ${pool.token1.symbol} ${pool.fee} liquidity mismatch: 
+            current ${targetProviderPool.liquidity} vs truth ${pool.liquidity}.`)
+
+          metric.putMetric('V3_POOL_PROVIDER_POOL_TARGET_LIQUIDITY_MISMATCH', 1, MetricLoggerUnit.None)
+        }
+
+        if (!accurate) {
           metric.putMetric('V3_POOL_PROVIDER_POOL_TARGET_ACCURACY_MISMATCH', 1, MetricLoggerUnit.None)
         } else {
           metric.putMetric('V3_POOL_PROVIDER_POOL_TARGET_ACCURACY_MATCH', 1, MetricLoggerUnit.None)

--- a/test/unit/handlers/pools/provider-migration/traffic-switch-pool-provider.test.ts
+++ b/test/unit/handlers/pools/provider-migration/traffic-switch-pool-provider.test.ts
@@ -104,7 +104,7 @@ describe('TrafficSwitchV3PoolProvider', async () => {
   })
 
   it('not switch traffic and sample pools with inaccurate pricing but accurate liquidity', async () => {
-    const USDC_DAI_LOW_INACCURATE = new Pool(USDC, DAI, FeeAmount.LOW, encodeSqrtRatioX96(2, 2), 9, 0)
+    const USDC_DAI_LOW_INACCURATE = new Pool(USDC, DAI, FeeAmount.LOW, encodeSqrtRatioX96(2, 2), 10, 0)
 
     spy.withArgs('V3_POOL_PROVIDER_POOL_CURRENT_QUOTE_MISMATCH', 1, MetricLoggerUnit.None)
     spy.withArgs('V3_POOL_PROVIDER_POOL_CURRENT_LIQUIDITY_MATCH', 1, MetricLoggerUnit.None)

--- a/test/unit/handlers/pools/provider-migration/traffic-switch-pool-provider.test.ts
+++ b/test/unit/handlers/pools/provider-migration/traffic-switch-pool-provider.test.ts
@@ -27,8 +27,11 @@ describe('TrafficSwitchV3PoolProvider', async () => {
   const spy = sinon.spy(metric, 'putMetric')
 
   it('switch traffic and sample pools with accurate pricing and liquidity', async () => {
+    spy.withArgs('V3_POOL_PROVIDER_POOL_CURRENT_QUOTE_MATCH', 1, MetricLoggerUnit.None)
+    spy.withArgs('V3_POOL_PROVIDER_POOL_CURRENT_LIQUIDITY_MATCH', 1, MetricLoggerUnit.None)
     spy.withArgs('V3_POOL_PROVIDER_POOL_CURRENT_ACCURACY_MATCH', 1, MetricLoggerUnit.None)
-    spy.withArgs('V3_POOL_PROVIDER_POOL_CURRENT_ACCURACY_MATCH', 1, MetricLoggerUnit.None)
+    spy.withArgs('V3_POOL_PROVIDER_POOL_TARGET_QUOTE_MATCH', 1, MetricLoggerUnit.None)
+    spy.withArgs('V3_POOL_PROVIDER_POOL_TARGET_LIQUIDITY_MATCH', 1, MetricLoggerUnit.None)
     spy.withArgs('V3_POOL_PROVIDER_POOL_TARGET_ACCURACY_MATCH', 1, MetricLoggerUnit.None)
     spy.withArgs('V3_POOL_PROVIDER_POOL_TRAFFIC_SAMPLING', 1, MetricLoggerUnit.None)
     spy.withArgs('V3_POOL_PROVIDER_POOL_TRAFFIC_TOTAL', 1, MetricLoggerUnit.None)

--- a/test/unit/handlers/pools/provider-migration/traffic-switch-pool-provider.test.ts
+++ b/test/unit/handlers/pools/provider-migration/traffic-switch-pool-provider.test.ts
@@ -26,7 +26,8 @@ describe('TrafficSwitchV3PoolProvider', async () => {
   setupTables(TEST_ROUTE_TABLE)
   const spy = sinon.spy(metric, 'putMetric')
 
-  it('switch traffic and sample pools with accurate pricing', async () => {
+  it('switch traffic and sample pools with accurate pricing and liquidity', async () => {
+    spy.withArgs('V3_POOL_PROVIDER_POOL_CURRENT_ACCURACY_MATCH', 1, MetricLoggerUnit.None)
     spy.withArgs('V3_POOL_PROVIDER_POOL_CURRENT_ACCURACY_MATCH', 1, MetricLoggerUnit.None)
     spy.withArgs('V3_POOL_PROVIDER_POOL_TARGET_ACCURACY_MATCH', 1, MetricLoggerUnit.None)
     spy.withArgs('V3_POOL_PROVIDER_POOL_TRAFFIC_SAMPLING', 1, MetricLoggerUnit.None)
@@ -57,10 +58,56 @@ describe('TrafficSwitchV3PoolProvider', async () => {
     sinon.assert.called(spy)
   })
 
-  it('not switch traffic and sample pools with inaccurate pricing', async () => {
-    const USDC_DAI_LOW_INACCURATE = new Pool(USDC, DAI, FeeAmount.LOW, encodeSqrtRatioX96(2, 2), 10, 0)
+  it('not switch traffic and sample pools with inaccurate pricing and inaccurate liquidity', async () => {
+    const USDC_DAI_LOW_INACCURATE = new Pool(USDC, DAI, FeeAmount.LOW, encodeSqrtRatioX96(2, 2), 9, 0)
 
+    spy.withArgs('V3_POOL_PROVIDER_POOL_CURRENT_QUOTE_MISMATCH', 1, MetricLoggerUnit.None)
+    spy.withArgs('V3_POOL_PROVIDER_POOL_CURRENT_LIQUIDITY_MISMATCH', 1, MetricLoggerUnit.None)
     spy.withArgs('V3_POOL_PROVIDER_POOL_CURRENT_ACCURACY_MISMATCH', 1, MetricLoggerUnit.None)
+    spy.withArgs('V3_POOL_PROVIDER_POOL_TARGET_QUOTE_MISMATCH', 1, MetricLoggerUnit.None)
+    spy.withArgs('V3_POOL_PROVIDER_POOL_TARGET_LIQUIDITY_MISMATCH', 1, MetricLoggerUnit.None)
+    spy.withArgs('V3_POOL_PROVIDER_POOL_TARGET_ACCURACY_MISMATCH', 1, MetricLoggerUnit.None)
+    spy.withArgs('V3_POOL_PROVIDER_POOL_TRAFFIC_TOTAL', 1, MetricLoggerUnit.None)
+
+    const underlyingPool = getMockedV3PoolProvider([
+      USDC_DAI_LOW_INACCURATE,
+      USDC_DAI_MEDIUM,
+      USDC_WETH_LOW,
+      WETH9_USDT_LOW,
+      DAI_USDT_LOW,
+    ])
+    const inMemoryPoolCache = new CachingV3PoolProvider(
+      ChainId.GÖRLI,
+      underlyingPool,
+      new NodeJSCache(new NodeCache({ stdTTL: 15, useClones: false }))
+    )
+    const dynamoPoolCache = new DynamoDBCachingV3PoolProvider(ChainId.GÖRLI, underlyingPool, TEST_ROUTE_TABLE.TableName)
+    const trafficSwitchProvider = new (class SwitchTrafficSwitchV3PoolProvider extends TrafficSwitchV3PoolProvider {
+      override readonly SHOULD_SWITCH_TRAFFIC = () => false
+      override readonly SHOULD_SAMPLE_TRAFFIC = () => true
+    })({
+      currentPoolProvider: inMemoryPoolCache,
+      targetPoolProvider: dynamoPoolCache,
+      sourceOfTruthPoolProvider: underlyingPool,
+    })
+
+    const tokenPairs: [Token, Token, FeeAmount][] = SUPPORTED_POOLS.map((pool: Pool) => {
+      return [pool.token0, pool.token1, pool.fee]
+    })
+    const providerConfig: ProviderConfig = { blockNumber: 111 }
+    await trafficSwitchProvider.getPools(tokenPairs, providerConfig)
+
+    sinon.assert.called(spy)
+  })
+
+  it('not switch traffic and sample pools with inaccurate pricing but accurate liquidity', async () => {
+    const USDC_DAI_LOW_INACCURATE = new Pool(USDC, DAI, FeeAmount.LOW, encodeSqrtRatioX96(2, 2), 9, 0)
+
+    spy.withArgs('V3_POOL_PROVIDER_POOL_CURRENT_QUOTE_MISMATCH', 1, MetricLoggerUnit.None)
+    spy.withArgs('V3_POOL_PROVIDER_POOL_CURRENT_LIQUIDITY_MATCH', 1, MetricLoggerUnit.None)
+    spy.withArgs('V3_POOL_PROVIDER_POOL_CURRENT_ACCURACY_MISMATCH', 1, MetricLoggerUnit.None)
+    spy.withArgs('V3_POOL_PROVIDER_POOL_TARGET_QUOTE_MISMATCH', 1, MetricLoggerUnit.None)
+    spy.withArgs('V3_POOL_PROVIDER_POOL_TARGET_LIQUIDITY_MATCH', 1, MetricLoggerUnit.None)
     spy.withArgs('V3_POOL_PROVIDER_POOL_TARGET_ACCURACY_MISMATCH', 1, MetricLoggerUnit.None)
     spy.withArgs('V3_POOL_PROVIDER_POOL_TRAFFIC_TOTAL', 1, MetricLoggerUnit.None)
 


### PR DESCRIPTION
## What?
From the dynamo caching optimization change https://github.com/Uniswap/smart-order-router/pull/253/files, we realized that the liquidity part of the pool was used in that path, not quote. We want to export liquidity accuracy metrics.

## Why?
Because TVL heuristics path is on the critical gas build model codepath as part of every route request.

## How?
We start exporting quote mismatch & liquidity mismatch metrics. We keep the high level match/mismatch metrics so we don't need to change the [dashboard](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#dashboards/dashboard/Temp).

## Testing?
Modified unit test to ensure the additional metrics getting exported.

## Screenshots (optional)
Deployed to cdk via personal AWS account to verify new metrics:
<img width="1438" alt="Screenshot 2023-06-13 at 3 58 57 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/13d2079b-70c5-4bd8-a5aa-aa5c44a4e198">


## Anything Else?
N/A