### PR TITLE
do not sample dynamo caching pool

### DIFF
--- a/lib/handlers/pools/util/pool-provider-traffic-switch-configuration.ts
+++ b/lib/handlers/pools/util/pool-provider-traffic-switch-configuration.ts
@@ -1,4 +1,4 @@
 export const POOL_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = {
   switchPercentage: 0.0,
-  samplingPercentage: 1.0,
+  samplingPercentage: 0.0,
 }


### PR DESCRIPTION
We decided to turn off the sampling in dynamo caching pool. We found the sampling path has some inefficient code, and we already filed [ROUTE-63](https://linear.app/uniswap/issue/ROUTE-63/re-enable-dynamo-pool-caching-sampling-with-better-implementation-that) as a follow-up.