### PR TITLE
Revert "Create a debugRoutingConfig param and a UnicornSecret (#290)" - see more details in descriptions

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -34,7 +34,6 @@ export class RoutingAPIStage extends Stage {
       tenderlyUser: string
       tenderlyProject: string
       tenderlyAccessKey: string
-      unicornSecret: string
     }
   ) {
     super(scope, id, props)
@@ -52,7 +51,6 @@ export class RoutingAPIStage extends Stage {
       tenderlyUser,
       tenderlyProject,
       tenderlyAccessKey,
-      unicornSecret,
     } = props
 
     const { url } = new RoutingAPIStack(this, 'RoutingAPI', {
@@ -69,7 +67,6 @@ export class RoutingAPIStage extends Stage {
       tenderlyUser,
       tenderlyProject,
       tenderlyAccessKey,
-      unicornSecret,
     })
     this.url = url
   }
@@ -126,11 +123,6 @@ export class RoutingAPIPipeline extends Stack {
       //secretCompleteArn: arn:aws:secretsmanager:us-east-2:644039819003:secret:routing-api-rpc-urls-json-backup-D2sWoe
     })
 
-    // Secret that controls the access to the debugging query string params
-    const unicornSecrets = sm.Secret.fromSecretAttributes(this, 'DebugConfigUnicornSecrets', {
-      secretCompleteArn: 'arn:aws:secretsmanager:us-east-2:644039819003:secret:debug-config-unicornsecrets-jvmCsq',
-    })
-
     const tenderlyCreds = sm.Secret.fromSecretAttributes(this, 'TenderlyCreds', {
       secretCompleteArn: 'arn:aws:secretsmanager:us-east-2:644039819003:secret:tenderly-api-wQaI2R',
     })
@@ -181,7 +173,6 @@ export class RoutingAPIPipeline extends Stack {
       tenderlyUser: tenderlyCreds.secretValueFromJson('tenderly-user').toString(),
       tenderlyProject: tenderlyCreds.secretValueFromJson('tenderly-project').toString(),
       tenderlyAccessKey: tenderlyCreds.secretValueFromJson('tenderly-access-key').toString(),
-      unicornSecret: unicornSecrets.secretValueFromJson('debug-config-unicorn-key').toString(),
     })
 
     const betaUsEast2AppStage = pipeline.addStage(betaUsEast2Stage)
@@ -204,7 +195,6 @@ export class RoutingAPIPipeline extends Stack {
       tenderlyUser: tenderlyCreds.secretValueFromJson('tenderly-user').toString(),
       tenderlyProject: tenderlyCreds.secretValueFromJson('tenderly-project').toString(),
       tenderlyAccessKey: tenderlyCreds.secretValueFromJson('tenderly-access-key').toString(),
-      unicornSecret: unicornSecrets.secretValueFromJson('debug-config-unicornsecrets').toString(),
     })
 
     const prodUsEast2AppStage = pipeline.addStage(prodUsEast2Stage)
