### PR TITLE
Chore: add WETH/BITBOY pool caching logging for debugging

### DIFF
--- a/lib/handlers/pools/pool-caching/v2/v2-dynamo-cache.ts
+++ b/lib/handlers/pools/pool-caching/v2/v2-dynamo-cache.ts
@@ -99,13 +99,16 @@ export class V2DynamoCache implements ICache<{ pair: Pair; block?: number }> {
         // Finally we unmarshal that JSON into a `Pair` object
         const pair = PairMarshaller.unmarshal(pairJson)
 
-        if (record.cacheKey === "pool-1-0xA802E152244c6eC47F9a0337F4E62E47B6d6A2d0") {
-            const fakeError = new Error();
-            log.error({ fakeError }, `[V2DynamoCache] We are retrieving WETH/BITBOY pool. We are debugging to see the pair object values.
+        if (record.cacheKey === 'pool-1-0xA802E152244c6eC47F9a0337F4E62E47B6d6A2d0') {
+          const fakeError = new Error()
+          log.error(
+            { fakeError },
+            `[V2DynamoCache] We are retrieving WETH/BITBOY pool. We are debugging to see the pair object values.
             key: ${key}
             value: ${JSON.stringify(pair)}
             block: ${record.block}
-            stackTrace: ${fakeError.stack}`)
+            stackTrace: ${fakeError.stack}`
+          )
         }
 
         return {
@@ -131,13 +134,16 @@ export class V2DynamoCache implements ICache<{ pair: Pair; block?: number }> {
       log.error('[V2DynamoCache] We can only cache values with a block number')
       return false
     } else {
-      if (key === "pool-1-0xA802E152244c6eC47F9a0337F4E62E47B6d6A2d0") {
-        const fakeError = new Error();
-        log.error({ fakeError }, `[V2DynamoCache] We are caching WETH/BITBOY pool. We are debugging to see the pair object values.
+      if (key === 'pool-1-0xA802E152244c6eC47F9a0337F4E62E47B6d6A2d0') {
+        const fakeError = new Error()
+        log.error(
+          { fakeError },
+          `[V2DynamoCache] We are caching WETH/BITBOY pool. We are debugging to see the pair object values.
             key: ${key}
             value: ${JSON.stringify(value.pair)}
             block: ${value.block}
-            stackTrace: ${fakeError.stack}`)
+            stackTrace: ${fakeError.stack}`
+        )
       }
 
       // Marshal the Pair object in preparation for storing in DynamoDB

--- a/lib/handlers/pools/pool-caching/v2/v2-dynamo-cache.ts
+++ b/lib/handlers/pools/pool-caching/v2/v2-dynamo-cache.ts
@@ -89,6 +89,7 @@ export class V2DynamoCache implements ICache<{ pair: Pair; block?: number }> {
 
       if (result.Items && result.Items.length > 0) {
         const record = result.Items[0]
+
         // If we got a response with more than 1 item, we extract the binary field from the response
         const itemBinary = record.item
         // Then we convert it into a Buffer
@@ -96,8 +97,19 @@ export class V2DynamoCache implements ICache<{ pair: Pair; block?: number }> {
         // We convert that buffer into string and parse as JSON (it was encoded as JSON when it was inserted into cache)
         const pairJson = JSON.parse(pairBuffer.toString())
         // Finally we unmarshal that JSON into a `Pair` object
+        const pair = PairMarshaller.unmarshal(pairJson)
+
+        if (record.cacheKey === "pool-1-0xA802E152244c6eC47F9a0337F4E62E47B6d6A2d0") {
+            const fakeError = new Error();
+            log.error({ fakeError }, `[V2DynamoCache] We are retrieving WETH/BITBOY pool. We are debugging to see the pair object values.
+            key: ${key}
+            value: ${JSON.stringify(pair)}
+            block: ${record.block}
+            stackTrace: ${fakeError.stack}`)
+        }
+
         return {
-          pair: PairMarshaller.unmarshal(pairJson),
+          pair: pair,
           block: record.block,
         }
       } else {
@@ -119,6 +131,15 @@ export class V2DynamoCache implements ICache<{ pair: Pair; block?: number }> {
       log.error('[V2DynamoCache] We can only cache values with a block number')
       return false
     } else {
+      if (key === "pool-1-0xA802E152244c6eC47F9a0337F4E62E47B6d6A2d0") {
+        const fakeError = new Error();
+        log.error({ fakeError }, `[V2DynamoCache] We are caching WETH/BITBOY pool. We are debugging to see the pair object values.
+            key: ${key}
+            value: ${JSON.stringify(value.pair)}
+            block: ${value.block}
+            stackTrace: ${fakeError.stack}`)
+      }
+
       // Marshal the Pair object in preparation for storing in DynamoDB
       const marshalledPair = PairMarshaller.marshal(value.pair)
       // Convert the marshalledPair to JSON string


### PR DESCRIPTION
Aside from the [FeeOnTransferDetector](https://etherscan.io/address/0x19C97dc2a25845C7f9d1d519c8C2d4809c58b43f#code) on-chain contract call failures, we want to make sure sor doesn't hide any other bug that doesn't set the FOT tax. I had a chance to retrieve a WETH/BITBOY pool caching from prod RA dynamo table, that has not BITBOY FOT tax:

| cacheKey  | block | item | TTL |
| ------------- | ------------- |------------- | ------------- |
| pool-1-0xA802E152244c6eC47F9a0337F4E62E47B6d6A2d0  | 18217380  | eyJwcm90b2NvbCI6IlYyIiwiY3VycmVuY3lBbW91bnRBIjp7ImN1cnJlbmN5Ijp7ImNoYWluSWQiOjEsImFkZHJlc3MiOiIweDRBNTAwRUQ2YWRkNTk5NDU2OUU2NjQyNjU4ODE2ODcwNUZjQzk3NjciLCJkZWNpbWFscyI6MTgsInN5bWJvbCI6IkJJVEJPWSJ9LCJudW1lcmF0b3IiOiI0ODAyNDkyNDg5Njk3MTAyNjc3MjAzOTg1NTIiLCJkZW5vbWluYXRvciI6IjEifSwidG9rZW5BbW91bnRCIjp7ImN1cnJlbmN5Ijp7ImNoYWluSWQiOjEsImFkZHJlc3MiOiIweEMwMmFhQTM5YjIyM0ZFOEQwQTBlNUM0RjI3ZUFEOTA4M0M3NTZDYzIiLCJkZWNpbWFscyI6MTgsInN5bWJvbCI6IldFVEgiLCJuYW1lIjoiV3JhcHBlZCBFdGhlciJ9LCJudW1lcmF0b3IiOiIxNzQ4NzQ0MDc1MDA1Nzk1OTQ0IiwiZGVub21pbmF0b3IiOiIxIn19 | 1695700241 |

This means we can add WETH/BITBOY specific debugging logging, that logs the call stacktrace as well. Coupled with the request Id, we can confirm if it's due to the same [FeeOnTransferDetector](https://etherscan.io/address/0x19C97dc2a25845C7f9d1d519c8C2d4809c58b43f#code) on-chain contract call failures, or if sor has other hidden bug.

<img width="1253" alt="Screenshot 2023-09-26 at 5 39 05 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/cbf909b1-a4ce-4889-aa9e-417aada68205">

