### PR TITLE
Fix metric for blocks difference

### DIFF
--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -364,7 +364,8 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
 
     log.info({ cachedRoutes }, `[DynamoRouteCachingProvider] Returning the cached and unmarshalled route.`)
 
-    const blocksDifference = currentBlockNumber - blockNumber
+    // Normalize blocks difference, if the route is from a new block (which could happen in L2s), consider it same block
+    const blocksDifference = Math.max(0, currentBlockNumber - blockNumber)
     metric.putMetric(`${cachedRoutesSource}BlockDifference`, blocksDifference, MetricLoggerUnit.Count)
     metric.putMetric(
       `${cachedRoutesSource}BlockDifference_${ID_TO_NETWORK_NAME(chainId)}`,


### PR DESCRIPTION
When the sample is a negative number the metrics go haywaire, so we should normalize to 0 if that's a route from a newer block
