### PR TITLE
instrument top level latencies and requests across cached routes hit vs non-cached routes hit

### DIFF
--- a/lib/handlers/handler.ts
+++ b/lib/handlers/handler.ts
@@ -224,9 +224,7 @@ export abstract class APIGLambdaHandler<CInj, RInj extends BaseRInj, ReqBody, Re
     )
   }
 
-  protected abstract afterHandler(metric: MetricsLogger,
-                                  response: Res,
-                                  requestStart: number): void
+  protected abstract afterHandler(metric: MetricsLogger, response: Res, requestStart: number): void
 
   public abstract handleRequest(
     params: HandleRequestParams<CInj, RInj, ReqBody, ReqQueryParams>
@@ -245,10 +243,10 @@ export abstract class APIGLambdaHandler<CInj, RInj extends BaseRInj, ReqBody, Re
     log: Logger
   ): Promise<
     | {
-    state: 'valid'
-    requestBody: ReqBody
-    requestQueryParams: ReqQueryParams
-  }
+        state: 'valid'
+        requestBody: ReqBody
+        requestQueryParams: ReqQueryParams
+      }
     | { state: 'invalid'; errorResponse: APIGatewayProxyResult }
   > {
     let bodyRaw: any

--- a/lib/handlers/handler.ts
+++ b/lib/handlers/handler.ts
@@ -108,132 +108,125 @@ export abstract class APIGLambdaHandler<CInj, RInj extends BaseRInj, ReqBody, Re
     }
   }
 
