### PR TITLE
[fix] [ROUTE-9] fix the TTL not passed down

### DIFF
--- a/lib/handlers/pools/pool-caching/v3/cache-dynamo-pool.ts
+++ b/lib/handlers/pools/pool-caching/v3/cache-dynamo-pool.ts
@@ -6,8 +6,8 @@ import { PoolMarshaller } from '../../../marshalling/pool-marshaller'
 interface DynamoCachingV3PoolProps extends DynamoCachingProps {}
 
 export class DynamoCachingV3Pool extends DynamoCaching<string, number, Pool> {
-  constructor({ tableName }: DynamoCachingV3PoolProps) {
-    super({ tableName })
+  constructor({ tableName, ttlMinutes }: DynamoCachingV3PoolProps) {
+    super({ tableName, ttlMinutes })
   }
 
   override async get(partitionKey: string, sortKey?: number): Promise<Pool | undefined> {


### PR DESCRIPTION
## What?
The TTL was not passed down for the `DynamoCachingV3Pool` class, so it defaults to 2 min as in the base class.

## Why?
We are fixing the TTL to 1 min, and since we have the dynamo caching hit/miss rate monitoring. If there's no drop in the hit rate, this change only brings positive effect.

## How?
By passing down the TTL within `DynamoCachingV3Pool` class.

## Testing?
Testing is a bit difficult, since TTL is set as a epoch time, and we can't assert the epoch time from test, since the 1 min from now might be slightly different in the test than in the application.

## Screenshots (optional)
N/A

## Anything Else?
N/A