### PR TITLE
Chore: decrease routing lambda memory to 1792mb

### DIFF
--- a/bin/stacks/routing-lambda-stack.ts
+++ b/bin/stacks/routing-lambda-stack.ts
@@ -91,7 +91,7 @@ export class RoutingLambdaStack extends cdk.NestedStack {
       entry: path.join(__dirname, '../../lib/handlers/index.ts'),
       handler: 'quoteHandler',
       timeout: cdk.Duration.seconds(15),
-      memorySize: 2048,
+      memorySize: 1792,
       ephemeralStorageSize: Size.gibibytes(1),
       deadLetterQueueEnabled: true,
       bundling: {


### PR DESCRIPTION
Previously, we increased routing lambda memory from 1530mb to 2048mb https://github.com/Uniswap/routing-api/pull/349/files, and overall memory utilization decreased from 55% to 45%. We think 50% might be a sweet spot for saved memories/AWS bills meanwhile maintaining the latencies. 50% is roughly 1792mb.

<img width="1210" alt="Screenshot 2023-10-31 at 2 20 43 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/ecac765c-99a8-4e15-b6ca-3f1a38ddb2b7">