-  protected async processRequestInEntirety(
-    metric: MetricsLogger,
-    event: APIGatewayProxyEvent,
-    context: Context
-  ): Promise<[APIGatewayProxyResult, Res | null]> {
-    let log: Logger = bunyan.createLogger({
-      name: this.handlerName,
-      serializers: bunyan.stdSerializers,
-      level: bunyan.INFO,
-      requestId: context.awsRequestId,
-    })
-
-    const requestStart = Date.now()
-    log.info({ event, context }, 'Request started.')
-
-    let requestBody: ReqBody
-    let requestQueryParams: ReqQueryParams
-    try {
-      const requestValidation = await this.parseAndValidateRequest(event, log)
-
-      if (requestValidation.state == 'invalid') {
-        return [requestValidation.errorResponse, null]
-      }
-
-      requestBody = requestValidation.requestBody
-      requestQueryParams = requestValidation.requestQueryParams
-    } catch (err) {
-      log.error({ err }, 'Unexpected error validating request')
-      return [INTERNAL_ERROR(), null]
-    }
-
-    const injector = await this.injectorPromise
-
-    const containerInjected = await injector.getContainerInjected()
-
-    let requestInjected: RInj
-    try {
-      requestInjected = await injector.getRequestInjected(
-        containerInjected,
-        requestBody,
-        requestQueryParams,
-        event,
-        context,
-        log,
-        metric
-      )
-    } catch (err) {
-      log.error({ err, event }, 'Unexpected error building request injected.')
-      return [INTERNAL_ERROR(), null]
-    }
-
-    const { id } = requestInjected
-
-    ;({ log } = requestInjected)
-
-    let statusCode: number
-    let body: Res
-
-    try {
-      const handleRequestResult = await this.handleRequest({
-        context,
-        event,
-        requestBody,
-        requestQueryParams,
-        containerInjected,
-        requestInjected,
-      })
-
-      if (this.isError(handleRequestResult)) {
-        log.info({ handleRequestResult }, 'Handler did not return a 200')
-        const { statusCode, detail, errorCode } = handleRequestResult
-        const response = JSON.stringify({ detail, errorCode, id })
-
-        log.info({ statusCode, response }, `Request ended. ${statusCode}`)
-        return [
-          {
-            statusCode,
-            body: response,
-          },
-          null,
-        ]
-      } else {
-        log.info(
-          { requestBody, requestQueryParams, requestDuration: Date.now() - requestStart },
-          'Handler returned 200'
-        )
-        ;({ body, statusCode } = handleRequestResult)
-      }
-    } catch (err) {
-      log.error({ err }, 'Unexpected error in handler')
-      return [INTERNAL_ERROR(id), null]
-    }
-
-    let response: Res
-    try {
-      const responseValidation = await this.parseAndValidateResponse(body, id, log)
-
-      if (responseValidation.state == 'invalid') {
-        return [responseValidation.errorResponse, null]
-      }
-
-      response = responseValidation.response
-    } catch (err) {
-      log.error({ err }, 'Unexpected error validating response')
-      return [INTERNAL_ERROR(id), null]
-    }
-
-    log.info({ statusCode, response }, `Request ended. ${statusCode}`)
-    return [
-      {
-        statusCode,
-        body: JSON.stringify(response),
-      },
-      response,
-    ]
-  }
-
   private buildHandler(): APIGatewayProxyHandler {
     return metricScope(
       (metric: MetricsLogger) =>
         async (event: APIGatewayProxyEvent, context: Context): Promise<APIGatewayProxyResult> => {
-          const [apiGateyProxyResult, _] = await this.processRequestInEntirety(metric, event, context)
-          return apiGateyProxyResult
+          const requestStart = Date.now()
+
+          let log: Logger = bunyan.createLogger({
+            name: this.handlerName,
+            serializers: bunyan.stdSerializers,
+            level: bunyan.INFO,
+            requestId: context.awsRequestId,
+          })
+
+          log.info({ event, context }, 'Request started.')
+
+          let requestBody: ReqBody
+          let requestQueryParams: ReqQueryParams
+          try {
+            const requestValidation = await this.parseAndValidateRequest(event, log)
+
+            if (requestValidation.state == 'invalid') {
+              return requestValidation.errorResponse
+            }
+
+            requestBody = requestValidation.requestBody
+            requestQueryParams = requestValidation.requestQueryParams
+          } catch (err) {
+            log.error({ err }, 'Unexpected error validating request')
+            return INTERNAL_ERROR()
+          }
+
+          const injector = await this.injectorPromise
+
+          const containerInjected = await injector.getContainerInjected()
+
+          let requestInjected: RInj
+          try {
+            requestInjected = await injector.getRequestInjected(
+              containerInjected,
+              requestBody,
+              requestQueryParams,
+              event,
+              context,
+              log,
+              metric
+            )
+          } catch (err) {
+            log.error({ err, event }, 'Unexpected error building request injected.')
+            return INTERNAL_ERROR()
+          }
+
+          const { id } = requestInjected
+
+          ;({ log } = requestInjected)
+
+          let statusCode: number
+          let body: Res
+
+          try {
+            const handleRequestResult = await this.handleRequest({
+              context,
+              event,
+              requestBody,
+              requestQueryParams,
+              containerInjected,
+              requestInjected,
+            })
+
+            if (this.isError(handleRequestResult)) {
+              log.info({ handleRequestResult }, 'Handler did not return a 200')
+              const { statusCode, detail, errorCode } = handleRequestResult
+              const response = JSON.stringify({ detail, errorCode, id })
+
+              log.info({ statusCode, response }, `Request ended. ${statusCode}`)
+              return {
+                statusCode,
+                body: response,
+              }
+            } else {
+              log.info(
+                { requestBody, requestQueryParams, requestDuration: Date.now() - requestStart },
+                'Handler returned 200'
+              )
+              ;({ body, statusCode } = handleRequestResult)
+            }
+          } catch (err) {
+            log.error({ err }, 'Unexpected error in handler')
+            return INTERNAL_ERROR(id)
+          }
+
+          let response: Res
+          try {
+            const responseValidation = await this.parseAndValidateResponse(body, id, log)
+
+            if (responseValidation.state == 'invalid') {
+              return responseValidation.errorResponse
+            }
+
+            response = responseValidation.response
+          } catch (err) {
+            log.error({ err }, 'Unexpected error validating response')
+            return INTERNAL_ERROR(id)
+          }
+
+          log.info({ statusCode, response }, `Request ended. ${statusCode}`)
+
+          this.afterHandler(metric, response, requestStart)
+
+          return {
+            statusCode,
+            body: JSON.stringify(response),
+          }
         }
     )
   }
