### PR TITLE
ProvisionedConcurrency back to 500

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -193,7 +193,7 @@ export class RoutingAPIPipeline extends Stack {
       env: { account: '606857263320', region: 'us-east-2' },
       jsonRpcProviders: jsonRpcProviders,
       internalApiKey: internalApiKey.secretValue.toString(),
-      provisionedConcurrency: 350,
+      provisionedConcurrency: 500,
       ethGasStationInfoUrl: ethGasStationInfoUrl.secretValue.toString(),
       chatbotSNSArn: 'arn:aws:sns:us-east-2:644039819003:SlackChatbotTopic',
       stage: STAGE.PROD,


### PR DESCRIPTION
I've been noticing some spottiness in the metrics after we reduced the provisioned concurrency, so I'm going back to the previous setting.
