### PR TITLE
aws subgraph provider use correct clock skew

### DIFF
--- a/lib/handlers/router-entities/aws-subgraph-provider.ts
+++ b/lib/handlers/router-entities/aws-subgraph-provider.ts
@@ -13,6 +13,7 @@ import { S3_POOL_CACHE_KEY } from '../../util/pool-cache-key'
 
 const POOL_CACHE = new NodeCache({ stdTTL: 240, useClones: false })
 const LOCAL_POOL_CACHE_KEY = (chainId: ChainId, protocol: Protocol) => `pools${chainId}#${protocol}`
+const s3 = new S3({ correctClockSkew: true, maxRetries: 1 })
 
 export class AWSSubgraphProvider<TSubgraphPool extends V2SubgraphPool | V3SubgraphPool> {
   constructor(private chain: ChainId, private protocol: Protocol, private bucket: string, private baseKey: string) {}
@@ -36,7 +37,6 @@ export class AWSSubgraphProvider<TSubgraphPool extends V2SubgraphPool | V3Subgra
       `Subgraph pools local cache miss for protocol ${this.protocol}. Getting subgraph pools from S3`
     )
 
-    const s3 = new S3({ correctClockSkew: true })
 
     const pools = await cachePoolsFromS3<TSubgraphPool>(s3, this.bucket, this.baseKey, this.chain, this.protocol)
 
@@ -82,7 +82,6 @@ export class V3AWSSubgraphProvider extends AWSSubgraphProvider<V3SubgraphPool> i
   }
 
   public static async EagerBuild(bucket: string, baseKey: string, chainId: ChainId): Promise<V3AWSSubgraphProvider> {
-    const s3 = new S3({ correctClockSkew: true })
     await cachePoolsFromS3<V3SubgraphPool>(s3, bucket, baseKey, chainId, Protocol.V3)
 
     return new V3AWSSubgraphProvider(chainId, bucket, baseKey)
@@ -95,7 +94,6 @@ export class V2AWSSubgraphProvider extends AWSSubgraphProvider<V2SubgraphPool> i
   }
 
   public static async EagerBuild(bucket: string, baseKey: string, chainId: ChainId): Promise<V2AWSSubgraphProvider> {
-    const s3 = new S3({ correctClockSkew: true })
     await cachePoolsFromS3<V2SubgraphPool>(s3, bucket, baseKey, chainId, Protocol.V2)
 
     return new V2AWSSubgraphProvider(chainId, bucket, baseKey)

--- a/lib/handlers/router-entities/aws-subgraph-provider.ts
+++ b/lib/handlers/router-entities/aws-subgraph-provider.ts
@@ -37,7 +37,6 @@ export class AWSSubgraphProvider<TSubgraphPool extends V2SubgraphPool | V3Subgra
       `Subgraph pools local cache miss for protocol ${this.protocol}. Getting subgraph pools from S3`
     )
 
-
     const pools = await cachePoolsFromS3<TSubgraphPool>(s3, this.bucket, this.baseKey, this.chain, this.protocol)
 
     return pools

--- a/lib/handlers/router-entities/aws-subgraph-provider.ts
+++ b/lib/handlers/router-entities/aws-subgraph-provider.ts
@@ -36,7 +36,7 @@ export class AWSSubgraphProvider<TSubgraphPool extends V2SubgraphPool | V3Subgra
       `Subgraph pools local cache miss for protocol ${this.protocol}. Getting subgraph pools from S3`
     )
 
-    const s3 = new S3()
+    const s3 = new S3({ correctClockSkew: true})
 
     const pools = await cachePoolsFromS3<TSubgraphPool>(s3, this.bucket, this.baseKey, this.chain, this.protocol)
 
