### PR TITLE
Chore: add tenderly simulation http status alarm

### DIFF
--- a/bin/stacks/routing-api-stack.ts
+++ b/bin/stacks/routing-api-stack.ts
@@ -301,32 +301,37 @@ export class RoutingAPIStack extends cdk.Stack {
     // Tenderly universal router simulation alarms focuses on the http status code returned
     // It was to capture the situation like the HTTPS redirect issue in the past incident
     // https://www.notion.so/uniswaplabs/New-tokens-swap-outages-on-Wallet-due-to-Tenderly-enforcing-HTTPS-aad4719087f0407d8a9b21f0137fd070?pvs=4#86b9072133b949a6b9e636dfcca1e76e
-    const tenderlyUniversalRouterSimulationHttpStatusAlarmSev2 = new aws_cloudwatch.Alarm(this, 'RoutingAPI-SEV2-Tenderly-UniversalRouter-Simulation', {
-      alarmName: 'RoutingAPI-SEV2-TenderlySimulation',
-      metric: new MathExpression({
-        expression: '100*(tenderlySimulationUniversalRouterResponseStatus200/tenderlySimulationUniversalRouterRequested)',
-        period: Duration.minutes(5),
-        usingMetrics: {
-          tenderlySimulationUniversalRouterRequested: new aws_cloudwatch.Metric({
-            namespace: 'Uniswap',
-            metricName: `TenderlySimulationUniversalRouterRequests`,
-            dimensionsMap: { Service: 'RoutingAPI' },
-            unit: aws_cloudwatch.Unit.COUNT,
-            statistic: 'sum',
-          }),
-          tenderlySimulationUniversalRouterResponseStatus200: new aws_cloudwatch.Metric({
-            namespace: 'Uniswap',
-            metricName: `TenderlySimulationUniversalRouterResponseStatus200`,
-            dimensionsMap: { Service: 'RoutingAPI' },
-            unit: aws_cloudwatch.Unit.COUNT,
-            statistic: 'sum',
-          }),
-        }
-      }),
-      threshold: 99,
-      evaluationPeriods: 3,
-      treatMissingData: aws_cloudwatch.TreatMissingData.BREACHING, // Missing data points are bad, because it means a different http status code was returned
-    });
+    const tenderlyUniversalRouterSimulationHttpStatusAlarmSev2 = new aws_cloudwatch.Alarm(
+      this,
+      'RoutingAPI-SEV2-Tenderly-UniversalRouter-Simulation',
+      {
+        alarmName: 'RoutingAPI-SEV2-TenderlySimulation',
+        metric: new MathExpression({
+          expression:
+            '100*(tenderlySimulationUniversalRouterResponseStatus200/tenderlySimulationUniversalRouterRequested)',
+          period: Duration.minutes(5),
+          usingMetrics: {
+            tenderlySimulationUniversalRouterRequested: new aws_cloudwatch.Metric({
+              namespace: 'Uniswap',
+              metricName: `TenderlySimulationUniversalRouterRequests`,
+              dimensionsMap: { Service: 'RoutingAPI' },
+              unit: aws_cloudwatch.Unit.COUNT,
+              statistic: 'sum',
+            }),
+            tenderlySimulationUniversalRouterResponseStatus200: new aws_cloudwatch.Metric({
+              namespace: 'Uniswap',
+              metricName: `TenderlySimulationUniversalRouterResponseStatus200`,
+              dimensionsMap: { Service: 'RoutingAPI' },
+              unit: aws_cloudwatch.Unit.COUNT,
+              statistic: 'sum',
+            }),
+          },
+        }),
+        threshold: 99,
+        evaluationPeriods: 3,
+        treatMissingData: aws_cloudwatch.TreatMissingData.BREACHING, // Missing data points are bad, because it means a different http status code was returned
+      }
+    )
 
     // Simulations can fail for valid reasons. For example, if the simulation reverts due
     // to slippage checks (can happen with FOT tokens sometimes since our quoter does not
@@ -431,7 +436,9 @@ export class RoutingAPIStack extends cdk.Stack {
       apiAlarm5xxSev3.addAlarmAction(new aws_cloudwatch_actions.SnsAction(chatBotTopic))
       apiAlarm4xxSev3.addAlarmAction(new aws_cloudwatch_actions.SnsAction(chatBotTopic))
       apiAlarmLatencySev3.addAlarmAction(new aws_cloudwatch_actions.SnsAction(chatBotTopic))
-      tenderlyUniversalRouterSimulationHttpStatusAlarmSev2.addAlarmAction(new aws_cloudwatch_actions.SnsAction(chatBotTopic))
+      tenderlyUniversalRouterSimulationHttpStatusAlarmSev2.addAlarmAction(
+        new aws_cloudwatch_actions.SnsAction(chatBotTopic)
+      )
       simulationAlarmSev3.addAlarmAction(new aws_cloudwatch_actions.SnsAction(chatBotTopic))
 
       percent4XXByChainAlarm.forEach((alarm) => {

--- a/bin/stacks/routing-api-stack.ts
+++ b/bin/stacks/routing-api-stack.ts
@@ -298,6 +298,36 @@ export class RoutingAPIStack extends cdk.Stack {
       evaluationPeriods: 3,
     })
 
+    // Tenderly universal router simulation alarms focuses on the http status code returned
+    // It was to capture the situation like the HTTPS redirect issue in the past incident
+    // https://www.notion.so/uniswaplabs/New-tokens-swap-outages-on-Wallet-due-to-Tenderly-enforcing-HTTPS-aad4719087f0407d8a9b21f0137fd070?pvs=4#86b9072133b949a6b9e636dfcca1e76e
+    const tenderlyUniversalRouterSimulationHttpStatusAlarmSev2 = new aws_cloudwatch.Alarm(this, 'RoutingAPI-SEV2-Tenderly-UniversalRouter-Simulation', {
+      alarmName: 'RoutingAPI-SEV2-TenderlySimulation',
+      metric: new MathExpression({
+        expression: '100*(tenderlySimulationUniversalRouterResponseStatus200/tenderlySimulationUniversalRouterRequested)',
+        period: Duration.minutes(5),
+        usingMetrics: {
+          tenderlySimulationUniversalRouterRequested: new aws_cloudwatch.Metric({
+            namespace: 'Uniswap',
+            metricName: `TenderlySimulationUniversalRouterRequests`,
+            dimensionsMap: { Service: 'RoutingAPI' },
+            unit: aws_cloudwatch.Unit.COUNT,
+            statistic: 'sum',
+          }),
+          tenderlySimulationUniversalRouterResponseStatus200: new aws_cloudwatch.Metric({
+            namespace: 'Uniswap',
+            metricName: `TenderlySimulationUniversalRouterResponseStatus200`,
+            dimensionsMap: { Service: 'RoutingAPI' },
+            unit: aws_cloudwatch.Unit.COUNT,
+            statistic: 'sum',
+          }),
+        }
+      }),
+      threshold: 99,
+      evaluationPeriods: 3,
+      treatMissingData: aws_cloudwatch.TreatMissingData.BREACHING, // Missing data points are bad, because it means a different http status code was returned
+    });
+
     // Simulations can fail for valid reasons. For example, if the simulation reverts due
     // to slippage checks (can happen with FOT tokens sometimes since our quoter does not
     // account for the fees taken during transfer when we show the user the quote).
@@ -401,6 +431,7 @@ export class RoutingAPIStack extends cdk.Stack {
       apiAlarm5xxSev3.addAlarmAction(new aws_cloudwatch_actions.SnsAction(chatBotTopic))
       apiAlarm4xxSev3.addAlarmAction(new aws_cloudwatch_actions.SnsAction(chatBotTopic))
       apiAlarmLatencySev3.addAlarmAction(new aws_cloudwatch_actions.SnsAction(chatBotTopic))
+      tenderlyUniversalRouterSimulationHttpStatusAlarmSev2.addAlarmAction(new aws_cloudwatch_actions.SnsAction(chatBotTopic))
       simulationAlarmSev3.addAlarmAction(new aws_cloudwatch_actions.SnsAction(chatBotTopic))
 
       percent4XXByChainAlarm.forEach((alarm) => {


### PR DESCRIPTION
As a follow-up action item from https://www.notion.so/uniswaplabs/New-tokens-swap-outages-on-Wallet-due-to-Tenderly-enforcing-HTTPS-aad4719087f0407d8a9b21f0137fd070?pvs=4#86b9072133b949a6b9e636dfcca1e76e, we will need to be able to detect and alert, when the tenderly requests are no longer returning success (http status 200).

It makes sense to alert against universal router simulation, but not swap router 02, due to swap router 02 being intended to get deprecated. Also universal router simulation is the main simulation traffic volume.

1. If tenderly no longer returns HTTP 200, then there will be insufficient datapoints, turning into alarm, tested in local AWS account: ![Screenshot 2023-11-16 at 3 34 30 PM](https://github.com/Uniswap/routing-api/assets/91580504/67cc4e1a-6742-4421-8565-d5a1ac13ea41)
2. If there's enough datapoints, every 5 minutes the evaluation should result in more than 99% in prod:
![Screenshot 2023-11-16 at 3 45 02 PM](https://github.com/Uniswap/routing-api/assets/91580504/b89e2f0c-c5db-4abf-86c3-f4fa5c42226c)
