### PR TITLE
remove obsolete RouteCachingDB and CacheReqFlagDB

### DIFF
--- a/bin/stacks/routing-api-stack.ts
+++ b/bin/stacks/routing-api-stack.ts
@@ -82,8 +82,6 @@ export class RoutingAPIStack extends cdk.Stack {
     const {
       routesDynamoDb,
       routesDbCachingRequestFlagDynamoDb,
-      cachedRoutesDynamoDb,
-      cachingRequestFlagDynamoDb,
       cachedV3PoolsDynamoDb,
       cachedV2PairsDynamoDb,
     } = new RoutingDatabaseStack(this, 'RoutingDatabaseStack', {})
@@ -102,8 +100,6 @@ export class RoutingAPIStack extends cdk.Stack {
       tenderlyAccessKey,
       routesDynamoDb,
       routesDbCachingRequestFlagDynamoDb,
-      cachedRoutesDynamoDb,
-      cachingRequestFlagDynamoDb,
       cachedV3PoolsDynamoDb,
       cachedV2PairsDynamoDb,
       unicornSecret,

--- a/bin/stacks/routing-api-stack.ts
+++ b/bin/stacks/routing-api-stack.ts
@@ -79,12 +79,8 @@ export class RoutingAPIStack extends cdk.Stack {
       hosted_zone,
     })
 
-    const {
-      routesDynamoDb,
-      routesDbCachingRequestFlagDynamoDb,
-      cachedV3PoolsDynamoDb,
-      cachedV2PairsDynamoDb,
-    } = new RoutingDatabaseStack(this, 'RoutingDatabaseStack', {})
+    const { routesDynamoDb, routesDbCachingRequestFlagDynamoDb, cachedV3PoolsDynamoDb, cachedV2PairsDynamoDb } =
+      new RoutingDatabaseStack(this, 'RoutingDatabaseStack', {})
 
     const { routingLambda, routingLambdaAlias } = new RoutingLambdaStack(this, 'RoutingLambdaStack', {
       poolCacheBucket,

--- a/bin/stacks/routing-database-stack.ts
+++ b/bin/stacks/routing-database-stack.ts
@@ -16,16 +16,6 @@ export const DynamoDBTableProps = {
     PartitionKeyName: 'pairTradeTypeChainId',
     SortKeyName: 'amount',
   },
-  CacheRouteDynamoDbTable: {
-    Name: 'RouteCachingDB',
-    PartitionKeyName: 'pairTradeTypeChainId',
-    SortKeyName: 'protocolsBucketBlockNumber',
-  },
-  CachingRequestFlagDynamoDbTable: {
-    Name: 'CacheReqFlagDB',
-    PartitionKeyName: 'pairTradeTypeChainId',
-    SortKeyName: 'protocolsBucketBlockNumber',
-  },
   V3PoolsDynamoDbTable: {
     Name: 'V3PoolsCachingDB',
     PartitionKeyName: 'poolAddress',
@@ -42,8 +32,6 @@ export const DynamoDBTableProps = {
 export class RoutingDatabaseStack extends cdk.NestedStack {
   public readonly routesDynamoDb: aws_dynamodb.Table
   public readonly routesDbCachingRequestFlagDynamoDb: aws_dynamodb.Table
-  public readonly cachedRoutesDynamoDb: aws_dynamodb.Table
-  public readonly cachingRequestFlagDynamoDb: aws_dynamodb.Table
   public readonly cachedV3PoolsDynamoDb: aws_dynamodb.Table
   public readonly cachedV2PairsDynamoDb: aws_dynamodb.Table
 
@@ -70,31 +58,6 @@ export class RoutingDatabaseStack extends cdk.NestedStack {
           type: AttributeType.STRING,
         },
         sortKey: { name: DynamoDBTableProps.RoutesDbCachingRequestFlagTable.SortKeyName, type: AttributeType.NUMBER },
-        billingMode: BillingMode.PAY_PER_REQUEST,
-        timeToLiveAttribute: DynamoDBTableProps.TTLAttributeName,
-      }
-    )
-
-    // Creates a DynamoDB Table for storing the cached routes
-    this.cachedRoutesDynamoDb = new aws_dynamodb.Table(this, DynamoDBTableProps.CacheRouteDynamoDbTable.Name, {
-      tableName: DynamoDBTableProps.CacheRouteDynamoDbTable.Name,
-      partitionKey: { name: DynamoDBTableProps.CacheRouteDynamoDbTable.PartitionKeyName, type: AttributeType.STRING },
-      sortKey: { name: DynamoDBTableProps.CacheRouteDynamoDbTable.SortKeyName, type: AttributeType.STRING },
-      billingMode: BillingMode.PAY_PER_REQUEST,
-      timeToLiveAttribute: DynamoDBTableProps.TTLAttributeName,
-    })
-
-    // Creates a DynamoDB Table for storing the buckets that are flagging as already cached in the CachedRoutesDb
-    this.cachingRequestFlagDynamoDb = new aws_dynamodb.Table(
-      this,
-      DynamoDBTableProps.CachingRequestFlagDynamoDbTable.Name,
-      {
-        tableName: DynamoDBTableProps.CachingRequestFlagDynamoDbTable.Name,
-        partitionKey: {
-          name: DynamoDBTableProps.CachingRequestFlagDynamoDbTable.PartitionKeyName,
-          type: AttributeType.STRING,
-        },
-        sortKey: { name: DynamoDBTableProps.CachingRequestFlagDynamoDbTable.SortKeyName, type: AttributeType.STRING },
         billingMode: BillingMode.PAY_PER_REQUEST,
         timeToLiveAttribute: DynamoDBTableProps.TTLAttributeName,
       }

--- a/bin/stacks/routing-lambda-stack.ts
+++ b/bin/stacks/routing-lambda-stack.ts
@@ -28,8 +28,6 @@ export interface RoutingLambdaStackProps extends cdk.NestedStackProps {
   chatbotSNSArn?: string
   routesDynamoDb: aws_dynamodb.Table
   routesDbCachingRequestFlagDynamoDb: aws_dynamodb.Table
-  cachedRoutesDynamoDb: aws_dynamodb.Table
-  cachingRequestFlagDynamoDb: aws_dynamodb.Table
   cachedV3PoolsDynamoDb: aws_dynamodb.Table
   cachedV2PairsDynamoDb: aws_dynamodb.Table
   unicornSecret: string
@@ -54,8 +52,6 @@ export class RoutingLambdaStack extends cdk.NestedStack {
       tenderlyAccessKey,
       routesDynamoDb,
       routesDbCachingRequestFlagDynamoDb,
-      cachedRoutesDynamoDb,
-      cachingRequestFlagDynamoDb,
       cachedV3PoolsDynamoDb,
       cachedV2PairsDynamoDb,
       unicornSecret,
@@ -75,8 +71,6 @@ export class RoutingLambdaStack extends cdk.NestedStack {
     tokenListCacheBucket.grantRead(lambdaRole)
     routesDynamoDb.grantReadWriteData(lambdaRole)
     routesDbCachingRequestFlagDynamoDb.grantReadWriteData(lambdaRole)
-    cachedRoutesDynamoDb.grantReadWriteData(lambdaRole)
-    cachingRequestFlagDynamoDb.grantReadWriteData(lambdaRole)
     cachedV3PoolsDynamoDb.grantReadWriteData(lambdaRole)
     cachedV2PairsDynamoDb.grantReadWriteData(lambdaRole)
 
@@ -112,8 +106,6 @@ export class RoutingLambdaStack extends cdk.NestedStack {
         TENDERLY_ACCESS_KEY: tenderlyAccessKey,
         ROUTES_TABLE_NAME: DynamoDBTableProps.RoutesDbTable.Name,
         ROUTES_CACHING_REQUEST_FLAG_TABLE_NAME: DynamoDBTableProps.RoutesDbCachingRequestFlagTable.Name,
-        CACHED_ROUTES_TABLE_NAME: DynamoDBTableProps.CacheRouteDynamoDbTable.Name,
-        CACHING_REQUEST_FLAG_TABLE_NAME: DynamoDBTableProps.CachingRequestFlagDynamoDbTable.Name,
         CACHED_V3_POOLS_TABLE_NAME: DynamoDBTableProps.V3PoolsDynamoDbTable.Name,
         V2_PAIRS_CACHE_TABLE_NAME: DynamoDBTableProps.V2PairsDynamoCache.Name,
         UNICORN_SECRET: unicornSecret,


### PR DESCRIPTION
After cleaning up the code references to obsolete RouteCachingDB and CacheReqFlagDB  in https://github.com/Uniswap/routing-api/pull/342, we see there's zero prod traffic:

<img width="1337" alt="Screenshot 2023-08-31 at 3 52 52 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/903751ab-ec66-4d91-b1c4-d94af50791c1">
<img width="1327" alt="Screenshot 2023-08-31 at 3 52 45 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/aa9cf0b6-9dcd-4125-a8a7-81c626f938ea">

Next is to remove the table from the CDK stack.