### PR TITLE
Adding comments on important configuration

### DIFF
--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -261,6 +261,8 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
       metric.putMetric(`RoutesDbExpired`, 1, MetricLoggerUnit.Count)
     }
 
+    // Caching requests are not `optimistic`, we need to be careful of not removing this flag
+    // This condition is protecting us against firing another caching request from inside a caching request
     if (optimistic) {
       // We send an async caching quote
       // we do not await on this function, it's a fire and forget

--- a/lib/handlers/shared.ts
+++ b/lib/handlers/shared.ts
@@ -142,6 +142,7 @@ export const INTENT_SPECIFIC_CONFIG: { [key: string]: IntentSpecificConfig } = {
   caching: {
     // When the intent is to create a cache entry, we should not use the cache
     useCachedRoutes: false,
+    // This is *super* important to avoid an infinite loop of caching quotes calling themselves
     optimisticCachedRoutes: false,
   },
   quote: {


### PR DESCRIPTION
We are going to implement Tapcompare for caching requests, but we need to make sure we avoid an infinte loop of lambdas calling themselves.