### PR TITLE
Switch to StaticJsonRpcProvider

### DIFF
--- a/lib/handlers/evm/EVMClient.ts
+++ b/lib/handlers/evm/EVMClient.ts
@@ -1,22 +1,22 @@
 import { ethers } from 'ethers'
 
 export interface EVMClient {
-  getProvider(): ethers.providers.JsonRpcProvider
+  getProvider(): ethers.providers.StaticJsonRpcProvider
 }
 
 export type EVMClientProps = {
-  allProviders: Array<ethers.providers.JsonRpcProvider>
+  allProviders: Array<ethers.providers.StaticJsonRpcProvider>
 }
 
 export class DefaultEVMClient implements EVMClient {
-  private readonly allProviders: Array<ethers.providers.JsonRpcProvider>
+  private readonly allProviders: Array<ethers.providers.StaticJsonRpcProvider>
 
   // delegate all non-private method calls
   constructor({ allProviders }: EVMClientProps) {
     this.allProviders = allProviders
   }
 
-  getProvider(): ethers.providers.JsonRpcProvider {
+  getProvider(): ethers.providers.StaticJsonRpcProvider {
     // TODO: use strategy pattern to have heuristics selecting which provider
     return this.allProviders[0]
   }

--- a/lib/handlers/evm/provider/InstrumentedEVMProvider.ts
+++ b/lib/handlers/evm/provider/InstrumentedEVMProvider.ts
@@ -22,7 +22,7 @@ export type InstrumentedEVMProviderProps = {
   name: ProviderName
 }
 
-export class InstrumentedEVMProvider extends ethers.providers.JsonRpcProvider {
+export class InstrumentedEVMProvider extends ethers.providers.StaticJsonRpcProvider {
   private readonly name: ProviderName
   private readonly metricPrefix: string
 

--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -84,7 +84,7 @@ export interface RequestInjected<Router> extends BaseRInj {
 }
 
 export type ContainerDependencies = {
-  provider: ethers.providers.JsonRpcProvider
+  provider: ethers.providers.StaticJsonRpcProvider
   v3SubgraphProvider: IV3SubgraphProvider
   v2SubgraphProvider: IV2SubgraphProvider
   tokenListProvider: ITokenListProvider


### PR DESCRIPTION
From this issue in ethers: https://github.com/ethers-io/ethers.js/issues/901

We can switch to using the StaticJsonRpcProvider which avoids an unnecessary chainId call to infura, saving about 30% of requests to infura