+
+  protected abstract afterHandler(metric: MetricsLogger,
+                                  response: Res,
+                                  requestStart: number): void
 
   public abstract handleRequest(
     params: HandleRequestParams<CInj, RInj, ReqBody, ReqQueryParams>
@@ -252,10 +245,10 @@ export abstract class APIGLambdaHandler<CInj, RInj extends BaseRInj, ReqBody, Re
     log: Logger
   ): Promise<
     | {
-        state: 'valid'
-        requestBody: ReqBody
-        requestQueryParams: ReqQueryParams
-      }
+    state: 'valid'
+    requestBody: ReqBody
+    requestQueryParams: ReqQueryParams
+  }
     | { state: 'invalid'; errorResponse: APIGatewayProxyResult }
   > {
     let bodyRaw: any

--- a/lib/handlers/handler.ts
+++ b/lib/handlers/handler.ts
@@ -224,7 +224,7 @@ export abstract class APIGLambdaHandler<CInj, RInj extends BaseRInj, ReqBody, Re
     )
   }
 
-  protected abstract afterHandler(metric: MetricsLogger, response: Res, requestStart: number): void
+  protected afterHandler(_: MetricsLogger, __: Res, ___: number): void {}
 
   public abstract handleRequest(
     params: HandleRequestParams<CInj, RInj, ReqBody, ReqQueryParams>

--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -73,7 +73,9 @@ export interface RequestInjected<Router> extends BaseRInj {
   v2PoolProvider: IV2PoolProvider
   tokenProvider: ITokenProvider
   tokenListProvider: ITokenListProvider
-  router: Router
+  router: Router,
+  quoteSpeed?: string,
+  intent?: string,
 }
 
 export type ContainerDependencies = {

--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -73,9 +73,9 @@ export interface RequestInjected<Router> extends BaseRInj {
   v2PoolProvider: IV2PoolProvider
   tokenProvider: ITokenProvider
   tokenListProvider: ITokenListProvider
-  router: Router,
-  quoteSpeed?: string,
-  intent?: string,
+  router: Router
+  quoteSpeed?: string
+  intent?: string
 }
 
 export type ContainerDependencies = {

--- a/lib/handlers/quote/injector.ts
+++ b/lib/handlers/quote/injector.ts
@@ -37,7 +37,7 @@ export class QuoteHandlerInjector extends InjectorSOR<
     // to capture Tapcompare logs in the smart-order-router.
     const logLevel = Math.random() < 0.1 ? bunyan.INFO : bunyan.WARN
 
-    const { tokenInAddress, tokenInChainId, tokenOutAddress, amount, type, algorithm, gasPriceWei } = requestQueryParams
+    const { tokenInAddress, tokenInChainId, tokenOutAddress, amount, type, algorithm, gasPriceWei, quoteSpeed, intent } = requestQueryParams
 
     log = log.child({
       serializers: bunyan.stdSerializers,
@@ -126,6 +126,8 @@ export class QuoteHandlerInjector extends InjectorSOR<
       v2PoolProvider,
       tokenProvider,
       tokenListProvider,
+      quoteSpeed,
+      intent,
     }
   }
 }

--- a/lib/handlers/quote/injector.ts
+++ b/lib/handlers/quote/injector.ts
@@ -37,7 +37,17 @@ export class QuoteHandlerInjector extends InjectorSOR<
     // to capture Tapcompare logs in the smart-order-router.
     const logLevel = Math.random() < 0.1 ? bunyan.INFO : bunyan.WARN
 
-    const { tokenInAddress, tokenInChainId, tokenOutAddress, amount, type, algorithm, gasPriceWei, quoteSpeed, intent } = requestQueryParams
+    const {
+      tokenInAddress,
+      tokenInChainId,
+      tokenOutAddress,
+      amount,
+      type,
+      algorithm,
+      gasPriceWei,
+      quoteSpeed,
+      intent,
+    } = requestQueryParams
 
     log = log.child({
       serializers: bunyan.stdSerializers,

--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -35,6 +35,8 @@ import { simulationStatusToString } from './util/simulation'
 import Logger from 'bunyan'
 import { PAIRS_TO_TRACK } from './util/pairs-to-track'
 import { measureDistributionPercentChangeImpact } from '../../util/alpha-config-measurement'
+import { MetricsLogger } from 'aws-embedded-metrics'
+import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from 'aws-lambda'
 
 export class QuoteHandler extends APIGLambdaHandler<
   ContainerInjected,
@@ -646,5 +648,39 @@ export class QuoteHandler extends APIGLambdaHandler<
 
   protected responseBodySchema(): Joi.ObjectSchema | null {
     return QuoteResponseSchemaJoi
+  }
+
+  protected override async processRequestInEntirety(
+    metric: MetricsLogger,
+    event: APIGatewayProxyEvent,
+    context: Context
+  ): Promise<[APIGatewayProxyResult, QuoteResponse | null]> {
+    const topLevelRequestStartTime = Date.now()
+
+    const aggregateResult = await super.processRequestInEntirety(metric, event, context)
+    const [_, quoteResponseOrNull] = aggregateResult
+
+    // fwiw, we are only interested in a completed request, not a failed one
+    // there are many reasons the top-level request processing can fail,
+    // including input validations, etc.
+    // Our focus on is the investigation of the top-level quote latencies,
+    // so we should focus on the successful ones
+    if (quoteResponseOrNull) {
+      // once the metric is here,
+      // it already got instantiated in the base handler,
+      // with the same namespace as in the quote handler
+      metric.putMetric(
+        `GET_QUOTE_LATENCY_TOP_LEVEL_${quoteResponseOrNull.hitsCache ? 'CACHED_ROUTES_HIT' : 'CACHED_ROUTES_MISS'}`,
+        Date.now() - topLevelRequestStartTime,
+        MetricLoggerUnit.Milliseconds
+      )
+      metric.putMetric(
+        `GET_QUOTE_REQUESTED_TOP_LEVEL_${quoteResponseOrNull.hitsCache ? 'CACHED_ROUTES_HIT' : 'CACHED_ROUTES_MISS'}`,
+        1,
+        MetricLoggerUnit.Count
+      )
+    }
+
+    return aggregateResult
   }
 }

--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -647,7 +647,7 @@ export class QuoteHandler extends APIGLambdaHandler<
 
   protected afterHandler(metric: MetricsLogger, response: QuoteResponse, requestStart: number): void {
     metric.putMetric(
-      `GET_QUOTE_LATENCY_TOP_LEVEL_${response.hitsCache ? 'CACHED_ROUTES_HIT' : 'CACHED_ROUTES_MISS'}`,
+      `GET_QUOTE_LATENCY_TOP_LEVEL_${response.hitsCachedRoutes ? 'CACHED_ROUTES_HIT' : 'CACHED_ROUTES_MISS'}`,
       Date.now() - requestStart,
       MetricLoggerUnit.Milliseconds
     )

--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -557,7 +557,7 @@ export class QuoteHandler extends APIGLambdaHandler<
       chainId,
       amount,
       routeString,
-      swapRoute,
+      swapRoute
     )
 
     return {
@@ -578,7 +578,7 @@ export class QuoteHandler extends APIGLambdaHandler<
     chainId: ChainId,
     amount: CurrencyAmount<Currency>,
     routeString: string,
-    swapRoute: SwapRoute,
+    swapRoute: SwapRoute
   ): void {
     const tradingPair = `${currencyIn.wrapped.symbol}/${currencyOut.wrapped.symbol}`
     const wildcardInPair = `${currencyIn.wrapped.symbol}/*`

--- a/lib/handlers/schema.ts
+++ b/lib/handlers/schema.ts
@@ -81,5 +81,5 @@ export type QuoteResponse = {
   route: Array<(V3PoolInRoute | V2PoolInRoute)[]>
   routeString: string
   methodParameters?: MethodParameters
-  hitsCache?: boolean
+  hitsCachedRoutes?: boolean
 }

--- a/lib/handlers/schema.ts
+++ b/lib/handlers/schema.ts
@@ -81,4 +81,5 @@ export type QuoteResponse = {
   route: Array<(V3PoolInRoute | V2PoolInRoute)[]>
   routeString: string
   methodParameters?: MethodParameters
+  hitsCache?: boolean
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@uniswap/permit2-sdk": "^1.2.0",
         "@uniswap/router-sdk": "^1.6.0",
         "@uniswap/sdk-core": "^4.0.3",
-        "@uniswap/smart-order-router": "3.16.12",
+        "@uniswap/smart-order-router": "3.16.13",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^1.5.7",
         "@uniswap/v2-sdk": "^3.2.0",
@@ -4310,9 +4310,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.16.12",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.16.12.tgz",
-      "integrity": "sha512-8kgU04eTjX0qmX/88Qibc2CZmTgkBVbVQKx0CcP+CfiuDR1/Qzw2YoQt2Pzz5sEI6pCiO8XLLIM+/v9vXdqI6g==",
+      "version": "3.16.13",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.16.13.tgz",
+      "integrity": "sha512-hurUvX6l6LncKNX2EuIai5gbMI5TpJvpYGst69iu5zFMRGflMLj6i8oTwOHWlSBWDZtZk1CvRjAftSdkZ2yQ+w==",
       "dependencies": {
         "@uniswap/default-token-list": "^11.2.0",
         "@uniswap/permit2-sdk": "^1.2.0",
@@ -27386,9 +27386,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.16.12",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.16.12.tgz",
-      "integrity": "sha512-8kgU04eTjX0qmX/88Qibc2CZmTgkBVbVQKx0CcP+CfiuDR1/Qzw2YoQt2Pzz5sEI6pCiO8XLLIM+/v9vXdqI6g==",
+      "version": "3.16.13",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.16.13.tgz",
+      "integrity": "sha512-hurUvX6l6LncKNX2EuIai5gbMI5TpJvpYGst69iu5zFMRGflMLj6i8oTwOHWlSBWDZtZk1CvRjAftSdkZ2yQ+w==",
       "requires": {
         "@uniswap/default-token-list": "^11.2.0",
         "@uniswap/permit2-sdk": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@uniswap/permit2-sdk": "^1.2.0",
     "@uniswap/router-sdk": "^1.6.0",
     "@uniswap/sdk-core": "^4.0.3",
-    "@uniswap/smart-order-router": "3.16.12",
+    "@uniswap/smart-order-router": "3.16.13",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^1.5.7",
     "@uniswap/v2-sdk": "^3.2.0",


### PR DESCRIPTION
We are instrumenting at the truly top-request level, because we suspect there's some levels of lambda cold start in the static initialization and “lazy” initialization.

Tested on personal AWS account, and see the metrics:
<img width="1209" alt="Screenshot 2023-08-25 at 11 25 00 AM" src="https://github.com/Uniswap/routing-api/assets/91580504/dcfe5ad2-6b59-47d8-bf84-d01e2111a997">

We are also releasing:
https://github.com/Uniswap/smart-order-router/pull/358
https://github.com/Uniswap/smart-order-router/pull/366
https://github.com/Uniswap/smart-order-router/pull/367
