### PR TITLE
Sample more frequently for caching requests

### DIFF
--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -293,11 +293,11 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
       metric.putMetric('CachingQuoteForRoutesDbCheck', 1, MetricLoggerUnit.Count)
 
       const result = await this.ddbClient.query(queryParams).promise()
-      const shouldSendCachingRequest = result.Items && (
-        result.Items.length == 0 || // no caching request has been sent recently
-        // or there are less than 2 samples for the given block in the range of the amount
-        result.Items.filter(record => (record.blockNumber ?? 0) >= currentBlockNumber).length < 2
-      )
+      const shouldSendCachingRequest =
+        result.Items &&
+        (result.Items.length == 0 || // no caching request has been sent recently
+          // or there are less than 2 samples for the given block in the range of the amount
+          result.Items.filter((record) => (record.blockNumber ?? 0) >= currentBlockNumber).length < 2)
 
       // if no Item is found it means we need to send a caching request
       if (shouldSendCachingRequest) {
@@ -352,7 +352,7 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
         pairTradeTypeChainId: partitionKey.toString(),
         amount: parseFloat(amount.toExact()),
         ttl: Math.floor(Date.now() / 1000) + this.ROUTES_DB_FLAG_TTL,
-        blockNumber: currentBlockNumber
+        blockNumber: currentBlockNumber,
       },
     }
 

--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -263,14 +263,15 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
 
     // We send an async caching quote
     // we do not await on this function, it's a fire and forget
-    this.maybeSendCachingQuoteForRoutesDb(partitionKey, amount)
+    this.maybeSendCachingQuoteForRoutesDb(partitionKey, amount, currentBlockNumber)
 
     return cachedRoutes
   }
 
   private async maybeSendCachingQuoteForRoutesDb(
     partitionKey: PairTradeTypeChainId,
-    amount: CurrencyAmount<Currency>
+    amount: CurrencyAmount<Currency>,
+    currentBlockNumber: number
   ): Promise<void> {
     try {
       const queryParams = {
@@ -292,12 +293,17 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
       metric.putMetric('CachingQuoteForRoutesDbCheck', 1, MetricLoggerUnit.Count)
 
       const result = await this.ddbClient.query(queryParams).promise()
+      const shouldSendCachingRequest = result.Items && (
+        result.Items.length == 0 || // no caching request has been sent recently
+        // or there are less than 3 routes from the current block number
+        result.Items.filter(record => (record.blockNumber ?? 0) >= currentBlockNumber).length < 3
+      )
 
       // if no Item is found it means we need to send a caching request
-      if (result.Items && result.Items.length == 0) {
+      if (shouldSendCachingRequest) {
         metric.putMetric('CachingQuoteForRoutesDbRequestSent', 1, MetricLoggerUnit.Count)
         this.sendAsyncCachingRequest(partitionKey, [Protocol.V2, Protocol.V3, Protocol.MIXED], amount)
-        this.setRoutesDbCachingIntentFlag(partitionKey, amount)
+        this.setRoutesDbCachingIntentFlag(partitionKey, amount, currentBlockNumber)
       } else {
         metric.putMetric('CachingQuoteForRoutesDbRequestNotNeeded', 1, MetricLoggerUnit.Count)
       }
@@ -335,14 +341,18 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
     this.lambdaClient.invoke(params).promise()
   }
 
-  private setRoutesDbCachingIntentFlag(partitionKey: PairTradeTypeChainId, amount: CurrencyAmount<Currency>): void {
+  private setRoutesDbCachingIntentFlag(
+    partitionKey: PairTradeTypeChainId,
+    amount: CurrencyAmount<Currency>,
+    currentBlockNumber: number
+  ): void {
     const putParams = {
       TableName: this.routesCachingRequestFlagTableName,
       Item: {
         pairTradeTypeChainId: partitionKey.toString(),
         amount: parseFloat(amount.toExact()),
         ttl: Math.floor(Date.now() / 1000) + this.ROUTES_DB_FLAG_TTL,
-        caching: true,
+        blockNumber: currentBlockNumber
       },
     }
 

--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -296,8 +296,8 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
       const shouldSendCachingRequest =
         result.Items &&
         (result.Items.length == 0 || // no caching request has been sent recently
-          // or there are less than 2 samples for the given block in the range of the amount
-          result.Items.filter((record) => (record.blockNumber ?? 0) >= currentBlockNumber).length < 2)
+          // or there is not a single sample for the current block
+          result.Items.every((record) => (record.blockNumber ?? 0) < currentBlockNumber))
 
       // if no Item is found it means we need to send a caching request
       if (shouldSendCachingRequest) {

--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -295,8 +295,8 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
       const result = await this.ddbClient.query(queryParams).promise()
       const shouldSendCachingRequest = result.Items && (
         result.Items.length == 0 || // no caching request has been sent recently
-        // or there are less than 3 routes from the current block number
-        result.Items.filter(record => (record.blockNumber ?? 0) >= currentBlockNumber).length < 3
+        // or there are less than 2 samples for the given block in the range of the amount
+        result.Items.filter(record => (record.blockNumber ?? 0) >= currentBlockNumber).length < 2
       )
 
       // if no Item is found it means we need to send a caching request


### PR DESCRIPTION
Previously we would only sample for a given amount every time the flag was missing. This change will now force our RoutesDb to have atleast 1 samples for a given bucket in the same block
