### PR TITLE
Fix: integ-test setup for funding from whale wallets

### DIFF
--- a/test/mocha/integ/quote.test.ts
+++ b/test/mocha/integ/quote.test.ts
@@ -248,20 +248,23 @@ describe('quote', function () {
     const aliceEthBalance = await getBalance(alice, Ether.onChain(1))
     /// Since alice is deploying the QuoterV3 contract, expect to have slightly less than 10_000 ETH but not too little
     expect(!aliceEthBalance.lessThan(CurrencyAmount.fromRawAmount(Ether.onChain(1), '9995'))).to.be.true
+
+    // for all other balance checks, we ensure they are at least X amount. There's a possibility for more than X token amount,
+    // due to a single whale address being whale for more than one token.
     const aliceUSDCBalance = await getBalance(alice, USDC_MAINNET)
-    expect(aliceUSDCBalance.quotient.toString()).equal(parseAmount('8000000', USDC_MAINNET).quotient.toString())
+    expect(!aliceUSDCBalance.lessThan(parseAmount('8000000', USDC_MAINNET))).to.be.true;
     const aliceUSDTBalance = await getBalance(alice, USDT_MAINNET)
-    expect(aliceUSDTBalance.quotient.toString()).equal(parseAmount('5000000', USDT_MAINNET).quotient.toString())
+    expect(!aliceUSDTBalance.lessThan(parseAmount('5000000', USDT_MAINNET))).to.be.true;
     const aliceWETH9Balance = await getBalance(alice, WETH9[1])
-    expect(aliceWETH9Balance.quotient.toString()).equal(parseAmount('4000', WETH9[1]).quotient.toString())
+    expect(!aliceWETH9Balance.lessThan(parseAmount('4000', WETH9[1]))).to.be.true;
     const aliceWBTCBalance = await getBalance(alice, WBTC_MAINNET)
-    expect(aliceWBTCBalance.quotient.toString()).equal(parseAmount('10', WBTC_MAINNET).quotient.toString())
+    expect(!aliceWBTCBalance.lessThan(parseAmount('10', WBTC_MAINNET))).to.be.true;
     const aliceDAIBalance = await getBalance(alice, DAI_MAINNET)
-    expect(aliceDAIBalance.quotient.toString()).equal(parseAmount('5000000', DAI_MAINNET).quotient.toString())
+    expect(!aliceDAIBalance.lessThan(parseAmount('5000000', DAI_MAINNET))).to.be.true;
     const aliceUNIBalance = await getBalance(alice, UNI_MAINNET)
-    expect(aliceUNIBalance.quotient.toString()).equal(parseAmount('1000', UNI_MAINNET).quotient.toString())
+    expect(!aliceUNIBalance.lessThan(parseAmount('1000', UNI_MAINNET))).to.be.true;
     const aliceBULLETBalance = await getBalance(alice, BULLET)
-    expect(aliceBULLETBalance.quotient.toString()).equal(parseAmount('735871', BULLET).quotient.toString())
+    expect(!aliceBULLETBalance.lessThan(parseAmount('735871', BULLET))).to.be.true;
   })
 
   for (const algorithm of ['alpha']) {

--- a/test/mocha/integ/quote.test.ts
+++ b/test/mocha/integ/quote.test.ts
@@ -252,19 +252,19 @@ describe('quote', function () {
     // for all other balance checks, we ensure they are at least X amount. There's a possibility for more than X token amount,
     // due to a single whale address being whale for more than one token.
     const aliceUSDCBalance = await getBalance(alice, USDC_MAINNET)
-    expect(!aliceUSDCBalance.lessThan(parseAmount('8000000', USDC_MAINNET))).to.be.true;
+    expect(!aliceUSDCBalance.lessThan(parseAmount('8000000', USDC_MAINNET))).to.be.true
     const aliceUSDTBalance = await getBalance(alice, USDT_MAINNET)
-    expect(!aliceUSDTBalance.lessThan(parseAmount('5000000', USDT_MAINNET))).to.be.true;
+    expect(!aliceUSDTBalance.lessThan(parseAmount('5000000', USDT_MAINNET))).to.be.true
     const aliceWETH9Balance = await getBalance(alice, WETH9[1])
-    expect(!aliceWETH9Balance.lessThan(parseAmount('4000', WETH9[1]))).to.be.true;
+    expect(!aliceWETH9Balance.lessThan(parseAmount('4000', WETH9[1]))).to.be.true
     const aliceWBTCBalance = await getBalance(alice, WBTC_MAINNET)
-    expect(!aliceWBTCBalance.lessThan(parseAmount('10', WBTC_MAINNET))).to.be.true;
+    expect(!aliceWBTCBalance.lessThan(parseAmount('10', WBTC_MAINNET))).to.be.true
     const aliceDAIBalance = await getBalance(alice, DAI_MAINNET)
-    expect(!aliceDAIBalance.lessThan(parseAmount('5000000', DAI_MAINNET))).to.be.true;
+    expect(!aliceDAIBalance.lessThan(parseAmount('5000000', DAI_MAINNET))).to.be.true
     const aliceUNIBalance = await getBalance(alice, UNI_MAINNET)
-    expect(!aliceUNIBalance.lessThan(parseAmount('1000', UNI_MAINNET))).to.be.true;
+    expect(!aliceUNIBalance.lessThan(parseAmount('1000', UNI_MAINNET))).to.be.true
     const aliceBULLETBalance = await getBalance(alice, BULLET)
-    expect(!aliceBULLETBalance.lessThan(parseAmount('735871', BULLET))).to.be.true;
+    expect(!aliceBULLETBalance.lessThan(parseAmount('735871', BULLET))).to.be.true
   })
 
   for (const algorithm of ['alpha']) {


### PR DESCRIPTION
Routing-api integration test failed with:

```
1) quote
121 | "before all" hook in "quote":
122 |  
123 | AssertionError: expected '5000000077916' to equal '5000000000000'
124 | + expected - actual
125 |  
126 | -5000000077916
127 | +5000000000000
128 |  
129 | at Context.<anonymous> (test/mocha/integ/quote.test.ts:254:50)
130 | at runMicrotasks (<anonymous>)
131 | at processTicksAndRejections (node:internal/process/task_queues:96:5)
132 | at runNextTicks (node:internal/process/task_queues:65:3)
133 | at listOnTimeout (node:internal/timers:528:9)
134 | at processTimers (node:internal/timers:502:7)
135 |  
136
```

It's possible to see more token amount getting funded than hardcoded amount, because a single whale address can turn out be a whale across more than one token. As long as in the integ-test set up, we assert that there are at least X amount of tokens being funded per token, the test setup is good.