### PR TITLE
[fix] [ROUTE-30] Fix RPC Provider QuickNode Metrics

### DIFF
--- a/lib/handlers/evm/provider/ProviderName.ts
+++ b/lib/handlers/evm/provider/ProviderName.ts
@@ -1,6 +1,6 @@
 export enum ProviderName {
   INFURA = 'INFURA',
-  QUIKNODE = 'QUIKNODE', // quicknode RPC doesn't have letter c
+  QUIKNODE = 'QUIKNODE', // quicknode doesn't have letter c in the RPC endpoint
   FORNO = 'FORNO',
   UNKNOWN = 'UNKNOWN',
 }

--- a/lib/handlers/evm/provider/ProviderName.ts
+++ b/lib/handlers/evm/provider/ProviderName.ts
@@ -1,6 +1,6 @@
 export enum ProviderName {
   INFURA = 'INFURA',
-  QUICKNODE = 'QUICKNODE',
+  QUIKNODE = 'QUIKNODE', // quicknode RPC doesn't have letter c
   FORNO = 'FORNO',
   UNKNOWN = 'UNKNOWN',
 }

--- a/test/mocha/dynamoDBLocalFixture.ts
+++ b/test/mocha/dynamoDBLocalFixture.ts
@@ -3,8 +3,8 @@ import { ChildProcess } from 'child_process'
 import DDBLocal from 'dynamodb-local'
 import { deleteAllTables } from './dbSetup'
 
-process.env.AWS_ACCESS_KEY_ID = 'my_access_key'
-process.env.AWS_SECRET_ACCESS_KEY = 'my_secret_key'
+process.env.AWS_ACCESS_KEY_ID = 'myaccesskey'
+process.env.AWS_SECRET_ACCESS_KEY = 'mysecretkey'
 
 const dbPort = Number(process.env.DYNAMODB_LOCAL_PORT || 8000)
 


### PR DESCRIPTION
## What?
QuickNode RPC metrics are shown as UNKNOWN (We use QuickNode RPC for chain id 56 and 42220). We want to fix it to show QuickNode metrics.

## Why?
Because QuickNode RPC endpoint has QuikNode instead of QuickNode. We were matching against QuickNode.

## How?
Match against QuikNode.

## Testing?
N/A

## Screenshots (optional)
<img width="1172" alt="Screenshot 2023-07-05 at 9 15 24 AM" src="https://github.com/Uniswap/routing-api/assets/91580504/d7f78e4d-671f-46d2-bf55-877877cb41c8">


## Anything Else?