### PR TITLE
Update CachePool params

### DIFF
--- a/bin/stacks/routing-caching-stack.ts
+++ b/bin/stacks/routing-caching-stack.ts
@@ -85,7 +85,7 @@ export class RoutingCachingStack extends cdk.NestedStack {
 
     // Spin up a new pool cache lambda for each config in chain X protocol
     for (let i = 0; i < chainProtocols.length; i++) {
-      const { protocol, chainId, timeout } = chainProtocols[i]
+      const { protocol, chainId, timeout, lambdaTimeoutInSeconds } = chainProtocols[i]
       const lambda = new aws_lambda_nodejs.NodejsFunction(
         this,
         `PoolCacheLambda-ChainId${chainId}-Protocol${protocol}`,
@@ -94,7 +94,7 @@ export class RoutingCachingStack extends cdk.NestedStack {
           runtime: aws_lambda.Runtime.NODEJS_14_X,
           entry: path.join(__dirname, '../../lib/cron/cache-pools.ts'),
           handler: 'handler',
-          timeout: Duration.seconds(900),
+          timeout: Duration.seconds(lambdaTimeoutInSeconds),
           memorySize: 1024,
           bundling: {
             minify: true,
@@ -114,7 +114,7 @@ export class RoutingCachingStack extends cdk.NestedStack {
         }
       )
       new aws_events.Rule(this, `SchedulePoolCache-ChainId${chainId}-Protocol${protocol}`, {
-        schedule: aws_events.Schedule.rate(Duration.minutes(15)),
+        schedule: aws_events.Schedule.rate(Duration.seconds(lambdaTimeoutInSeconds)),
         targets: [new aws_events_targets.LambdaFunction(lambda)],
       })
       this.poolCacheBucket2.grantReadWrite(lambda)

--- a/lib/cron/cache-config.ts
+++ b/lib/cron/cache-config.ts
@@ -7,30 +7,35 @@ export const chainProtocols = [
     protocol: Protocol.V3,
     chainId: ChainId.MAINNET,
     timeout: 90000,
+    lambdaTimeoutInSeconds: 900,
     provider: new V3SubgraphProvider(ChainId.MAINNET, 3, 90000),
   },
   {
     protocol: Protocol.V3,
     chainId: ChainId.ARBITRUM_ONE,
     timeout: 90000,
+    lambdaTimeoutInSeconds: 900,
     provider: new V3SubgraphProvider(ChainId.ARBITRUM_ONE, 3, 90000),
   },
   {
     protocol: Protocol.V3,
     chainId: ChainId.POLYGON,
     timeout: 90000,
+    lambdaTimeoutInSeconds: 900,
     provider: new V3SubgraphProvider(ChainId.POLYGON, 3, 90000),
   },
   {
     protocol: Protocol.V3,
     chainId: ChainId.CELO,
     timeout: 90000,
+    lambdaTimeoutInSeconds: 900,
     provider: new V3SubgraphProvider(ChainId.CELO, 3, 90000),
   },
   {
     protocol: Protocol.V3,
     chainId: ChainId.BSC,
     timeout: 90000,
+    lambdaTimeoutInSeconds: 900,
     provider: new V3SubgraphProvider(ChainId.BSC, 3, 90000),
   },
   // Currently there is no working V3 subgraph for Optimism so we use a static provider.
@@ -39,7 +44,8 @@ export const chainProtocols = [
   {
     protocol: Protocol.V2,
     chainId: ChainId.MAINNET,
-    timeout: 840000,
-    provider: new V2SubgraphProvider(ChainId.MAINNET, 3, 900000, true, 250),
+    timeout: 1760000,
+    lambdaTimeoutInSeconds: 1800,
+    provider: new V2SubgraphProvider(ChainId.MAINNET, 3, 1800000, true, 500),
   },
 ]


### PR DESCRIPTION
The CachePool lambda is not able to complete the cache of V2 in time.
In this branch I'm doing the following changes:
1. Double the page size of the V2 subgraph query from 250 to 500
2. Double the timeout from 15 minutes to 30 minutes

The total number of v2 pools is 202k (https://dune.com/queries/2657172?category=decoded_project&namespace=uniswap_v2&contract=Factory&blockchains=ethereum), and the lambda stops when it gets to ~50k, so in theory these changes should get us to the finish line.
