### PR TITLE
fix: routing-api base native->erc20 test

### DIFF
--- a/test/mocha/integ/quote.test.ts
+++ b/test/mocha/integ/quote.test.ts
@@ -2003,7 +2003,7 @@ describe('quote', function () {
             tokenInChainId: chain,
             tokenOutAddress: baseErc20.address,
             tokenOutChainId: chain,
-            amount: await getAmountFromToken(type, WNATIVE_ON(chain), erc2, '1'),
+            amount: await getAmountFromToken(type, WNATIVE_ON(chain), baseErc20, '1'),
             type,
             enableUniversalRouter: true,
           }


### PR DESCRIPTION
Previous fix https://github.com/Uniswap/routing-api/pull/279 was incomplete. Token amount was off and resulted in no route found https://app.warp.dev/block/NA2mbp1S9mj7XqP41K2QmN.

Fixed to ensure the route gets found https://app.warp.dev/block/jfv615OfaR9pZJNJTJ9Z3i.