### PR TITLE
Revert "Initial quote perf tuning by increasing the distribution percent from 5% to 10% for the mainnet (#285)"

### DIFF
--- a/lib/handlers/shared.ts
+++ b/lib/handlers/shared.ts
@@ -91,7 +91,7 @@ export const DEFAULT_ROUTING_CONFIG_BY_CHAIN = (chainId: ChainId): AlphaRouterCo
         maxSwapsPerPath: 3,
         minSplits: 1,
         maxSplits: 7,
-        distributionPercent: 10,
+        distributionPercent: 5,
         forceCrossProtocol: false,
       }
   }


### PR DESCRIPTION
We have collected sufficient datapoints in potential quote latency improvements, hence reverting for now.