### PR TITLE
measure distribution change

### DIFF
--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -32,6 +32,7 @@ import { utils } from 'ethers'
 import { simulationStatusToString } from './util/simulation'
 import Logger from 'bunyan'
 import { PAIRS_TO_TRACK } from './util/pairs-to-track'
+import { measureDistributionPercentChangeImpact } from '../../util/alpha-config-measurement'
 
 export class QuoteHandler extends APIGLambdaHandler<
   ContainerInjected,
@@ -526,7 +527,8 @@ export class QuoteHandler extends APIGLambdaHandler<
       type,
       chainId,
       amount,
-      routeString
+      routeString,
+      swapRoute
     )
 
     return {
@@ -546,13 +548,16 @@ export class QuoteHandler extends APIGLambdaHandler<
     tradeType: 'exactIn' | 'exactOut',
     chainId: ChainId,
     amount: CurrencyAmount<Currency>,
-    routeString: string
+    routeString: string,
+    swapRoute: SwapRoute
   ): void {
     const tradingPair = `${currencyIn.wrapped.symbol}/${currencyOut.wrapped.symbol}`
     const wildcardInPair = `${currencyIn.wrapped.symbol}/*`
     const wildcardOutPair = `*/${currencyOut.wrapped.symbol}`
     const tradeTypeEnumValue = tradeType == 'exactIn' ? TradeType.EXACT_INPUT : TradeType.EXACT_OUTPUT
     const pairsTracked = PAIRS_TO_TRACK.get(chainId)?.get(tradeTypeEnumValue)
+
+    measureDistributionPercentChangeImpact(5, 10, swapRoute, currencyIn, currencyOut, tradeType, chainId, amount)
 
     if (
       pairsTracked?.includes(tradingPair) ||

--- a/lib/util/alpha-config-measurement.ts
+++ b/lib/util/alpha-config-measurement.ts
@@ -1,0 +1,52 @@
+import { ChainId, Currency, CurrencyAmount } from '@uniswap/sdk-core'
+import { Protocol } from '@uniswap/router-sdk';
+import { log, metric, MetricLoggerUnit, SwapRoute } from '@uniswap/smart-order-router'
+
+export const getDistribution = (distributionPercent: number) => {
+  const percents: Array<number> = new Array<number>();
+
+  for (let i = 1; i <= 100 / distributionPercent; i++) {
+    percents.push(i * distributionPercent);
+  }
+
+  return percents;
+};
+
+export const measureDistributionPercentChangeImpact = (distributionPercentBefore: number,
+                                                       distributionPercentAfter: number,
+                                                       bestSwapRoute: SwapRoute,
+                                                       currencyIn: Currency,
+                                                       currencyOut: Currency,
+                                                       tradeType: string,
+                                                       chainId: ChainId,
+                                                       amount: CurrencyAmount<Currency>) => {
+  const routesImpacted: Array<string> = new Array<string>();
+
+  const percentDistributionBefore = getDistribution(distributionPercentBefore);
+  const percentDistributionAfter = getDistribution(distributionPercentAfter);
+
+  bestSwapRoute.route.forEach((route) => {
+    switch (route.protocol) {
+      case Protocol.MIXED:
+      case Protocol.V3:
+        if (percentDistributionBefore.includes(route.percent) && !percentDistributionAfter.includes(route.percent)) {
+          routesImpacted.push(route.toString());
+        }
+        break;
+      case Protocol.V2:
+        // if it's v2, there's no distribution, skip the current route
+        break;
+    }
+  })
+
+  if (routesImpacted.length > 0) {
+    log.warn(`Distribution percent change impacted the routes ${routesImpacted.join(',')},
+      for currency ${currencyIn.wrapped.symbol}
+      amount ${amount.toExact()}
+      quote currency ${currencyOut.wrapped.symbol}
+      trade type ${tradeType}
+      chain id ${chainId}`);
+    metric.putMetric("BEST_SWAP_ROUTE_DISTRIBUTION_PERCENT_CHANGE_IMPACTED", 1, MetricLoggerUnit.Count);
+    metric.putMetric("ROUTES_WITH_VALID_QUOTE_DISTRIBUTION_PERCENT_CHANGE_IMPACTED", routesImpacted.length, MetricLoggerUnit.Count);
+  }
+}

--- a/lib/util/alpha-config-measurement.ts
+++ b/lib/util/alpha-config-measurement.ts
@@ -1,41 +1,43 @@
 import { ChainId, Currency, CurrencyAmount } from '@uniswap/sdk-core'
-import { Protocol } from '@uniswap/router-sdk';
+import { Protocol } from '@uniswap/router-sdk'
 import { log, metric, MetricLoggerUnit, SwapRoute } from '@uniswap/smart-order-router'
 
 export const getDistribution = (distributionPercent: number) => {
-  const percents: Array<number> = new Array<number>();
+  const percents: Array<number> = new Array<number>()
 
   for (let i = 1; i <= 100 / distributionPercent; i++) {
-    percents.push(i * distributionPercent);
+    percents.push(i * distributionPercent)
   }
 
-  return percents;
-};
+  return percents
+}
 
-export const measureDistributionPercentChangeImpact = (distributionPercentBefore: number,
-                                                       distributionPercentAfter: number,
-                                                       bestSwapRoute: SwapRoute,
-                                                       currencyIn: Currency,
-                                                       currencyOut: Currency,
-                                                       tradeType: string,
-                                                       chainId: ChainId,
-                                                       amount: CurrencyAmount<Currency>) => {
-  const routesImpacted: Array<string> = new Array<string>();
+export const measureDistributionPercentChangeImpact = (
+  distributionPercentBefore: number,
+  distributionPercentAfter: number,
+  bestSwapRoute: SwapRoute,
+  currencyIn: Currency,
+  currencyOut: Currency,
+  tradeType: string,
+  chainId: ChainId,
+  amount: CurrencyAmount<Currency>
+) => {
+  const routesImpacted: Array<string> = new Array<string>()
 
-  const percentDistributionBefore = getDistribution(distributionPercentBefore);
-  const percentDistributionAfter = getDistribution(distributionPercentAfter);
+  const percentDistributionBefore = getDistribution(distributionPercentBefore)
+  const percentDistributionAfter = getDistribution(distributionPercentAfter)
 
   bestSwapRoute.route.forEach((route) => {
     switch (route.protocol) {
       case Protocol.MIXED:
       case Protocol.V3:
         if (percentDistributionBefore.includes(route.percent) && !percentDistributionAfter.includes(route.percent)) {
-          routesImpacted.push(route.toString());
+          routesImpacted.push(route.toString())
         }
-        break;
+        break
       case Protocol.V2:
         // if it's v2, there's no distribution, skip the current route
-        break;
+        break
     }
   })
 
@@ -45,8 +47,12 @@ export const measureDistributionPercentChangeImpact = (distributionPercentBefore
       amount ${amount.toExact()}
       quote currency ${currencyOut.wrapped.symbol}
       trade type ${tradeType}
-      chain id ${chainId}`);
-    metric.putMetric("BEST_SWAP_ROUTE_DISTRIBUTION_PERCENT_CHANGE_IMPACTED", 1, MetricLoggerUnit.Count);
-    metric.putMetric("ROUTES_WITH_VALID_QUOTE_DISTRIBUTION_PERCENT_CHANGE_IMPACTED", routesImpacted.length, MetricLoggerUnit.Count);
+      chain id ${chainId}`)
+    metric.putMetric('BEST_SWAP_ROUTE_DISTRIBUTION_PERCENT_CHANGE_IMPACTED', 1, MetricLoggerUnit.Count)
+    metric.putMetric(
+      'ROUTES_WITH_VALID_QUOTE_DISTRIBUTION_PERCENT_CHANGE_IMPACTED',
+      routesImpacted.length,
+      MetricLoggerUnit.Count
+    )
   }
 }


### PR DESCRIPTION
Instead of measuring how many swaps will be impacted by distribution change in [smart-order-router](https://github.com/Uniswap/smart-order-router) https://github.com/Uniswap/smart-order-router/pull/308, we should determine the impact in routing-api directly, as we plan to increase the distribution in routing-api.