### PR TITLE
quote intent specific endpoint latencies

### DIFF
--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -545,7 +545,9 @@ export class QuoteHandler extends APIGLambdaHandler<
       chainId,
       amount,
       routeString,
-      swapRoute
+      swapRoute,
+      quoteSpeed,
+      intent,
     )
 
     return {
@@ -566,7 +568,9 @@ export class QuoteHandler extends APIGLambdaHandler<
     chainId: ChainId,
     amount: CurrencyAmount<Currency>,
     routeString: string,
-    swapRoute: SwapRoute
+    swapRoute: SwapRoute,
+    quoteSpeed?: string,
+    intent?: string,
   ): void {
     const tradingPair = `${currencyIn.wrapped.symbol}/${currencyOut.wrapped.symbol}`
     const wildcardInPair = `${currencyIn.wrapped.symbol}/*`
@@ -598,6 +602,14 @@ export class QuoteHandler extends APIGLambdaHandler<
         Date.now() - startTime,
         MetricLoggerUnit.Milliseconds
       )
+
+      metric.putMetric(`GET_QUOTE_LATENCY_CHAIN_${chainId}_${quoteSpeed ?? 'standard'}`,
+        Date.now() - startTime,
+        MetricLoggerUnit.Milliseconds)
+      metric.putMetric(`GET_QUOTE_LATENCY_CHAIN_${chainId}_${intent ?? 'quote'}`,
+        Date.now() - startTime,
+        MetricLoggerUnit.Milliseconds)
+
       // Create a hashcode from the routeString, this will indicate that a different route is being used
       // hashcode function copied from: https://gist.github.com/hyamamoto/fd435505d29ebfa3d9716fd2be8d42f0?permalink_comment_id=4261728#gistcomment-4261728
       const routeStringHash = Math.abs(

--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -547,7 +547,7 @@ export class QuoteHandler extends APIGLambdaHandler<
       routeString,
       swapRoute,
       quoteSpeed,
-      intent,
+      intent
     )
 
     return {
@@ -570,7 +570,7 @@ export class QuoteHandler extends APIGLambdaHandler<
     routeString: string,
     swapRoute: SwapRoute,
     quoteSpeed?: string,
-    intent?: string,
+    intent?: string
   ): void {
     const tradingPair = `${currencyIn.wrapped.symbol}/${currencyOut.wrapped.symbol}`
     const wildcardInPair = `${currencyIn.wrapped.symbol}/*`
@@ -603,12 +603,16 @@ export class QuoteHandler extends APIGLambdaHandler<
         MetricLoggerUnit.Milliseconds
       )
 
-      metric.putMetric(`GET_QUOTE_LATENCY_CHAIN_${chainId}_${quoteSpeed ?? 'standard'}`,
+      metric.putMetric(
+        `GET_QUOTE_LATENCY_CHAIN_${chainId}_${quoteSpeed ?? 'standard'}`,
         Date.now() - startTime,
-        MetricLoggerUnit.Milliseconds)
-      metric.putMetric(`GET_QUOTE_LATENCY_CHAIN_${chainId}_${intent ?? 'quote'}`,
+        MetricLoggerUnit.Milliseconds
+      )
+      metric.putMetric(
+        `GET_QUOTE_LATENCY_CHAIN_${chainId}_${intent ?? 'quote'}`,
         Date.now() - startTime,
-        MetricLoggerUnit.Milliseconds)
+        MetricLoggerUnit.Milliseconds
+      )
 
       // Create a hashcode from the routeString, this will indicate that a different route is being used
       // hashcode function copied from: https://gist.github.com/hyamamoto/fd435505d29ebfa3d9716fd2be8d42f0?permalink_comment_id=4261728#gistcomment-4261728

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@uniswap/permit2-sdk": "^1.2.0",
         "@uniswap/router-sdk": "^1.6.0",
         "@uniswap/sdk-core": "^4.0.3",
-        "@uniswap/smart-order-router": "3.16.10",
+        "@uniswap/smart-order-router": "3.16.11",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^1.5.7",
         "@uniswap/v2-sdk": "^3.2.0",
@@ -4310,9 +4310,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.16.10",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.16.10.tgz",
-      "integrity": "sha512-yBs7QvjkOUvrLkuz3g3ghIxeBoln9Wjw7s044eA8taSekmroUPBlZFAOSbUV/my1OV60XcXNOSOLyO1jpy+gMA==",
+      "version": "3.16.11",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.16.11.tgz",
+      "integrity": "sha512-8taRj79iOyQbKW4vutvpEenSA4guy5WVs/JUdvbSSXEkIaBsbH/dP9UH/mMRCI4fTDjIRiNShmyTMIHekr63Kw==",
       "dependencies": {
         "@uniswap/default-token-list": "^11.2.0",
         "@uniswap/permit2-sdk": "^1.2.0",
@@ -27386,9 +27386,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.16.10",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.16.10.tgz",
-      "integrity": "sha512-yBs7QvjkOUvrLkuz3g3ghIxeBoln9Wjw7s044eA8taSekmroUPBlZFAOSbUV/my1OV60XcXNOSOLyO1jpy+gMA==",
+      "version": "3.16.11",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.16.11.tgz",
+      "integrity": "sha512-8taRj79iOyQbKW4vutvpEenSA4guy5WVs/JUdvbSSXEkIaBsbH/dP9UH/mMRCI4fTDjIRiNShmyTMIHekr63Kw==",
       "requires": {
         "@uniswap/default-token-list": "^11.2.0",
         "@uniswap/permit2-sdk": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@uniswap/permit2-sdk": "^1.2.0",
     "@uniswap/router-sdk": "^1.6.0",
     "@uniswap/sdk-core": "^4.0.3",
-    "@uniswap/smart-order-router": "3.16.10",
+    "@uniswap/smart-order-router": "3.16.11",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^1.5.7",
     "@uniswap/v2-sdk": "^3.2.0",


### PR DESCRIPTION
## What?
We are releasing together:
- quote and intent specified endpoint-level latencies to see fast quote improvements, if any @jsy1218 
- sor topByETH* heuristics optimizations @mikeki 
- sor cached blocked token list in-memory mapping optimization @mikeki 

## Why?
We shipped both debugRoutingConfig endpoint as well as quoteFast endpoint. Don't seem to see the fast enough quote that we were expecting. We want to have more holistic view of the quoteFast endpoint with different quoteSpeed and intent query string params.
We know that topByETH* heuristics is slowing down the breaking of the for-loop in the subgraph pools. We want to see if we can make the loop break sooner if the topBaseNTokenInTokenOut luckily includes the topByETH*
On local profiling, it seems like cached block token list provider is also the perf bottleneck, so want to tackle together.

## How?
See Why

## Testing?
tried on my personal AWS account

## Screenshots (optional)
<img width="1222" alt="Screenshot 2023-08-24 at 7 46 09 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/a702515c-ad78-4d91-a0f6-535369a517f6">


## Anything Else?
N/A