### PR TITLE
Allow expired cachedRoutes to be returned

### DIFF
--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -261,14 +261,9 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
       metric.putMetric(`RoutesDbExpired`, 1, MetricLoggerUnit.Count)
     }
 
-    if (
-      optimistic && // If we are in optimistic mode
-      notExpiredCachedRoute // and the cachedRoutes are not expired (if they are expired, the regular request will insert cache)
-    ) {
-      // We send an async caching quote
-      // we do not await on this function, it's a fire and forget
-      this.maybeSendCachingQuoteForRoutesDb(partitionKey, amount)
-    }
+    // We send an async caching quote
+    // we do not await on this function, it's a fire and forget
+    this.maybeSendCachingQuoteForRoutesDb(partitionKey, amount)
 
     return cachedRoutes
   }
@@ -362,10 +357,6 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
    * @protected
    */
   protected async _setCachedRoute(cachedRoutes: CachedRoutes): Promise<boolean> {
-    return await this.insertRoutesDbEntry(cachedRoutes)
-  }
-
-  private async insertRoutesDbEntry(cachedRoutes: CachedRoutes): Promise<boolean> {
     const routesDbEntries = cachedRoutes.routes.map((route) => {
       const individualCachedRoutes = new CachedRoutes({
         routes: [route],
@@ -441,6 +432,14 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
     _protocols: Protocol[]
   ): Promise<CacheMode> {
     return this.DEFAULT_CACHEMODE_ROUTES_DB
+  }
+
+  protected override filterExpiredCachedRoutes(
+    cachedRoutes: CachedRoutes | undefined,
+    _blockNumber: number,
+    _optimistic: boolean
+  ): CachedRoutes | undefined {
+    return cachedRoutes
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@uniswap/permit2-sdk": "^1.2.0",
         "@uniswap/router-sdk": "^1.6.0",
         "@uniswap/sdk-core": "^4.0.3",
-        "@uniswap/smart-order-router": "3.16.18",
+        "@uniswap/smart-order-router": "3.16.19",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^1.5.7",
         "@uniswap/v2-sdk": "^3.2.0",
@@ -4310,9 +4310,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.16.18",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.16.18.tgz",
-      "integrity": "sha512-KM1CNYv2RGD3/ufuZ6m6xoq7dkXEYtH/zDAhN4i03nPRTp3E6zI7MnrdG/sqann1jWsmOFw3cCisNeIlcPmcJQ==",
+      "version": "3.16.19",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.16.19.tgz",
+      "integrity": "sha512-yGeU1QO6GPCWy42+j98L+/gFsjCmxBsyoJoD8R/5RVNK+EReXzQGrUyWbXG2r0bmuAkzn7sqrh0W3OzgDyUuPA==",
       "dependencies": {
         "@uniswap/default-token-list": "^11.2.0",
         "@uniswap/permit2-sdk": "^1.2.0",
@@ -27386,9 +27386,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.16.18",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.16.18.tgz",
-      "integrity": "sha512-KM1CNYv2RGD3/ufuZ6m6xoq7dkXEYtH/zDAhN4i03nPRTp3E6zI7MnrdG/sqann1jWsmOFw3cCisNeIlcPmcJQ==",
+      "version": "3.16.19",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.16.19.tgz",
+      "integrity": "sha512-yGeU1QO6GPCWy42+j98L+/gFsjCmxBsyoJoD8R/5RVNK+EReXzQGrUyWbXG2r0bmuAkzn7sqrh0W3OzgDyUuPA==",
       "requires": {
         "@uniswap/default-token-list": "^11.2.0",
         "@uniswap/permit2-sdk": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@uniswap/permit2-sdk": "^1.2.0",
     "@uniswap/router-sdk": "^1.6.0",
     "@uniswap/sdk-core": "^4.0.3",
-    "@uniswap/smart-order-router": "3.16.18",
+    "@uniswap/smart-order-router": "3.16.19",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^1.5.7",
     "@uniswap/v2-sdk": "^3.2.0",


### PR DESCRIPTION
As a way to increase our cache coverage, we are considering increasing our allowed cachedRoutes.

Previously if the cachedRoute was expired we would ignore it and cause a cache miss, now if the cached route is expired we will allow it.
There's a curent change in SOR that would instead change the cacheMode to `Tapcompare` when that route is expired, so this will not impact current behavior, but we will start collecting metrics about misquotes

We will use those metrics to make a go/no-go decision
