### PR TITLE
increase distribution percent 5 -> 10 permanently for ETH/USDC and WETH/USDC small trades

### DIFF
--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -223,7 +223,7 @@ export class QuoteHandler extends APIGLambdaHandler<
 
     const routingConfig: AlphaRouterConfig = {
       ...DEFAULT_ROUTING_CONFIG_BY_CHAIN(chainId),
-      ...{ distributionPercent: DISTRIBUTION_PERCENT_CONFIG(chainId, currencyIn, currencyOut, type, amountRaw, log) },
+      ...{ distributionPercent: DISTRIBUTION_PERCENT_CONFIG(chainId, currencyIn, currencyOut, type, amountRaw) },
       ...(minSplits ? { minSplits } : {}),
       ...(forceCrossProtocol ? { forceCrossProtocol } : {}),
       ...(forceMixedRoutes ? { forceMixedRoutes } : {}),

--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -221,7 +221,7 @@ export class QuoteHandler extends APIGLambdaHandler<
     }
 
     const routingConfig: AlphaRouterConfig = {
-      ...DEFAULT_ROUTING_CONFIG_BY_CHAIN(chainId),
+      ...DEFAULT_ROUTING_CONFIG_BY_CHAIN(chainId, currencyIn, currencyOut, type, amountRaw),
       ...(minSplits ? { minSplits } : {}),
       ...(forceCrossProtocol ? { forceCrossProtocol } : {}),
       ...(forceMixedRoutes ? { forceMixedRoutes } : {}),

--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -223,7 +223,7 @@ export class QuoteHandler extends APIGLambdaHandler<
 
     const routingConfig: AlphaRouterConfig = {
       ...DEFAULT_ROUTING_CONFIG_BY_CHAIN(chainId),
-      ...{ distributionPercent: DISTRIBUTION_PERCENT_CONFIG(chainId, currencyIn, currencyOut, type, amountRaw) },
+      ...{ distributionPercent: DISTRIBUTION_PERCENT_CONFIG(chainId, currencyIn, currencyOut, type, amountRaw, log) },
       ...(minSplits ? { minSplits } : {}),
       ...(forceCrossProtocol ? { forceCrossProtocol } : {}),
       ...(forceMixedRoutes ? { forceMixedRoutes } : {}),

--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -28,6 +28,7 @@ import {
   tokenStringToCurrency,
   QUOTE_SPEED_CONFIG,
   INTENT_SPECIFIC_CONFIG,
+  DISTRIBUTION_PERCENT_CONFIG,
 } from '../shared'
 import { QuoteQueryParams, QuoteQueryParamsJoi } from './schema/quote-schema'
 import { utils } from 'ethers'
@@ -221,7 +222,8 @@ export class QuoteHandler extends APIGLambdaHandler<
     }
 
     const routingConfig: AlphaRouterConfig = {
-      ...DEFAULT_ROUTING_CONFIG_BY_CHAIN(chainId, currencyIn, currencyOut, type, amountRaw, log),
+      ...DEFAULT_ROUTING_CONFIG_BY_CHAIN(chainId),
+      ...{ distributionPercent: DISTRIBUTION_PERCENT_CONFIG(chainId, currencyIn, currencyOut, type, amountRaw) },
       ...(minSplits ? { minSplits } : {}),
       ...(forceCrossProtocol ? { forceCrossProtocol } : {}),
       ...(forceMixedRoutes ? { forceMixedRoutes } : {}),

--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -221,7 +221,7 @@ export class QuoteHandler extends APIGLambdaHandler<
     }
 
     const routingConfig: AlphaRouterConfig = {
-      ...DEFAULT_ROUTING_CONFIG_BY_CHAIN(chainId, currencyIn, currencyOut, type, amountRaw),
+      ...DEFAULT_ROUTING_CONFIG_BY_CHAIN(chainId, currencyIn, currencyOut, type, amountRaw, log),
       ...(minSplits ? { minSplits } : {}),
       ...(forceCrossProtocol ? { forceCrossProtocol } : {}),
       ...(forceMixedRoutes ? { forceMixedRoutes } : {}),

--- a/lib/handlers/shared.ts
+++ b/lib/handlers/shared.ts
@@ -1,4 +1,4 @@
-import { ChainId, Currency, CurrencyAmount, Fraction, Percent, WETH9 } from '@uniswap/sdk-core'
+import { ChainId, Currency, CurrencyAmount, Percent, WETH9 } from '@uniswap/sdk-core'
 import {
   AlphaRouterConfig,
   ITokenListProvider,
@@ -6,62 +6,17 @@ import {
   MapWithLowerCaseKey,
   NATIVE_NAMES_BY_ID,
   nativeOnChain,
-  ProtocolPoolSelection, USDC_MAINNET
+  ProtocolPoolSelection,
+  USDC_MAINNET,
 } from '@uniswap/smart-order-router'
-import Logger from 'bunyan'
 import JSBI from 'jsbi'
+import Logger from 'bunyan'
 
 export const SECONDS_PER_BLOCK_BY_CHAIN_ID: { [chainId in ChainId]?: number } = {
   [ChainId.MAINNET]: 30,
 }
 
-export const DEFAULT_ROUTING_CONFIG_BY_CHAIN = (chainId: ChainId, currencyIn: Currency, currencyOut: Currency, type: string, amountRaw: string, log: Logger): AlphaRouterConfig => {
-  let distributionPercent = 5;
-  let amount: CurrencyAmount<Currency>
-
-  switch (type) {
-    case 'exactIn':
-      amount = CurrencyAmount.fromRawAmount(currencyIn, JSBI.BigInt(amountRaw))
-      
-      if (chainId == ChainId.MAINNET) {
-        if (currencyIn.symbol == WETH9[chainId].symbol && currencyOut.symbol == USDC_MAINNET.symbol && amount.lessThan(JSBI.BigInt(WETH9[chainId].decimals * 0.5))) {
-          distributionPercent = 10;
-        }
-        if (currencyIn.symbol == WETH9[chainId].symbol && currencyOut.symbol == USDC_MAINNET.symbol && amount.lessThan(JSBI.BigInt(WETH9[chainId].decimals * 0.5))) {
-          distributionPercent = 10;
-        }
-        if (currencyIn.symbol == USDC_MAINNET.symbol && currencyOut.symbol == 'ETH' && amount.lessThan(USDC_MAINNET.decimals * 1000)) {
-          distributionPercent = 10;
-        }
-        if (currencyIn.symbol == USDC_MAINNET.symbol && currencyOut.symbol == 'WETH' && amount.lessThan(USDC_MAINNET.decimals * 1000)) {
-          distributionPercent = 10;
-        }
-      }
-
-      break
-    case 'exactOut':
-      amount = CurrencyAmount.fromRawAmount(currencyOut, JSBI.BigInt(amountRaw))
-
-      if (chainId == ChainId.MAINNET) {
-        if (currencyIn.symbol == 'ETH' && currencyOut.symbol == 'USDC' && amount.lessThan(USDC_MAINNET.decimals * 1000)) {
-          distributionPercent = 10;
-        }
-        if (currencyIn.symbol == 'WETH' && currencyOut.symbol == 'USDC' && amount.lessThan(USDC_MAINNET.decimals * 1000)) {
-          distributionPercent = 10;
-        }
-        if (currencyIn.symbol == 'USDC' && currencyOut.symbol == 'ETH' && amount.lessThan(JSBI.BigInt(WETH9[chainId].decimals * 0.5))) {
-          distributionPercent = 10;
-        }
-        if (currencyIn.symbol == 'USDC' && currencyOut.symbol == 'WETH' && amount.lessThan(JSBI.BigInt(WETH9[chainId].decimals * 0.5))) {
-          distributionPercent = 10;
-        }
-      }
-
-      break
-    default:
-      throw new Error('Invalid swap type')
-  }
-
+export const DEFAULT_ROUTING_CONFIG_BY_CHAIN = (chainId: ChainId): AlphaRouterConfig => {
   switch (chainId) {
     case ChainId.BASE:
     case ChainId.OPTIMISM:
@@ -139,7 +94,7 @@ export const DEFAULT_ROUTING_CONFIG_BY_CHAIN = (chainId: ChainId, currencyIn: Cu
         maxSwapsPerPath: 3,
         minSplits: 1,
         maxSplits: 7,
-        distributionPercent: distributionPercent,
+        distributionPercent: 5,
         forceCrossProtocol: false,
       }
   }
@@ -201,6 +156,94 @@ export const INTENT_SPECIFIC_CONFIG: { [key: string]: IntentSpecificConfig } = {
     useCachedRoutes: true,
     optimisticCachedRoutes: false,
   },
+}
+
+export const DISTRIBUTION_PERCENT_CONFIG = (
+  chainId: ChainId,
+  currencyIn: Currency,
+  currencyOut: Currency,
+  type: string,
+  amountRaw: string
+) => {
+  let distributionPercent = 5
+  let amount: CurrencyAmount<Currency>
+
+  switch (type) {
+    case 'exactIn':
+      amount = CurrencyAmount.fromRawAmount(currencyIn, JSBI.BigInt(amountRaw))
+
+      if (chainId == ChainId.MAINNET) {
+        if (
+          currencyIn.symbol == WETH9[chainId].symbol &&
+          currencyOut.symbol == USDC_MAINNET.symbol &&
+          amount.lessThan(JSBI.BigInt(WETH9[chainId].decimals * 0.5))
+        ) {
+          distributionPercent = 10
+        }
+        if (
+          currencyIn.symbol == WETH9[chainId].symbol &&
+          currencyOut.symbol == USDC_MAINNET.symbol &&
+          amount.lessThan(JSBI.BigInt(WETH9[chainId].decimals * 0.5))
+        ) {
+          distributionPercent = 10
+        }
+        if (
+          currencyIn.symbol == USDC_MAINNET.symbol &&
+          currencyOut.symbol == 'ETH' &&
+          amount.lessThan(USDC_MAINNET.decimals * 1000)
+        ) {
+          distributionPercent = 10
+        }
+        if (
+          currencyIn.symbol == USDC_MAINNET.symbol &&
+          currencyOut.symbol == 'WETH' &&
+          amount.lessThan(USDC_MAINNET.decimals * 1000)
+        ) {
+          distributionPercent = 10
+        }
+      }
+
+      break
+    case 'exactOut':
+      amount = CurrencyAmount.fromRawAmount(currencyOut, JSBI.BigInt(amountRaw))
+
+      if (chainId == ChainId.MAINNET) {
+        if (
+          currencyIn.symbol == 'ETH' &&
+          currencyOut.symbol == 'USDC' &&
+          amount.lessThan(USDC_MAINNET.decimals * 1000)
+        ) {
+          distributionPercent = 10
+        }
+        if (
+          currencyIn.symbol == 'WETH' &&
+          currencyOut.symbol == 'USDC' &&
+          amount.lessThan(USDC_MAINNET.decimals * 1000)
+        ) {
+          distributionPercent = 10
+        }
+        if (
+          currencyIn.symbol == 'USDC' &&
+          currencyOut.symbol == 'ETH' &&
+          amount.lessThan(JSBI.BigInt(WETH9[chainId].decimals * 0.5))
+        ) {
+          distributionPercent = 10
+        }
+        if (
+          currencyIn.symbol == 'USDC' &&
+          currencyOut.symbol == 'WETH' &&
+          amount.lessThan(JSBI.BigInt(WETH9[chainId].decimals * 0.5))
+        ) {
+          distributionPercent = 10
+        }
+      }
+
+      break
+    default:
+      throw new Error('Invalid swap type')
+  }
+
+  return distributionPercent
 }
 
 export async function tokenStringToCurrency(

--- a/lib/handlers/shared.ts
+++ b/lib/handlers/shared.ts
@@ -163,8 +163,7 @@ export const DISTRIBUTION_PERCENT_CONFIG = (
   currencyIn: Currency,
   currencyOut: Currency,
   type: string,
-  amountRaw: string,
-  log: Logger
+  amountRaw: string
 ) => {
   let distributionPercent = 5
   let amount: CurrencyAmount<Currency>
@@ -177,14 +176,14 @@ export const DISTRIBUTION_PERCENT_CONFIG = (
         if (
           currencyIn.wrapped.symbol == WETH9[chainId].symbol &&
           currencyOut.wrapped.symbol == USDC_MAINNET.symbol &&
-          amount.divide(amount.decimalScale).lessThan(new Fraction(1, 2))
+          amount.lessThan(new Fraction(1, 2).multiply(amount.decimalScale))
         ) {
           distributionPercent = 10
         }
         if (
           currencyIn.wrapped.symbol == USDC_MAINNET.symbol &&
           currencyOut.wrapped.symbol == WETH9[chainId].symbol &&
-          amount.divide(amount.decimalScale).lessThan(1000)
+          amount.lessThan(new Fraction(1000, 1).multiply(amount.decimalScale))
         ) {
           distributionPercent = 10
         }
@@ -198,14 +197,14 @@ export const DISTRIBUTION_PERCENT_CONFIG = (
         if (
           currencyIn.wrapped.symbol == WETH9[chainId].symbol &&
           currencyOut.wrapped.symbol == USDC_MAINNET.symbol &&
-          amount.divide(amount.decimalScale).lessThan(1000)
+          amount.lessThan(new Fraction(1000, 1).multiply(amount.decimalScale))
         ) {
           distributionPercent = 10
         }
         if (
           currencyIn.wrapped.symbol == USDC_MAINNET.symbol &&
           currencyOut.wrapped.symbol == WETH9[chainId].symbol &&
-          amount.divide(amount.decimalScale).lessThan(new Fraction(1, 2))
+          amount.lessThan(new Fraction(1, 2).multiply(amount.decimalScale))
         ) {
           distributionPercent = 10
         }

--- a/lib/handlers/shared.ts
+++ b/lib/handlers/shared.ts
@@ -175,29 +175,15 @@ export const DISTRIBUTION_PERCENT_CONFIG = (
 
       if (chainId == ChainId.MAINNET) {
         if (
-          currencyIn.symbol == WETH9[chainId].symbol &&
-          currencyOut.symbol == USDC_MAINNET.symbol &&
+          currencyIn.wrapped.symbol == WETH9[chainId].symbol &&
+          currencyOut.wrapped.symbol == USDC_MAINNET.symbol &&
           amount.lessThan(JSBI.BigInt(WETH9[chainId].decimals * 0.5))
         ) {
           distributionPercent = 10
         }
         if (
-          currencyIn.symbol == WETH9[chainId].symbol &&
-          currencyOut.symbol == USDC_MAINNET.symbol &&
-          amount.lessThan(JSBI.BigInt(WETH9[chainId].decimals * 0.5))
-        ) {
-          distributionPercent = 10
-        }
-        if (
-          currencyIn.symbol == USDC_MAINNET.symbol &&
-          currencyOut.symbol == 'ETH' &&
-          amount.lessThan(USDC_MAINNET.decimals * 1000)
-        ) {
-          distributionPercent = 10
-        }
-        if (
-          currencyIn.symbol == USDC_MAINNET.symbol &&
-          currencyOut.symbol == 'WETH' &&
+          currencyIn.wrapped.symbol == USDC_MAINNET.symbol &&
+          currencyOut.wrapped.symbol == WETH9[chainId].symbol &&
           amount.lessThan(USDC_MAINNET.decimals * 1000)
         ) {
           distributionPercent = 10
@@ -210,29 +196,15 @@ export const DISTRIBUTION_PERCENT_CONFIG = (
 
       if (chainId == ChainId.MAINNET) {
         if (
-          currencyIn.symbol == 'ETH' &&
-          currencyOut.symbol == 'USDC' &&
+          currencyIn.wrapped.symbol == WETH9[chainId].symbol &&
+          currencyOut.wrapped.symbol == USDC_MAINNET.symbol &&
           amount.lessThan(USDC_MAINNET.decimals * 1000)
         ) {
           distributionPercent = 10
         }
         if (
-          currencyIn.symbol == 'WETH' &&
-          currencyOut.symbol == 'USDC' &&
-          amount.lessThan(USDC_MAINNET.decimals * 1000)
-        ) {
-          distributionPercent = 10
-        }
-        if (
-          currencyIn.symbol == 'USDC' &&
-          currencyOut.symbol == 'ETH' &&
-          amount.lessThan(JSBI.BigInt(WETH9[chainId].decimals * 0.5))
-        ) {
-          distributionPercent = 10
-        }
-        if (
-          currencyIn.symbol == 'USDC' &&
-          currencyOut.symbol == 'WETH' &&
+          currencyIn.wrapped.symbol == USDC_MAINNET.symbol &&
+          currencyOut.wrapped.symbol == WETH9[chainId].symbol &&
           amount.lessThan(JSBI.BigInt(WETH9[chainId].decimals * 0.5))
         ) {
           distributionPercent = 10

--- a/lib/handlers/shared.ts
+++ b/lib/handlers/shared.ts
@@ -92,7 +92,7 @@ export const DEFAULT_ROUTING_CONFIG_BY_CHAIN = (chainId: ChainId): AlphaRouterCo
         maxSwapsPerPath: 3,
         minSplits: 1,
         maxSplits: 7,
-        distributionPercent: 5,
+        distributionPercent: 10,
         forceCrossProtocol: false,
       }
   }

--- a/lib/handlers/shared.ts
+++ b/lib/handlers/shared.ts
@@ -1,4 +1,4 @@
-import { ChainId, Currency, CurrencyAmount, Percent, WETH9 } from '@uniswap/sdk-core'
+import { ChainId, Currency, CurrencyAmount, Fraction, Percent, WETH9 } from '@uniswap/sdk-core'
 import {
   AlphaRouterConfig,
   ITokenListProvider,
@@ -177,14 +177,14 @@ export const DISTRIBUTION_PERCENT_CONFIG = (
         if (
           currencyIn.wrapped.symbol == WETH9[chainId].symbol &&
           currencyOut.wrapped.symbol == USDC_MAINNET.symbol &&
-          amount.lessThan(JSBI.BigInt(WETH9[chainId].decimals * 0.5))
+          amount.divide(WETH9[chainId].decimals).lessThan(new Fraction(1, 2))
         ) {
           distributionPercent = 10
         }
         if (
           currencyIn.wrapped.symbol == USDC_MAINNET.symbol &&
           currencyOut.wrapped.symbol == WETH9[chainId].symbol &&
-          amount.lessThan(USDC_MAINNET.decimals * 1000)
+          amount.divide(USDC_MAINNET.decimals).lessThan(1000)
         ) {
           distributionPercent = 10
         }
@@ -198,14 +198,14 @@ export const DISTRIBUTION_PERCENT_CONFIG = (
         if (
           currencyIn.wrapped.symbol == WETH9[chainId].symbol &&
           currencyOut.wrapped.symbol == USDC_MAINNET.symbol &&
-          amount.lessThan(USDC_MAINNET.decimals * 1000)
+          amount.divide(USDC_MAINNET.decimals).lessThan(100)
         ) {
           distributionPercent = 10
         }
         if (
           currencyIn.wrapped.symbol == USDC_MAINNET.symbol &&
           currencyOut.wrapped.symbol == WETH9[chainId].symbol &&
-          amount.lessThan(JSBI.BigInt(WETH9[chainId].decimals * 0.5))
+          amount.divide(WETH9[chainId].decimals).lessThan(new Fraction(1, 2))
         ) {
           distributionPercent = 10
         }

--- a/lib/handlers/shared.ts
+++ b/lib/handlers/shared.ts
@@ -22,9 +22,7 @@ export const DEFAULT_ROUTING_CONFIG_BY_CHAIN = (chainId: ChainId, currencyIn: Cu
   switch (type) {
     case 'exactIn':
       amount = CurrencyAmount.fromRawAmount(currencyIn, JSBI.BigInt(amountRaw))
-
-      log.error(`debug amount ${amount.toExact()}`)
-
+      
       if (chainId == ChainId.MAINNET) {
         if (currencyIn.symbol == WETH9[chainId].symbol && currencyOut.symbol == USDC_MAINNET.symbol && amount.lessThan(JSBI.BigInt(WETH9[chainId].decimals * 0.5))) {
           distributionPercent = 10;

--- a/lib/handlers/shared.ts
+++ b/lib/handlers/shared.ts
@@ -163,7 +163,8 @@ export const DISTRIBUTION_PERCENT_CONFIG = (
   currencyIn: Currency,
   currencyOut: Currency,
   type: string,
-  amountRaw: string
+  amountRaw: string,
+  log: Logger
 ) => {
   let distributionPercent = 5
   let amount: CurrencyAmount<Currency>
@@ -242,6 +243,13 @@ export const DISTRIBUTION_PERCENT_CONFIG = (
     default:
       throw new Error('Invalid swap type')
   }
+
+  log.info(`Distribution percent has changed to ${distributionPercent} for 
+      currency ${currencyIn.wrapped.symbol}
+      amount ${amount.toExact()}
+      quote currency ${currencyOut.wrapped.symbol}
+      trade type ${type}
+      chain id ${chainId}`)
 
   return distributionPercent
 }

--- a/lib/handlers/shared.ts
+++ b/lib/handlers/shared.ts
@@ -177,14 +177,14 @@ export const DISTRIBUTION_PERCENT_CONFIG = (
         if (
           currencyIn.wrapped.symbol == WETH9[chainId].symbol &&
           currencyOut.wrapped.symbol == USDC_MAINNET.symbol &&
-          amount.divide(WETH9[chainId].decimals).lessThan(new Fraction(1, 2))
+          amount.divide(amount.decimalScale).lessThan(new Fraction(1, 2))
         ) {
           distributionPercent = 10
         }
         if (
           currencyIn.wrapped.symbol == USDC_MAINNET.symbol &&
           currencyOut.wrapped.symbol == WETH9[chainId].symbol &&
-          amount.divide(USDC_MAINNET.decimals).lessThan(1000)
+          amount.divide(amount.decimalScale).lessThan(1000)
         ) {
           distributionPercent = 10
         }
@@ -198,14 +198,14 @@ export const DISTRIBUTION_PERCENT_CONFIG = (
         if (
           currencyIn.wrapped.symbol == WETH9[chainId].symbol &&
           currencyOut.wrapped.symbol == USDC_MAINNET.symbol &&
-          amount.divide(USDC_MAINNET.decimals).lessThan(100)
+          amount.divide(amount.decimalScale).lessThan(1000)
         ) {
           distributionPercent = 10
         }
         if (
           currencyIn.wrapped.symbol == USDC_MAINNET.symbol &&
           currencyOut.wrapped.symbol == WETH9[chainId].symbol &&
-          amount.divide(WETH9[chainId].decimals).lessThan(new Fraction(1, 2))
+          amount.divide(amount.decimalScale).lessThan(new Fraction(1, 2))
         ) {
           distributionPercent = 10
         }
@@ -215,13 +215,6 @@ export const DISTRIBUTION_PERCENT_CONFIG = (
     default:
       throw new Error('Invalid swap type')
   }
-
-  log.info(`Distribution percent has changed to ${distributionPercent} for 
-      currency ${currencyIn.wrapped.symbol}
-      amount ${amount.toExact()}
-      quote currency ${currencyOut.wrapped.symbol}
-      trade type ${type}
-      chain id ${chainId}`)
 
   return distributionPercent
 }

--- a/lib/handlers/shared.ts
+++ b/lib/handlers/shared.ts
@@ -1,4 +1,4 @@
-import { ChainId, Currency, CurrencyAmount, Percent } from '@uniswap/sdk-core'
+import { ChainId, Currency, CurrencyAmount, Fraction, Percent, WETH9 } from '@uniswap/sdk-core'
 import {
   AlphaRouterConfig,
   ITokenListProvider,
@@ -6,7 +6,7 @@ import {
   MapWithLowerCaseKey,
   NATIVE_NAMES_BY_ID,
   nativeOnChain,
-  ProtocolPoolSelection,
+  ProtocolPoolSelection, USDC_MAINNET
 } from '@uniswap/smart-order-router'
 import Logger from 'bunyan'
 import JSBI from 'jsbi'
@@ -15,40 +15,48 @@ export const SECONDS_PER_BLOCK_BY_CHAIN_ID: { [chainId in ChainId]?: number } = 
   [ChainId.MAINNET]: 30,
 }
 
-export const DEFAULT_ROUTING_CONFIG_BY_CHAIN = (chainId: ChainId, currencyIn: Currency, currencyOut: Currency, type: string, amountRaw: string): AlphaRouterConfig => {
+export const DEFAULT_ROUTING_CONFIG_BY_CHAIN = (chainId: ChainId, currencyIn: Currency, currencyOut: Currency, type: string, amountRaw: string, log: Logger): AlphaRouterConfig => {
   let distributionPercent = 5;
   let amount: CurrencyAmount<Currency>
 
   switch (type) {
     case 'exactIn':
       amount = CurrencyAmount.fromRawAmount(currencyIn, JSBI.BigInt(amountRaw))
-      if (currencyIn.symbol == 'ETH' && currencyOut.symbol == 'USDC' && amount.lessThan(JSBI.BigInt(0.5))) {
-        distributionPercent = 10;
-      }
-      if (currencyIn.symbol == 'WETH' && currencyOut.symbol == 'USDC' && amount.lessThan(JSBI.BigInt(0.5))) {
-        distributionPercent = 10;
-      }
-      if (currencyIn.symbol == 'USDC' && currencyOut.symbol == 'ETH' && amount.lessThan(JSBI.BigInt(1000))) {
-        distributionPercent = 10;
-      }
-      if (currencyIn.symbol == 'USDC' && currencyOut.symbol == 'WETH' && amount.lessThan(JSBI.BigInt(1000))) {
-        distributionPercent = 10;
+
+      log.error(`debug amount ${amount.toExact()}`)
+
+      if (chainId == ChainId.MAINNET) {
+        if (currencyIn.symbol == WETH9[chainId].symbol && currencyOut.symbol == USDC_MAINNET.symbol && amount.lessThan(JSBI.BigInt(WETH9[chainId].decimals * 0.5))) {
+          distributionPercent = 10;
+        }
+        if (currencyIn.symbol == WETH9[chainId].symbol && currencyOut.symbol == USDC_MAINNET.symbol && amount.lessThan(JSBI.BigInt(WETH9[chainId].decimals * 0.5))) {
+          distributionPercent = 10;
+        }
+        if (currencyIn.symbol == USDC_MAINNET.symbol && currencyOut.symbol == 'ETH' && amount.lessThan(USDC_MAINNET.decimals * 1000)) {
+          distributionPercent = 10;
+        }
+        if (currencyIn.symbol == USDC_MAINNET.symbol && currencyOut.symbol == 'WETH' && amount.lessThan(USDC_MAINNET.decimals * 1000)) {
+          distributionPercent = 10;
+        }
       }
 
       break
     case 'exactOut':
       amount = CurrencyAmount.fromRawAmount(currencyOut, JSBI.BigInt(amountRaw))
-      if (currencyIn.symbol == 'ETH' && currencyOut.symbol == 'USDC' && amount.lessThan(JSBI.BigInt(1000))) {
-        distributionPercent = 10;
-      }
-      if (currencyIn.symbol == 'WETH' && currencyOut.symbol == 'USDC' && amount.lessThan(JSBI.BigInt(1000))) {
-        distributionPercent = 10;
-      }
-      if (currencyIn.symbol == 'USDC' && currencyOut.symbol == 'ETH' && amount.lessThan(JSBI.BigInt(0.5))) {
-        distributionPercent = 10;
-      }
-      if (currencyIn.symbol == 'USDC' && currencyOut.symbol == 'WETH' && amount.lessThan(JSBI.BigInt(0.5))) {
-        distributionPercent = 10;
+
+      if (chainId == ChainId.MAINNET) {
+        if (currencyIn.symbol == 'ETH' && currencyOut.symbol == 'USDC' && amount.lessThan(USDC_MAINNET.decimals * 1000)) {
+          distributionPercent = 10;
+        }
+        if (currencyIn.symbol == 'WETH' && currencyOut.symbol == 'USDC' && amount.lessThan(USDC_MAINNET.decimals * 1000)) {
+          distributionPercent = 10;
+        }
+        if (currencyIn.symbol == 'USDC' && currencyOut.symbol == 'ETH' && amount.lessThan(JSBI.BigInt(WETH9[chainId].decimals * 0.5))) {
+          distributionPercent = 10;
+        }
+        if (currencyIn.symbol == 'USDC' && currencyOut.symbol == 'WETH' && amount.lessThan(JSBI.BigInt(WETH9[chainId].decimals * 0.5))) {
+          distributionPercent = 10;
+        }
       }
 
       break


### PR DESCRIPTION
## What?
We are permanently increasing the distribution percent for the most traded pairs in small trade size to speed up the `V3GetQuoteLoad` latencies, and hence E2E quote latencies on some alt-chains:
<img width="735" alt="Screenshot 2023-08-20 at 9 40 54 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/5e5bc3ed-7612-412c-a00c-98a402387c1e">


## Why?
Last time we had to revert, because we didn't know how many trade pairs will get impacted by this change. This time we have collected enough datapoints, so that we know it mostly affects the large trades.

## How?
This time we will increase the distribution percent from 5% to 10% permanently.

## Testing?
Last week we tested in prod for couple hours:
https://github.com/Uniswap/routing-api/pull/285
https://github.com/Uniswap/routing-api/pull/286

## Screenshots (optional)
We saw there was no negative impact to the quotes success rates for couple hour, so we knew this is a safe change.

## Anything Else?
N/A