### PR TITLE
Chore: remove the test assertion that useCachedRoutes is negate of enableFeeOnTransferFeeFetching

### DIFF
--- a/test/mocha/integ/quote.test.ts
+++ b/test/mocha/integ/quote.test.ts
@@ -1061,7 +1061,7 @@ describe('quote', function () {
               for (const response of responses) {
                 const {
                   enableFeeOnTransferFeeFetching,
-                  data: { quote, quoteDecimals, quoteGasAdjustedDecimals, methodParameters, route, hitsCachedRoutes },
+                  data: { quote, quoteDecimals, quoteGasAdjustedDecimals, methodParameters, route },
                   status,
                 } = response
 

--- a/test/mocha/integ/quote.test.ts
+++ b/test/mocha/integ/quote.test.ts
@@ -1066,9 +1066,6 @@ describe('quote', function () {
                 } = response
 
                 expect(status).to.equal(200)
-                // not hitting cached routes when we send enableFeeOnTransferFeeFetching = true is important
-                // during QA internal testing
-                expect(hitsCachedRoutes).to.equal(!enableFeeOnTransferFeeFetching)
 
                 if (type == 'exactIn') {
                   expect(parseFloat(quoteGasAdjustedDecimals)).to.be.lessThanOrEqual(parseFloat(quoteDecimals))


### PR DESCRIPTION
Follow-up for https://github.com/Uniswap/routing-api/pull/378. We can no longer assert useCachedRoutes === !enableFeeOnTransferFeeFetching, since the test runtime may or may not hit cached routes with randomness.