### PR TITLE
[fix] [ROUTE-34] hardcode chain id to provider name

### DIFF
--- a/bin/stacks/routing-api-stack.ts
+++ b/bin/stacks/routing-api-stack.ts
@@ -205,7 +205,6 @@ export class RoutingAPIStack extends cdk.Stack {
       routingLambdaName: routingLambda.functionName,
       poolCacheLambdaNameArray,
       ipfsPoolCacheLambdaName: ipfsPoolCachingLambda ? ipfsPoolCachingLambda.functionName : undefined,
-      jsonRpcProviders: jsonRpcProviders,
     })
 
     const lambdaIntegration = new aws_apigateway.LambdaIntegration(routingLambdaAlias)

--- a/bin/stacks/routing-dashboard-stack.ts
+++ b/bin/stacks/routing-dashboard-stack.ts
@@ -25,14 +25,13 @@ export interface RoutingDashboardProps extends cdk.NestedStackProps {
   routingLambdaName: string
   poolCacheLambdaNameArray: string[]
   ipfsPoolCacheLambdaName?: string
-  jsonRpcProviders: { [chainName: string]: string }
 }
 
 export class RoutingDashboardStack extends cdk.NestedStack {
   constructor(scope: Construct, name: string, props: RoutingDashboardProps) {
     super(scope, name, props)
 
-    const { apiName, routingLambdaName, poolCacheLambdaNameArray, ipfsPoolCacheLambdaName, jsonRpcProviders } = props
+    const { apiName, routingLambdaName, poolCacheLambdaNameArray, ipfsPoolCacheLambdaName } = props
     const region = cdk.Stack.of(this).region
 
     const TESTNETS = [
@@ -442,8 +441,7 @@ export class RoutingDashboardStack extends cdk.NestedStack {
     const rpcProvidersWidgetsForRoutingDashboard = new RpcProvidersWidgetsFactory(
       NAMESPACE,
       region,
-      MAINNETS.concat(TESTNETS),
-      jsonRpcProviders
+      MAINNETS.concat(TESTNETS)
     ).generateWidgets()
 
     new aws_cloudwatch.CfnDashboard(this, 'RoutingAPIDashboard', {

--- a/lib/dashboards/rpc-providers-widgets-factory.ts
+++ b/lib/dashboards/rpc-providers-widgets-factory.ts
@@ -1,26 +1,41 @@
 import { WidgetsFactory } from './core/widgets-factory'
 import { Widget } from './core/model/widget'
 import { ChainId } from '@uniswap/sdk-core'
-import { deriveProviderName } from '../handlers/evm/provider/ProviderName'
 import _ from 'lodash'
 import { ID_TO_NETWORK_NAME } from '@uniswap/smart-order-router/build/main/util/chains'
+import { ProviderName } from '../handlers/evm/provider/ProviderName'
+
+const ID_TO_PROVIDER = (id: ChainId): string => {
+  switch (id) {
+    case ChainId.MAINNET:
+    case ChainId.OPTIMISM:
+    case ChainId.SEPOLIA:
+    case ChainId.POLYGON:
+    case ChainId.POLYGON_MUMBAI:
+    case ChainId.ARBITRUM_ONE:
+    case ChainId.ARBITRUM_GOERLI:
+    case ChainId.AVALANCHE:
+    case ChainId.GOERLI:
+      return ProviderName.INFURA
+    case ChainId.CELO:
+    case ChainId.BNB:
+      return ProviderName.QUIKNODE
+    case ChainId.CELO_ALFAJORES:
+      return ProviderName.FORNO
+    default:
+      return ProviderName.UNKNOWN
+  }
+}
 
 export class RpcProvidersWidgetsFactory implements WidgetsFactory {
   region: string
   namespace: string
   chains: Array<ChainId>
-  jsonRpcProviders: { [chainName: string]: string }
 
-  constructor(
-    namespace: string,
-    region: string,
-    chains: Array<ChainId>,
-    jsonRpcProviders: { [chainName: string]: string }
-  ) {
+  constructor(namespace: string, region: string, chains: Array<ChainId>) {
     this.namespace = namespace
     this.region = region
     this.chains = chains
-    this.jsonRpcProviders = jsonRpcProviders
   }
 
   generateWidgets(): Widget[] {
@@ -38,9 +53,7 @@ export class RpcProvidersWidgetsFactory implements WidgetsFactory {
     const metrics = _.flatMap(chainsWithIndices, (chainIdAndIndex) => {
       const chainId = chainIdAndIndex.chainId
       const index = chainIdAndIndex.index
-      const url = this.jsonRpcProviders[`WEB3_RPC_${chainId.toString()}`]!
-      if (url === undefined) return []
-      const providerName = deriveProviderName(url)
+      const providerName = ID_TO_PROVIDER(chainId)
 
       const metric1 = `m${index * 2 + 1}`
       const metric2 = `m${index * 2 + 2}`


### PR DESCRIPTION
Since the AWS Secrets values (JSON Provider URLs) require resolving at Cloudformation prepare time, we decided to just hard code the chain id to the provider name based on the internal institutional knowledge.

Hardcoded value will behave the same across local CDK environment vs. prod:
<img width="1448" alt="Screenshot 2023-07-06 at 5 47 21 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/1e21e2a9-dbf0-43ea-a80d-e25ba9ff3784">
