### PR TITLE
Increase PAgeSize for the V2SubgraphProvider

### DIFF
--- a/lib/cron/cache-config.ts
+++ b/lib/cron/cache-config.ts
@@ -47,11 +47,6 @@ export const chainProtocols = [
     protocol: Protocol.V2,
     chainId: ChainId.MAINNET,
     timeout: 840000,
-    provider: new V2SubgraphProvider(
-      ChainId.MAINNET,
-      3,
-      900000,
-      true,
-      1000), // 1000 is the largest page size supported by thegraph
+    provider: new V2SubgraphProvider(ChainId.MAINNET, 3, 900000, true, 1000), // 1000 is the largest page size supported by thegraph
   },
 ]

--- a/lib/cron/cache-config.ts
+++ b/lib/cron/cache-config.ts
@@ -47,6 +47,11 @@ export const chainProtocols = [
     protocol: Protocol.V2,
     chainId: ChainId.MAINNET,
     timeout: 840000,
-    provider: new V2SubgraphProvider(ChainId.MAINNET, 3, 900000, true, 500),
+    provider: new V2SubgraphProvider(
+      ChainId.MAINNET,
+      3,
+      900000,
+      true,
+      1000), // 1000 is the largest page size supported by thegraph
   },
 ]


### PR DESCRIPTION
Currently the V2SubgraphProvidcer used for the CachePoolLambda is using page size of 500, but the lambda is still timing out.

Increasing to 1000, which will max out all the potential optimizations we can do on this system.