### PR TITLE
Expose enableFeeOnTransferFeeFetching query string param

### DIFF
--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -134,6 +134,7 @@ export class QuoteHandler extends APIGLambdaHandler<
         debugRoutingConfig,
         unicornSecret,
         intent,
+        enableFeeOnTransferFeeFetching,
       },
       requestInjected: {
         router,
@@ -241,6 +242,7 @@ export class QuoteHandler extends APIGLambdaHandler<
       ...(quoteSpeed ? QUOTE_SPEED_CONFIG[quoteSpeed] : {}),
       ...parsedDebugRoutingConfig,
       ...(intent ? INTENT_SPECIFIC_CONFIG[intent] : {}),
+      ... (enableFeeOnTransferFeeFetching ? { enableFeeOnTransferFeeFetching } : {}),
     }
 
     metric.putMetric(`${intent}Intent`, 1, MetricLoggerUnit.Count)

--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -242,7 +242,7 @@ export class QuoteHandler extends APIGLambdaHandler<
       ...(quoteSpeed ? QUOTE_SPEED_CONFIG[quoteSpeed] : {}),
       ...parsedDebugRoutingConfig,
       ...(intent ? INTENT_SPECIFIC_CONFIG[intent] : {}),
-      ... (enableFeeOnTransferFeeFetching ? { enableFeeOnTransferFeeFetching } : {}),
+      ...(enableFeeOnTransferFeeFetching ? { enableFeeOnTransferFeeFetching } : {}),
     }
 
     metric.putMetric(`${intent}Intent`, 1, MetricLoggerUnit.Count)

--- a/lib/handlers/quote/schema/quote-schema.ts
+++ b/lib/handlers/quote/schema/quote-schema.ts
@@ -61,6 +61,7 @@ export const QuoteQueryParamsJoi = Joi.object({
   debugRoutingConfig: Joi.string().optional(),
   unicornSecret: Joi.string().optional(),
   intent: Joi.string().valid('quote', 'swap', 'caching', 'pricing').optional().default('quote'),
+  enableFeeOnTransferFeeFetching: Joi.boolean().optional().default(false),
 }).and('recipient', 'slippageTolerance', 'deadline')
 
 export type QuoteQueryParams = {
@@ -90,4 +91,5 @@ export type QuoteQueryParams = {
   debugRoutingConfig?: string
   unicornSecret?: string
   intent?: string
+  enableFeeOnTransferFeeFetching?: boolean
 }


### PR DESCRIPTION
Interface already fetches fee-on-transfer tax and shave off the quote amount. We need to protect smart-order-router  fee-on-transfer tax [feature](https://github.com/Uniswap/smart-order-router/pull/395/files) under a feature flag, so that interface doesn't double FOT tax.