### PR TITLE
Allow Routing API to re-use connetions to DDB/S3

### DIFF
--- a/bin/stacks/routing-lambda-stack.ts
+++ b/bin/stacks/routing-lambda-stack.ts
@@ -87,6 +87,9 @@ export class RoutingLambdaStack extends cdk.NestedStack {
         minify: true,
         sourceMap: true,
       },
+
+      awsSdkConnectionReuse: true,
+
       description: 'Routing Lambda',
       environment: {
         VERSION: '5',


### PR DESCRIPTION
By default, AWS will close all TCP connections to their services (S3, DDB, etc) on request completion. Keep these open across requests to avoid unnecessary connection time. 