### PR TITLE
correct clock skew limited to aws token list provider only

### DIFF
--- a/lib/handlers/router-entities/aws-token-list-provider.ts
+++ b/lib/handlers/router-entities/aws-token-list-provider.ts
@@ -18,7 +18,7 @@ export class AWSTokenListProvider extends CachingTokenListProvider {
     bucket: string,
     tokenListURI: string
   ): Promise<ITokenListProvider & ITokenProvider> {
-    const s3 = new S3({ correctClockSkew: true })
+    const s3 = new S3({ correctClockSkew: true, maxRetries: 3 })
 
     const cachedTokenList = TOKEN_LIST_CACHE.get<TokenList>(tokenListURI)
 

--- a/lib/handlers/router-entities/aws-token-list-provider.ts
+++ b/lib/handlers/router-entities/aws-token-list-provider.ts
@@ -18,7 +18,7 @@ export class AWSTokenListProvider extends CachingTokenListProvider {
     bucket: string,
     tokenListURI: string
   ): Promise<ITokenListProvider & ITokenProvider> {
-    const s3 = new S3()
+    const s3 = new S3({ correctClockSkew: true })
 
     const cachedTokenList = TOKEN_LIST_CACHE.get<TokenList>(tokenListURI)
 


### PR DESCRIPTION
we can use maxRetries = 3/maxAttempts = 4, since this retry only happens during lambda instantiation time. Cold start is better than constantly failing lambda, that makes routing-api down. We've seen bad routing-api downtime due to s3 clock skew within routing lambda during instantiation time.