### PR TITLE
bump sor to 3.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@uniswap/permit2-sdk": "^1.2.0",
         "@uniswap/router-sdk": "^1.6.0",
         "@uniswap/sdk-core": "^4.0.7",
-        "@uniswap/smart-order-router": "3.17.5",
+        "@uniswap/smart-order-router": "3.18.0",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^1.5.8",
         "@uniswap/v2-sdk": "^3.2.3",
@@ -4310,9 +4310,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.17.5.tgz",
-      "integrity": "sha512-f/vkgFVMKiVKO7jclzya+Zzf1jJj09yFJCm2onz4zYh5Z6gFetby0fG9pRXV8XpKWWL+hmdKhqAcgS/ZPV5k7g==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.18.0.tgz",
+      "integrity": "sha512-uLniH0pYgnRbSKayrKy1L9E+bqayjKSVmicMUflCoRQ9NyY7kqXN30EEy3eqsnY8OnpZzDHlVoJbvCc7EQEZxg==",
       "dependencies": {
         "@uniswap/default-token-list": "^11.2.0",
         "@uniswap/permit2-sdk": "^1.2.0",
@@ -27386,9 +27386,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.17.5.tgz",
-      "integrity": "sha512-f/vkgFVMKiVKO7jclzya+Zzf1jJj09yFJCm2onz4zYh5Z6gFetby0fG9pRXV8XpKWWL+hmdKhqAcgS/ZPV5k7g==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.18.0.tgz",
+      "integrity": "sha512-uLniH0pYgnRbSKayrKy1L9E+bqayjKSVmicMUflCoRQ9NyY7kqXN30EEy3eqsnY8OnpZzDHlVoJbvCc7EQEZxg==",
       "requires": {
         "@uniswap/default-token-list": "^11.2.0",
         "@uniswap/permit2-sdk": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@uniswap/permit2-sdk": "^1.2.0",
     "@uniswap/router-sdk": "^1.6.0",
     "@uniswap/sdk-core": "^4.0.7",
-    "@uniswap/smart-order-router": "3.17.5",
+    "@uniswap/smart-order-router": "3.18.0",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^1.5.8",
     "@uniswap/v2-sdk": "^3.2.3",


### PR DESCRIPTION
Release https://github.com/Uniswap/smart-order-router/pull/440. We need to merge this PR, in order to deploy the token-in native ETH gas estimate fix to routing-api