@@ -82,7 +82,7 @@ export class V3AWSSubgraphProvider extends AWSSubgraphProvider<V3SubgraphPool> i
   }
 
   public static async EagerBuild(bucket: string, baseKey: string, chainId: ChainId): Promise<V3AWSSubgraphProvider> {
-    const s3 = new S3()
+    const s3 = new S3({ correctClockSkew: true})
     await cachePoolsFromS3<V3SubgraphPool>(s3, bucket, baseKey, chainId, Protocol.V3)
 
     return new V3AWSSubgraphProvider(chainId, bucket, baseKey)
@@ -95,7 +95,7 @@ export class V2AWSSubgraphProvider extends AWSSubgraphProvider<V2SubgraphPool> i
   }
 
   public static async EagerBuild(bucket: string, baseKey: string, chainId: ChainId): Promise<V2AWSSubgraphProvider> {
-    const s3 = new S3()
+    const s3 = new S3({ correctClockSkew: true})
     await cachePoolsFromS3<V2SubgraphPool>(s3, bucket, baseKey, chainId, Protocol.V2)
 
     return new V2AWSSubgraphProvider(chainId, bucket, baseKey)

--- a/lib/handlers/router-entities/aws-subgraph-provider.ts
+++ b/lib/handlers/router-entities/aws-subgraph-provider.ts
@@ -36,7 +36,7 @@ export class AWSSubgraphProvider<TSubgraphPool extends V2SubgraphPool | V3Subgra
       `Subgraph pools local cache miss for protocol ${this.protocol}. Getting subgraph pools from S3`
     )
 
-    const s3 = new S3({ correctClockSkew: true})
+    const s3 = new S3({ correctClockSkew: true })
 
     const pools = await cachePoolsFromS3<TSubgraphPool>(s3, this.bucket, this.baseKey, this.chain, this.protocol)
 
@@ -82,7 +82,7 @@ export class V3AWSSubgraphProvider extends AWSSubgraphProvider<V3SubgraphPool> i
   }
 
   public static async EagerBuild(bucket: string, baseKey: string, chainId: ChainId): Promise<V3AWSSubgraphProvider> {
-    const s3 = new S3({ correctClockSkew: true})
+    const s3 = new S3({ correctClockSkew: true })
     await cachePoolsFromS3<V3SubgraphPool>(s3, bucket, baseKey, chainId, Protocol.V3)
 
     return new V3AWSSubgraphProvider(chainId, bucket, baseKey)
@@ -95,7 +95,7 @@ export class V2AWSSubgraphProvider extends AWSSubgraphProvider<V2SubgraphPool> i
   }
 
   public static async EagerBuild(bucket: string, baseKey: string, chainId: ChainId): Promise<V2AWSSubgraphProvider> {
-    const s3 = new S3({ correctClockSkew: true})
+    const s3 = new S3({ correctClockSkew: true })
     await cachePoolsFromS3<V2SubgraphPool>(s3, bucket, baseKey, chainId, Protocol.V2)
 
     return new V2AWSSubgraphProvider(chainId, bucket, baseKey)


### PR DESCRIPTION
We only see request clock skew in routing lambda fetching subgraph pools from s3 in the normal quote path, [log insights](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:logs-insights$3FqueryDetail$3D~(end~0~start~-3600~timeType~'RELATIVE~unit~'seconds~editorString~'fields*20*40timestamp*2c*20*40message*2c*20*40logStream*2c*20*40log*0a*7c*20filter*20*40message*20like*20*27The*20difference*20between*20the*20request*20time*20and*20the*20current*20time*20is*20too*20large*27*0a*7c*20sort*20*40timestamp*20desc~queryId~'3717b579fb703-fa61eb13-4b25139-cd23cee0-9749051fbd25664239e5e~source~(~'*2faws*2flambda*2fprod-us-east-2-RoutingAPI-Ro-RoutingLambdaF7AD8A1A-erFTueZgLnZ1~'*2faws*2flambda*2fprod-us-east-2-RoutingAPI-R-RoutingLambda2C4DF0900-Bbcx5MI4vlM6~'*2faws*2flambda*2fprod-us-east-2-RoutingAPI-TokenListCacheLambda8F76-fB00godEz7sh))):

<img width="1124" alt="Screenshot 2023-09-13 at 1 24 49 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/d47a88bf-37e9-46c1-b6e1-49bb47f888cd">

We are trying to pass `correctClockSkew` to see if this error will go away.

Also we will monitor the subgraph pools load carefully, since `correctClockSkew` code comment says: 

> Whether to apply a clock skew correction and retry requests that fail because of an skewed client clock

Unfortunately I can't find the corresponding source code in https://github.com/aws/aws-sdk-js-v3 to cross check