### PR TITLE
Chore: decrease routing lambda memory to 1530mb

### DIFF
--- a/bin/stacks/routing-lambda-stack.ts
+++ b/bin/stacks/routing-lambda-stack.ts
@@ -91,7 +91,7 @@ export class RoutingLambdaStack extends cdk.NestedStack {
       entry: path.join(__dirname, '../../lib/handlers/index.ts'),
       handler: 'quoteHandler',
       timeout: cdk.Duration.seconds(15),
-      memorySize: 1792,
+      memorySize: 1530,
       ephemeralStorageSize: Size.gibibytes(1),
       deadLetterQueueEnabled: true,
       bundling: {


### PR DESCRIPTION
https://github.com/Uniswap/routing-api/pull/398 only made memory utilization to 44%:

<img width="1231" alt="Screenshot 2023-10-31 at 4 42 47 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/cd824810-16c9-4dc4-887f-2875d590fe74">

No impact on tail latencies:
<img width="737" alt="Screenshot 2023-10-31 at 4 41 57 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/5502fed1-578e-420b-b82f-0f41ecf4f9b9">

We are decreasing back to 1530mb to see if memory utilization can reach 50%.