### PR TITLE
Chore: bump sor to 3.17.2 in routing-api & improve routing-api FOT integ-test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@uniswap/permit2-sdk": "^1.2.0",
         "@uniswap/router-sdk": "^1.6.0",
         "@uniswap/sdk-core": "^4.0.7",
-        "@uniswap/smart-order-router": "3.17.1",
+        "@uniswap/smart-order-router": "3.17.2",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^1.5.8",
         "@uniswap/v2-sdk": "^3.2.1",
@@ -4310,9 +4310,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.17.1.tgz",
-      "integrity": "sha512-Ol17EMZv7A3KyEGgq5feL78o5u1SYc5LmNvg3FASq6m8SlgZN7XiirNZic9WNwYoHk2I7gTM3PMKFyik5XrkEw==",
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.17.2.tgz",
+      "integrity": "sha512-N5AuS5WgzT8/P9bDCPv5OPWEB8RXkJLQEHAFFZKYrghOGdxkba8u0qPdSrE8tgYqhLTA8Babou1shrX5aS//Vw==",
       "dependencies": {
         "@uniswap/default-token-list": "^11.2.0",
         "@uniswap/permit2-sdk": "^1.2.0",
@@ -4322,7 +4322,7 @@
         "@uniswap/token-lists": "^1.0.0-beta.31",
         "@uniswap/universal-router": "^1.0.1",
         "@uniswap/universal-router-sdk": "^1.5.8",
-        "@uniswap/v2-sdk": "^3.2.2",
+        "@uniswap/v2-sdk": "^3.2.3",
         "@uniswap/v3-sdk": "^3.10.0",
         "async-retry": "^1.3.1",
         "await-timeout": "^1.1.1",
@@ -4481,9 +4481,9 @@
       }
     },
     "node_modules/@uniswap/v2-sdk": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@uniswap/v2-sdk/-/v2-sdk-3.2.2.tgz",
-      "integrity": "sha512-FyFEQPfNMXhG9i2M8AfowBhMqq44GzhaKU9wpCS6ancI3T+wg89hycTUXONIjsRm5WnpqmvQY73nGUK7T17RMw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@uniswap/v2-sdk/-/v2-sdk-3.2.3.tgz",
+      "integrity": "sha512-MEGNfd8hAvelDpXhKkgyKUycXVDWkabSUGg0VZvLB+WGtJ8c6wz44K/fABKfn00npWCAztUyIToEn7NlZSxEkg==",
       "dependencies": {
         "@ethersproject/address": "^5.0.0",
         "@ethersproject/solidity": "^5.0.0",
@@ -27386,9 +27386,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.17.1.tgz",
-      "integrity": "sha512-Ol17EMZv7A3KyEGgq5feL78o5u1SYc5LmNvg3FASq6m8SlgZN7XiirNZic9WNwYoHk2I7gTM3PMKFyik5XrkEw==",
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.17.2.tgz",
+      "integrity": "sha512-N5AuS5WgzT8/P9bDCPv5OPWEB8RXkJLQEHAFFZKYrghOGdxkba8u0qPdSrE8tgYqhLTA8Babou1shrX5aS//Vw==",
       "requires": {
         "@uniswap/default-token-list": "^11.2.0",
         "@uniswap/permit2-sdk": "^1.2.0",
@@ -27398,7 +27398,7 @@
         "@uniswap/token-lists": "^1.0.0-beta.31",
         "@uniswap/universal-router": "^1.0.1",
         "@uniswap/universal-router-sdk": "^1.5.8",
-        "@uniswap/v2-sdk": "^3.2.2",
+        "@uniswap/v2-sdk": "^3.2.3",
         "@uniswap/v3-sdk": "^3.10.0",
         "async-retry": "^1.3.1",
         "await-timeout": "^1.1.1",
@@ -27527,9 +27527,9 @@
       "integrity": "sha512-MtybtkUPSyysqLY2U210NBDeCHX+ltHt3oADGdjqoThZaFRDKwM6k1Nb3F0A3hk5hwuQvytFWhrWHOEq6nVJ8Q=="
     },
     "@uniswap/v2-sdk": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@uniswap/v2-sdk/-/v2-sdk-3.2.2.tgz",
-      "integrity": "sha512-FyFEQPfNMXhG9i2M8AfowBhMqq44GzhaKU9wpCS6ancI3T+wg89hycTUXONIjsRm5WnpqmvQY73nGUK7T17RMw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@uniswap/v2-sdk/-/v2-sdk-3.2.3.tgz",
+      "integrity": "sha512-MEGNfd8hAvelDpXhKkgyKUycXVDWkabSUGg0VZvLB+WGtJ8c6wz44K/fABKfn00npWCAztUyIToEn7NlZSxEkg==",
       "requires": {
         "@ethersproject/address": "^5.0.0",
         "@ethersproject/solidity": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@uniswap/smart-order-router": "3.17.2",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^1.5.8",
-        "@uniswap/v2-sdk": "^3.2.1",
+        "@uniswap/v2-sdk": "^3.2.3",
         "@uniswap/v3-periphery": "^1.1.0",
         "@uniswap/v3-sdk": "^3.10.0",
         "async-retry": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@uniswap/smart-order-router": "3.17.2",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^1.5.8",
-    "@uniswap/v2-sdk": "^3.2.1",
+    "@uniswap/v2-sdk": "^3.2.3",
     "@uniswap/v3-periphery": "^1.1.0",
     "@uniswap/v3-sdk": "^3.10.0",
     "async-retry": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@uniswap/permit2-sdk": "^1.2.0",
     "@uniswap/router-sdk": "^1.6.0",
     "@uniswap/sdk-core": "^4.0.7",
-    "@uniswap/smart-order-router": "3.17.1",
+    "@uniswap/smart-order-router": "3.17.2",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^1.5.8",
     "@uniswap/v2-sdk": "^3.2.1",

--- a/test/mocha/integ/quote.test.ts
+++ b/test/mocha/integ/quote.test.ts
@@ -10,7 +10,6 @@ import {
   ID_TO_NETWORK_NAME,
   NATIVE_CURRENCY,
   parseAmount,
-  SimulationStatus,
   SWAP_ROUTER_02_ADDRESSES,
   USDC_MAINNET,
   USDT_MAINNET,


### PR DESCRIPTION
Release:
- SOR https://github.com/Uniswap/smart-order-router/pull/433
- v2-sdk https://github.com/Uniswap/v2-sdk/pull/149

Enhanced existing routing-api integ-test coverage, after removing all the excluded test assertions:
- https://github.com/Uniswap/routing-api/pull/381/files#diff-e193a17cd7d38af77f287fe6bcf1c109b80c24bff4f9a4e317e4c95ea6a1c047R1081-R1088
- https://github.com/Uniswap/routing-api/pull/386/files