### PR TITLE
Revert "Chore: decrease routing lambda memory to 1530mb"

### DIFF
--- a/bin/stacks/routing-lambda-stack.ts
+++ b/bin/stacks/routing-lambda-stack.ts
@@ -91,7 +91,7 @@ export class RoutingLambdaStack extends cdk.NestedStack {
       entry: path.join(__dirname, '../../lib/handlers/index.ts'),
       handler: 'quoteHandler',
       timeout: cdk.Duration.seconds(15),
-      memorySize: 1530,
+      memorySize: 1792,
       ephemeralStorageSize: Size.gibibytes(1),
       deadLetterQueueEnabled: true,
       bundling: {


### PR DESCRIPTION
Reverts Uniswap/routing-api#400 because we saw small performance decreases

https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~'AWS*2fLambda~'ConcurrentExecutions~'FunctionName~'prod-us-east-2-RoutingAPI-R-RoutingLambda2C4DF0900-Bbcx5MI4vlM6))~view~'timeSeries~stacked~false~region~'us-east-2~start~'-PT168H~end~'P0D~stat~'Maximum~period~300)&query=~'*7bAWS*2fLambda*2cFunctionName*7d*20Concurrent