### PR TITLE
Revert "Revert "Skips FOT test (#382)""

### DIFF
--- a/test/mocha/integ/quote.test.ts
+++ b/test/mocha/integ/quote.test.ts
@@ -1025,7 +1025,7 @@ describe('quote', function () {
                 // If this test fails sporadically, dev needs to investigate further
                 // There could be genuine regressions in the form of race condition, due to complex layers of caching
                 // See https://github.com/Uniswap/smart-order-router/pull/415#issue-1914604864 as an example race condition
-                it.skip(`fee-on-transfer BULLET -> WETH`, async () => {
+                it(`fee-on-transfer BULLET -> WETH`, async () => {
                   const enableFeeOnTransferFeeFetching = [true, false, undefined]
                   // we want to swap the tokenIn/tokenOut order so that we can test both sellFeeBps and buyFeeBps for exactIn vs exactOut
                   const originalAmount = tokenIn.equals(WETH9[ChainId.MAINNET]!) ? '10' : '893517'


### PR DESCRIPTION
This reverts commit c1e1dfb4ff67388c9e2e3d91adecbee746206b5a.

We want to re-enable FOT integ-test, now that we know that this revert https://github.com/Uniswap/routing-api/pull/383 unblocked the release pipeline.