### PR TITLE
Chore: remove not use cached routes for fot flag & Revert "Chore: add WETH/BITBOY pool caching logging for debugging 

### DIFF
--- a/lib/handlers/pools/pool-caching/v2/v2-dynamo-cache.ts
+++ b/lib/handlers/pools/pool-caching/v2/v2-dynamo-cache.ts
@@ -89,7 +89,6 @@ export class V2DynamoCache implements ICache<{ pair: Pair; block?: number }> {
 
       if (result.Items && result.Items.length > 0) {
         const record = result.Items[0]
-
         // If we got a response with more than 1 item, we extract the binary field from the response
         const itemBinary = record.item
         // Then we convert it into a Buffer
@@ -97,22 +96,8 @@ export class V2DynamoCache implements ICache<{ pair: Pair; block?: number }> {
         // We convert that buffer into string and parse as JSON (it was encoded as JSON when it was inserted into cache)
         const pairJson = JSON.parse(pairBuffer.toString())
         // Finally we unmarshal that JSON into a `Pair` object
-        const pair = PairMarshaller.unmarshal(pairJson)
-
-        if (record.cacheKey === 'pool-1-0xA802E152244c6eC47F9a0337F4E62E47B6d6A2d0') {
-          const fakeError = new Error()
-          log.error(
-            { fakeError },
-            `[V2DynamoCache] We are retrieving WETH/BITBOY pool. We are debugging to see the pair object values.
-            key: ${key}
-            value: ${JSON.stringify(pair)}
-            block: ${record.block}
-            stackTrace: ${fakeError.stack}`
-          )
-        }
-
         return {
-          pair: pair,
+          pair: PairMarshaller.unmarshal(pairJson),
           block: record.block,
         }
       } else {
@@ -134,18 +119,6 @@ export class V2DynamoCache implements ICache<{ pair: Pair; block?: number }> {
       log.error('[V2DynamoCache] We can only cache values with a block number')
       return false
     } else {
-      if (key === 'pool-1-0xA802E152244c6eC47F9a0337F4E62E47B6d6A2d0') {
-        const fakeError = new Error()
-        log.error(
-          { fakeError },
-          `[V2DynamoCache] We are caching WETH/BITBOY pool. We are debugging to see the pair object values.
-            key: ${key}
-            value: ${JSON.stringify(value.pair)}
-            block: ${value.block}
-            stackTrace: ${fakeError.stack}`
-        )
-      }
-
       // Marshal the Pair object in preparation for storing in DynamoDB
       const marshalledPair = PairMarshaller.marshal(value.pair)
       // Convert the marshalledPair to JSON string

--- a/lib/handlers/shared.ts
+++ b/lib/handlers/shared.ts
@@ -164,21 +164,12 @@ export const INTENT_SPECIFIC_CONFIG: { [key: string]: IntentSpecificConfig } = {
 
 export type FeeOnTransferSpecificConfig = {
   enableFeeOnTransferFeeFetching?: boolean
-  useCachedRoutes?: boolean
 }
 
-// TODO: ROUTE-86 - remove useCachedRoutes: !enableFeeOnTransferFeeFetching once we are ready to consume from RoutesDB
-// We cannot consume from RoutesDB for getting the FOT tax from v2 cached routes yet,
-// because RoutesDB has 24hrs TTL, and routing-api no longer filters unexpired routers.
-// So during interface & mobile e2e testing, it won't work if the fot quote hits the cached routes read path.
-// We allow writing into RoutesDB but not reading from it, if enableFeeOnTransferFeeFetching is true.
 export const FEE_ON_TRANSFER_SPECIFIC_CONFIG = (
   enableFeeOnTransferFeeFetching?: boolean
 ): FeeOnTransferSpecificConfig => {
   return {
-    // if enableFeeOnTransferFeeFetching is true, then we do not use cached routes for read path
-    // if enableFeeOnTransferFeeFetching is false or undefined, then we use cached routes for read path
-    useCachedRoutes: !enableFeeOnTransferFeeFetching,
     enableFeeOnTransferFeeFetching: enableFeeOnTransferFeeFetching,
   } as FeeOnTransferSpecificConfig
 }


### PR DESCRIPTION
In prod, ever since we enabled always fetching FOT fees for caching pool entities (https://github.com/Uniswap/smart-order-router/pull/415), the Infura RPC calls went up dramatically:

<img width="1226" alt="Screenshot 2023-09-27 at 11 21 05 AM" src="https://github.com/Uniswap/routing-api/assets/91580504/810ef326-6c0b-4469-b979-a7c3f90e3925">

Also, V2PoolsLoad latencies have increased due to the same change:

<img width="1459" alt="Screenshot 2023-09-27 at 11 21 16 AM" src="https://github.com/Uniswap/routing-api/assets/91580504/42631a3e-5c2e-4460-b60f-7ac03dc44b7c">

Those were expected, since we are ensuring FOT quote stability/correctness over the latencies. So now, FOT quote will need to leverage the RoutesDB to improve perf as well as reduce infura RPC calls.