### PR TITLE
Only send Caching requests every X blocks

### DIFF
--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -83,10 +83,10 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
   private readonly ROUTES_DB_BUCKET_RATIO: Fraction = new Fraction(514229, 317811)
   private readonly ROUTES_TO_TAKE_FROM_ROUTES_DB = 8
   private readonly BLOCKS_DIFF_BETWEEN_CACHING_QUOTES: Map<ChainId, number> = new Map([
-    [ChainId.MAINNET, 10]
+    [ChainId.MAINNET, 3]
   ])
 
-  private readonly DEFAULT_BLOCKS_DIFF_CACHING = 100;
+  private readonly DEFAULT_BLOCKS_DIFF_CACHING = 15;
 
   constructor({ routesTableName, routesCachingRequestFlagTableName, cachingQuoteLambdaName }: ConstructorParams) {
     super()

--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -82,11 +82,9 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
   // For the Ratio we are approximating Phi (Golden Ratio) by creating a fraction with 2 consecutive Fibonacci numbers
   private readonly ROUTES_DB_BUCKET_RATIO: Fraction = new Fraction(514229, 317811)
   private readonly ROUTES_TO_TAKE_FROM_ROUTES_DB = 8
-  private readonly BLOCKS_DIFF_BETWEEN_CACHING_QUOTES: Map<ChainId, number> = new Map([
-    [ChainId.MAINNET, 3]
-  ])
+  private readonly BLOCKS_DIFF_BETWEEN_CACHING_QUOTES: Map<ChainId, number> = new Map([[ChainId.MAINNET, 3]])
 
-  private readonly DEFAULT_BLOCKS_DIFF_CACHING = 15;
+  private readonly DEFAULT_BLOCKS_DIFF_CACHING = 15
 
   constructor({ routesTableName, routesCachingRequestFlagTableName, cachingQuoteLambdaName }: ConstructorParams) {
     super()
@@ -307,13 +305,11 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
         (result.Items.length == 0 || // no caching request has been sent recently
           // or every sampled record is older than maximum blocks diff allowed for the chain
           result.Items.every((record) => {
-            const blocksDiff = currentBlockNumber - (record.blockNumber ?? 0);
+            const blocksDiff = currentBlockNumber - (record.blockNumber ?? 0)
             const maximumBlocksDiff =
-              this.BLOCKS_DIFF_BETWEEN_CACHING_QUOTES.get(partitionKey.chainId) ||
-              this.DEFAULT_BLOCKS_DIFF_CACHING
-            return blocksDiff > maximumBlocksDiff;
-          })
-        )
+              this.BLOCKS_DIFF_BETWEEN_CACHING_QUOTES.get(partitionKey.chainId) || this.DEFAULT_BLOCKS_DIFF_CACHING
+            return blocksDiff > maximumBlocksDiff
+          }))
 
       // if no Item is found it means we need to send a caching request
       if (shouldSendCachingRequest) {

--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -82,6 +82,11 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
   // For the Ratio we are approximating Phi (Golden Ratio) by creating a fraction with 2 consecutive Fibonacci numbers
   private readonly ROUTES_DB_BUCKET_RATIO: Fraction = new Fraction(514229, 317811)
   private readonly ROUTES_TO_TAKE_FROM_ROUTES_DB = 8
+  private readonly BLOCKS_DIFF_BETWEEN_CACHING_QUOTES: Map<ChainId, number> = new Map([
+    [ChainId.MAINNET, 10]
+  ])
+
+  private readonly DEFAULT_BLOCKS_DIFF_CACHING = 100;
 
   constructor({ routesTableName, routesCachingRequestFlagTableName, cachingQuoteLambdaName }: ConstructorParams) {
     super()
@@ -300,8 +305,15 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
       const shouldSendCachingRequest =
         result.Items &&
         (result.Items.length == 0 || // no caching request has been sent recently
-          // or there is not a single sample for the current block
-          result.Items.every((record) => (record.blockNumber ?? 0) < currentBlockNumber))
+          // or every sampled record is older than maximum blocks diff allowed for the chain
+          result.Items.every((record) => {
+            const blocksDiff = currentBlockNumber - (record.blockNumber ?? 0);
+            const maximumBlocksDiff =
+              this.BLOCKS_DIFF_BETWEEN_CACHING_QUOTES.get(partitionKey.chainId) ||
+              this.DEFAULT_BLOCKS_DIFF_CACHING
+            return blocksDiff > maximumBlocksDiff;
+          })
+        )
 
       // if no Item is found it means we need to send a caching request
       if (shouldSendCachingRequest) {


### PR DESCRIPTION
This change will change the behavior of how often we sample buckets in RoutesDB.

We currently have a RoutesDB that stores routes seen for the past 24 hours for every specific pair. This database is not really growing much, since most routes will tend to stay liquid within the same liquidity pools that are currently being traded.

We care about updating the database whenever theres a major change in liquidity, but that doesn't happen often, so we are setting some threshold for how often we sample each *bucket* of a given pair. (A bucket is a range of from amount to amount * phi), we are changing from sampling on every block to sampling less often to reduce the amount of sync request we send to the routing api.

We will likely have to play with the numbers based on the chain velocity (how often a block is generated).
