### PR TITLE
bump sor to 3.13.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@uniswap/permit2-sdk": "^1.2.0",
         "@uniswap/router-sdk": "^1.3.0",
         "@uniswap/sdk-core": "^3.0.1",
-        "@uniswap/smart-order-router": "3.13.0",
+        "@uniswap/smart-order-router": "3.13.1",
         "@uniswap/token-lists": "^1.0.0-beta.24",
         "@uniswap/universal-router-sdk": "^1.3.0",
         "@uniswap/v2-sdk": "^3.0.0",
@@ -3074,9 +3074,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.13.0.tgz",
-      "integrity": "sha512-eUzbF4fxAA5JrBr0PudsROCb8XhVA1TwCgNKcXxEICFO2dcPJM22cK1PylvESeB4u3yUrCfP/mnmSjvwGUdHWw==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.13.1.tgz",
+      "integrity": "sha512-caji6e20doLXeleKB6Saidof0cJci/JqRbzMmkAMhlvlj6J7jCMbXdDxdOSCIbgIlcWfW18Nmvbm6xgq88tUYg==",
       "dependencies": {
         "@uniswap/default-token-list": "^2.0.0",
         "@uniswap/permit2-sdk": "^1.2.0",
@@ -23407,9 +23407,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.13.0.tgz",
-      "integrity": "sha512-eUzbF4fxAA5JrBr0PudsROCb8XhVA1TwCgNKcXxEICFO2dcPJM22cK1PylvESeB4u3yUrCfP/mnmSjvwGUdHWw==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.13.1.tgz",
+      "integrity": "sha512-caji6e20doLXeleKB6Saidof0cJci/JqRbzMmkAMhlvlj6J7jCMbXdDxdOSCIbgIlcWfW18Nmvbm6xgq88tUYg==",
       "requires": {
         "@uniswap/default-token-list": "^2.0.0",
         "@uniswap/permit2-sdk": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@uniswap/permit2-sdk": "^1.2.0",
     "@uniswap/router-sdk": "^1.3.0",
     "@uniswap/sdk-core": "^3.0.1",
-    "@uniswap/smart-order-router": "3.13.0",
+    "@uniswap/smart-order-router": "3.13.1",
     "@uniswap/token-lists": "^1.0.0-beta.24",
     "@uniswap/universal-router-sdk": "^1.3.0",
     "@uniswap/v2-sdk": "^3.0.0",


### PR DESCRIPTION
Current 3.13.0

3.13.1: https://github.com/Uniswap/smart-order-router/pull/262

New 3.13.1 