### PR TITLE
[fix] [ROUTE-34] Skip widgets for chain id with no provider

### DIFF
--- a/bin/stacks/routing-dashboard-stack.ts
+++ b/bin/stacks/routing-dashboard-stack.ts
@@ -440,8 +440,10 @@ export class RoutingDashboardStack extends cdk.NestedStack {
       },
     ])
 
-    const missingProviderUrlsForChains = SUPPORTED_CHAINS.filter((chainId) => !jsonRpcProviders[`WEB3_RPC_${chainId.toString()}`])
-    const providerUrlsForChains = SUPPORTED_CHAINS.filter((chainId) => !SUPPORTED_CHAINS.includes(chainId))
+    const missingProviderUrlsForChains = SUPPORTED_CHAINS.filter(
+      (chainId) => !jsonRpcProviders[`WEB3_RPC_${chainId.toString()}`]
+    )
+    const providerUrlsForChains = SUPPORTED_CHAINS.filter((chainId) => !missingProviderUrlsForChains.includes(chainId))
 
     new CfnOutput(this, 'missingProviderUrlsForChains', {
       value: missingProviderUrlsForChains.join(','),

--- a/bin/stacks/routing-dashboard-stack.ts
+++ b/bin/stacks/routing-dashboard-stack.ts
@@ -8,6 +8,7 @@ import { SUPPORTED_CHAINS } from '../../lib/handlers/injector-sor'
 import { CachedRoutesWidgetsFactory } from '../../lib/dashboards/cached-routes-widgets-factory'
 import { ID_TO_NETWORK_NAME } from '@uniswap/smart-order-router/build/main/util/chains'
 import { RpcProvidersWidgetsFactory } from '../../lib/dashboards/rpc-providers-widgets-factory'
+import { CfnOutput } from 'aws-cdk-lib'
 
 export const NAMESPACE = 'Uniswap'
 
@@ -439,10 +440,17 @@ export class RoutingDashboardStack extends cdk.NestedStack {
       },
     ])
 
+    const missingProviderUrlsForChains = SUPPORTED_CHAINS.filter((chainId) => !jsonRpcProviders[`WEB3_RPC_${chainId.toString()}`])
+    const providerUrlsForChains = SUPPORTED_CHAINS.filter((chainId) => !SUPPORTED_CHAINS.includes(chainId))
+
+    new CfnOutput(this, 'missingProviderUrlsForChains', {
+      value: missingProviderUrlsForChains.join(','),
+    })
+
     const rpcProvidersWidgetsForRoutingDashboard = new RpcProvidersWidgetsFactory(
       NAMESPACE,
       region,
-      MAINNETS.concat(TESTNETS),
+      providerUrlsForChains,
       jsonRpcProviders
     ).generateWidgets()
 

--- a/lib/dashboards/rpc-providers-widgets-factory.ts
+++ b/lib/dashboards/rpc-providers-widgets-factory.ts
@@ -42,7 +42,7 @@ export class RpcProvidersWidgetsFactory implements WidgetsFactory {
 
       if (!url) {
         log.info(`No provider found for chain ${chainId.toString()}, skipping`)
-        return new Array<Widget>
+        return new Array<Widget>()
       }
 
       const providerName = deriveProviderName(url)

--- a/lib/dashboards/rpc-providers-widgets-factory.ts
+++ b/lib/dashboards/rpc-providers-widgets-factory.ts
@@ -37,7 +37,7 @@ export class RpcProvidersWidgetsFactory implements WidgetsFactory {
     const metrics = _.flatMap(chainsWithIndices, (chainIdAndIndex) => {
       const chainId = chainIdAndIndex.chainId
       const index = chainIdAndIndex.index
-      const url = this.jsonRpcProviders[`WEB3_RPC_${chainId.toString()}`]
+      const url = this.jsonRpcProviders[`WEB3_RPC_${chainId.toString()}`]!
 
       const providerName = deriveProviderName(url)
 

--- a/lib/dashboards/rpc-providers-widgets-factory.ts
+++ b/lib/dashboards/rpc-providers-widgets-factory.ts
@@ -3,7 +3,6 @@ import { Widget } from './core/model/widget'
 import { ChainId } from '@uniswap/sdk-core'
 import { deriveProviderName } from '../handlers/evm/provider/ProviderName'
 import _ from 'lodash'
-import { log } from '@uniswap/smart-order-router'
 
 export class RpcProvidersWidgetsFactory implements WidgetsFactory {
   region: string
@@ -39,11 +38,6 @@ export class RpcProvidersWidgetsFactory implements WidgetsFactory {
       const chainId = chainIdAndIndex.chainId
       const index = chainIdAndIndex.index
       const url = this.jsonRpcProviders[`WEB3_RPC_${chainId.toString()}`]
-
-      if (!url) {
-        log.info(`No provider found for chain ${chainId.toString()}, skipping`)
-        return new Array<Widget>()
-      }
 
       const providerName = deriveProviderName(url)
 

--- a/lib/dashboards/rpc-providers-widgets-factory.ts
+++ b/lib/dashboards/rpc-providers-widgets-factory.ts
@@ -3,6 +3,7 @@ import { Widget } from './core/model/widget'
 import { ChainId } from '@uniswap/sdk-core'
 import { deriveProviderName } from '../handlers/evm/provider/ProviderName'
 import _ from 'lodash'
+import { log } from '@uniswap/smart-order-router'
 
 export class RpcProvidersWidgetsFactory implements WidgetsFactory {
   region: string
@@ -37,7 +38,13 @@ export class RpcProvidersWidgetsFactory implements WidgetsFactory {
     const metrics = _.flatMap(chainsWithIndices, (chainIdAndIndex) => {
       const chainId = chainIdAndIndex.chainId
       const index = chainIdAndIndex.index
-      const url = this.jsonRpcProviders[`WEB3_RPC_${chainId.toString()}`]!
+      const url = this.jsonRpcProviders[`WEB3_RPC_${chainId.toString()}`]
+
+      if (!url) {
+        log.info(`No provider found for chain ${chainId.toString()}, skipping`)
+        return new Array<Widget>
+      }
+
       const providerName = deriveProviderName(url)
 
       const metric1 = `m${index * 2 + 1}`


### PR DESCRIPTION
## What?
Routing-API CodePipeline failed due to JSON RPC Provider URL not populated for some chain. 

## Why?
After troubleshooting, we think some net don't have the JSON RPC Provider URLs from the secrets. This was not caught in personal CDK Stack, because personal CDK Stack loads from the .env file, which adds all the chains.

## How?
We add log to ensure not all the chains are skipped. We are also not throwing error for the missing URLs to see how many URLs are missing during the codepipeline deploy.

## Testing?
Can deploy to personal CDK Stack successfully. Can see the missing chain ids in the cfn output. I intentially removed avax mainnet from my local .env. integ-test all succeeded except for avax, because of a separate change in tokenlist.

## Screenshots (optional)
<img width="655" alt="Screenshot 2023-07-06 at 2 24 46 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/628af5f9-d301-4d4a-a450-2e271b821214">
<img width="1082" alt="Screenshot 2023-07-06 at 2 24 38 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/ec0f8bb9-f83c-41b9-8f92-71d558729279">
<img width="1460" alt="Screenshot 2023-07-06 at 2 36 32 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/101b3271-cc8b-453a-9981-19237f50c0bf">


## Anything Else?
N/A