### PR TITLE
Create intent param for tracking intent of quote

### DIFF
--- a/lib/handlers/quote/schema/quote-schema.ts
+++ b/lib/handlers/quote/schema/quote-schema.ts
@@ -58,6 +58,7 @@ export const QuoteQueryParamsJoi = Joi.object({
   // TODO: Remove once universal router is no longer behind a feature flag.
   enableUniversalRouter: Joi.boolean().optional().default(false),
   quoteSpeed: Joi.string().valid('fast', 'standard').optional().default('standard'),
+  intent: Joi.string().valid('quote', 'swap', 'caching').optional().default('quote'),
 }).and('recipient', 'slippageTolerance', 'deadline')
 
 export type QuoteQueryParams = {
@@ -84,4 +85,5 @@ export type QuoteQueryParams = {
   permitSigDeadline?: string
   enableUniversalRouter?: boolean
   quoteSpeed?: string
+  intent?: string
 }

--- a/lib/handlers/shared.ts
+++ b/lib/handlers/shared.ts
@@ -107,7 +107,7 @@ export type QuoteSpeedConfig = {
   writeToCachedRoutes?: boolean
 }
 
-export const QUOTE_SPEED_MAP: { [key: string]: QuoteSpeedConfig } = {
+export const QUOTE_SPEED_CONFIG: { [key: string]: QuoteSpeedConfig } = {
   standard: {},
   fast: {
     v2PoolSelection: {
@@ -130,6 +130,29 @@ export const QUOTE_SPEED_MAP: { [key: string]: QuoteSpeedConfig } = {
     maxSplits: 2,
     distributionPercent: 10,
     writeToCachedRoutes: false,
+  },
+}
+
+export type IntentSpecificConfig = {
+  useCachedRoutes?: boolean
+  optimisticCachedRoutes?: boolean
+}
+
+export const INTENT_SPECIFIC_CONFIG: { [key: string]: IntentSpecificConfig } = {
+  caching: {
+    // When the intent is to create a cache entry, we should not use the cache
+    // useCachedRoutes: false,
+    // optimisticCachedRoutes: false,
+  },
+  quote: {
+    // When the intent is to get a quote, we should use the cache and optimistic cached routes
+    // useCachedRoutes: true,
+    // optimisticCachedRoutes: true,
+  },
+  swap: {
+    // When the intent is to prepare the swap, we can use cache, but it should not be optimistic
+    // useCachedRoutes: true,
+    // optimisticCachedRoutes: false,
   },
 }
 


### PR DESCRIPTION
The intent param will be used to indicate wether the quote request has the intent of caching, quoting or swapping
The intent will be used to modify the configuration sent to SOR
