### PR TITLE
Enable 1 to 2 ETH Caches as we are getting 25% of traffic for 1 ETH quotes

### DIFF
--- a/lib/handlers/router-entities/route-caching/cached-routes-configuration.ts
+++ b/lib/handlers/router-entities/route-caching/cached-routes-configuration.ts
@@ -191,7 +191,7 @@ export const CACHED_ROUTES_CONFIGURATION: Map<string, CachedRoutesStrategy> = ne
         new CachedRoutesBucket({ bucket: 0.05, cacheMode: CacheMode.Darkmode }),
         new CachedRoutesBucket({ bucket: 0.1, cacheMode: CacheMode.Tapcompare, withLastNCachedRoutes: 10 }),
         new CachedRoutesBucket({ bucket: 0.5, cacheMode: CacheMode.Tapcompare, withLastNCachedRoutes: 10 }),
-        new CachedRoutesBucket({ bucket: 1, cacheMode: CacheMode.Tapcompare, withLastNCachedRoutes: 10 }),
+        new CachedRoutesBucket({ bucket: 1, cacheMode: CacheMode.Livemode, withLastNCachedRoutes: 10 }),
         new CachedRoutesBucket({ bucket: 2, cacheMode: CacheMode.Tapcompare, withLastNCachedRoutes: 10 }),
         new CachedRoutesBucket({ bucket: 4, cacheMode: CacheMode.Tapcompare, withLastNCachedRoutes: 10 }),
         new CachedRoutesBucket({ bucket: 6, cacheMode: CacheMode.Tapcompare, withLastNCachedRoutes: 10 }),


### PR DESCRIPTION
# Enable Any to ETH ExactOut Caches for 1 to 2 ETH bucket

As seen in the following screenshot, there are some bursts of requests for 1 to 2 ETH, which are not using cached routes.
In order to reduce on the cost of those requests we should enable caches.

![Screenshot 2023-07-31 at 11 22 13 AM](https://github.com/Uniswap/routing-api/assets/294807/0a9acfbe-cb6b-4221-956d-530cfa0a427e)
