### PR TITLE
Add padding on secondary key

### DIFF
--- a/lib/handlers/router-entities/route-caching/model/protocols-bucket-block-number.ts
+++ b/lib/handlers/router-entities/route-caching/model/protocols-bucket-block-number.ts
@@ -33,7 +33,7 @@ export class ProtocolsBucketBlockNumber {
       throw Error('BlockNumber is necessary to create a fullSecondaryKey')
     }
 
-    return `${this.protocols}/${this.blockNumber}/${this.bucket}`
+    return `${this.protocols}/${this.blockNumber}/${this.bucket.toString().padStart(10, '0')}`
   }
 
   public protocolsBucketPartialKey(): string {


### PR DESCRIPTION
The bucket in the secondary key might be affecting the sorting algorithm in dynamo. This padding should normalize it