@@ -299,7 +289,6 @@ new RoutingAPIStack(app, 'RoutingAPIStack', {
   tenderlyUser: process.env.TENDERLY_USER!,
   tenderlyProject: process.env.TENDERLY_PROJECT!,
   tenderlyAccessKey: process.env.TENDERLY_ACCESS_KEY!,
-  unicornSecret: process.env.UNICORN_SECRET!,
 })
 
 new RoutingAPIPipeline(app, 'RoutingAPIPipelineStack', {

--- a/bin/stacks/routing-api-stack.ts
+++ b/bin/stacks/routing-api-stack.ts
@@ -40,7 +40,6 @@ export class RoutingAPIStack extends cdk.Stack {
       tenderlyUser: string
       tenderlyProject: string
       tenderlyAccessKey: string
-      unicornSecret: string
     }
   ) {
     super(parent, name, props)
@@ -60,7 +59,6 @@ export class RoutingAPIStack extends cdk.Stack {
       tenderlyUser,
       tenderlyProject,
       tenderlyAccessKey,
-      unicornSecret,
     } = props
 
     const {
@@ -100,7 +98,6 @@ export class RoutingAPIStack extends cdk.Stack {
       cachedRoutesDynamoDb,
       cachingRequestFlagDynamoDb,
       cachedV3PoolsDynamoDb,
-      unicornSecret,
     })
 
     const accessLogGroup = new aws_logs.LogGroup(this, 'RoutingAPIGAccessLogs')

--- a/bin/stacks/routing-lambda-stack.ts
+++ b/bin/stacks/routing-lambda-stack.ts
@@ -29,7 +29,6 @@ export interface RoutingLambdaStackProps extends cdk.NestedStackProps {
   cachedRoutesDynamoDb?: aws_dynamodb.Table
   cachingRequestFlagDynamoDb?: aws_dynamodb.Table
   cachedV3PoolsDynamoDb?: aws_dynamodb.Table
-  unicornSecret: string
 }
 export class RoutingLambdaStack extends cdk.NestedStack {
   public readonly routingLambda: aws_lambda_nodejs.NodejsFunction
@@ -52,7 +51,6 @@ export class RoutingLambdaStack extends cdk.NestedStack {
       cachedRoutesDynamoDb,
       cachingRequestFlagDynamoDb,
       cachedV3PoolsDynamoDb,
-      unicornSecret,
     } = props
 
     const lambdaRole = new aws_iam.Role(this, 'RoutingLambdaRole', {
@@ -99,7 +97,6 @@ export class RoutingLambdaStack extends cdk.NestedStack {
         CACHED_ROUTES_TABLE_NAME: DynamoDBTableProps.CacheRouteDynamoDbTable.Name,
         CACHING_REQUEST_FLAG_TABLE_NAME: DynamoDBTableProps.CachingRequestFlagDynamoDbTable.Name,
         CACHED_V3_POOLS_TABLE_NAME: DynamoDBTableProps.V3PoolsDynamoDbTable.Name,
-        UNICORN_SECRET: unicornSecret,
         ...jsonRpcProviders,
       },
       layers: [

--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -118,8 +118,6 @@ export class QuoteHandler extends APIGLambdaHandler<
         permitSigDeadline,
         enableUniversalRouter,
         quoteSpeed,
-        debugRoutingConfig,
-        unicornSecret,
         intent,
       },
       requestInjected: {
@@ -214,11 +212,6 @@ export class QuoteHandler extends APIGLambdaHandler<
       protocols = [Protocol.V3]
     }
 
-    let parsedDebugRoutingConfig = {}
-    if (debugRoutingConfig && unicornSecret && unicornSecret === process.env.UNICORN_SECRET) {
-      parsedDebugRoutingConfig = JSON.parse(debugRoutingConfig)
-    }
-
     const routingConfig: AlphaRouterConfig = {
       ...DEFAULT_ROUTING_CONFIG_BY_CHAIN(chainId),
       ...(minSplits ? { minSplits } : {}),
@@ -226,7 +219,6 @@ export class QuoteHandler extends APIGLambdaHandler<
       ...(forceMixedRoutes ? { forceMixedRoutes } : {}),
       protocols,
       ...(quoteSpeed ? QUOTE_SPEED_CONFIG[quoteSpeed] : {}),
-      ...parsedDebugRoutingConfig,
       ...(intent ? INTENT_SPECIFIC_CONFIG[intent] : {}),
     }
 

--- a/lib/handlers/quote/schema/quote-schema.ts
+++ b/lib/handlers/quote/schema/quote-schema.ts
@@ -58,8 +58,6 @@ export const QuoteQueryParamsJoi = Joi.object({
   // TODO: Remove once universal router is no longer behind a feature flag.
   enableUniversalRouter: Joi.boolean().optional().default(false),
   quoteSpeed: Joi.string().valid('fast', 'standard').optional().default('standard'),
-  debugRoutingConfig: Joi.string().optional(),
-  unicornSecret: Joi.string().optional(),
   intent: Joi.string().valid('quote', 'swap', 'caching').optional().default('quote'),
 }).and('recipient', 'slippageTolerance', 'deadline')
 
@@ -87,7 +85,5 @@ export type QuoteQueryParams = {
   permitSigDeadline?: string
   enableUniversalRouter?: boolean
   quoteSpeed?: string
-  debugRoutingConfig?: string
-  unicornSecret?: string
   intent?: string
 }


### PR DESCRIPTION
We revert, because the codepipeline beta-us-east-2 retry does not retrigger `RoutingAPI.Prepare`, which does not build `CloudFormation` resource anymore.

<img width="1148" alt="Screenshot 2023-08-20 at 2 44 27 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/8b2c9448-927b-4a0a-97c0-60d554e8d172">


We did find the reason Codepipeline failed was due to:

```
User: arn:aws:sts::145079444317:assumed-role/cdk-hnb659fds-cfn-exec-role-145079444317-us-east-2/AWSCloudFormation is not authorized to perform: secretsmanager:GetSecretValue on resource: arn:aws:secretsmanager:us-east-2:644039819003:secret:debug-config-unicornsecrets-jvmCsq because no resource-based policy allows the secretsmanager:GetSecretValue action (Service: AWSSecretsManager; Status Code: 400; Error Code: AccessDeniedException; Request ID: 0b587919-9f34-46c7-a0da-0809f2dfc06c; Proxy: null)
```

But we added the policy to secrets afterwards (it seems like we always manually add policy to secrets instead of programmatically, since it's from cloudformation to secrets, not between stack to resource).

We don't believe there's any wrong with the change, so we will revert revert again.