### PR TITLE
Fix: make tenderly http-level success rate alarm loosened & add tenderly http-level success rate widget

### DIFF
--- a/bin/stacks/routing-api-stack.ts
+++ b/bin/stacks/routing-api-stack.ts
@@ -328,6 +328,7 @@ export class RoutingAPIStack extends cdk.Stack {
           },
         }),
         threshold: 99,
+        comparisonOperator: ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
         evaluationPeriods: 3,
         treatMissingData: aws_cloudwatch.TreatMissingData.BREACHING, // Missing data points are bad, because it means a different http status code was returned
       }

--- a/bin/stacks/routing-api-stack.ts
+++ b/bin/stacks/routing-api-stack.ts
@@ -327,7 +327,7 @@ export class RoutingAPIStack extends cdk.Stack {
             }),
           },
         }),
-        threshold: 99,
+        threshold: 60,
         comparisonOperator: ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
         evaluationPeriods: 3,
         treatMissingData: aws_cloudwatch.TreatMissingData.BREACHING, // Missing data points are bad, because it means a different http status code was returned

--- a/bin/stacks/routing-dashboard-stack.ts
+++ b/bin/stacks/routing-dashboard-stack.ts
@@ -942,7 +942,7 @@ export class RoutingDashboardStack extends cdk.NestedStack {
                   },
                 },
               },
-            }
+            },
           ])
           .concat(rpcProvidersWidgetsForRoutingDashboard),
       }),

--- a/bin/stacks/routing-dashboard-stack.ts
+++ b/bin/stacks/routing-dashboard-stack.ts
@@ -906,6 +906,43 @@ export class RoutingDashboardStack extends cdk.NestedStack {
                 stat: 'Sum',
               },
             },
+            {
+              height: 8,
+              width: 12,
+              type: 'metric',
+              properties: {
+                metrics: [
+                  [
+                    {
+                      expression: `(m1 / m2) * 100`,
+                      label: `Tenderly Simulation API Success Rate by HTTP Status Code`,
+                      id: `tenderlySimulationHttpSuccessRate`,
+                    },
+                  ],
+                  [
+                    NAMESPACE,
+                    'TenderlySimulationUniversalRouterResponseStatus200',
+                    'Service',
+                    'RoutingAPI',
+                    { id: 'm1', visible: false },
+                  ],
+                  ['.', 'TenderlySimulationUniversalRouterRequests', '.', '.', { id: 'm2', visible: false }],
+                ],
+                view: 'timeSeries',
+                stacked: false,
+                region,
+                stat: 'Sum',
+                period: 300,
+                title: 'Tenderly Simulation API Success Rate by HTTP Status Code',
+                setPeriodToTimeRange: true,
+                yAxis: {
+                  left: {
+                    showUnits: false,
+                    label: '%',
+                  },
+                },
+              },
+            }
           ])
           .concat(rpcProvidersWidgetsForRoutingDashboard),
       }),


### PR DESCRIPTION
Tested in local routing-api, now the expression evaluates to OK:

![Screenshot 2023-11-16 at 4 53 39 PM](https://github.com/Uniswap/routing-api/assets/91580504/1afbd6ab-4844-4a2f-bb1e-5891e25d9787)

Also routing dashboard now contains tenderly http-level success rate widget:
![Screenshot 2023-11-16 at 5 25 14 PM](https://github.com/Uniswap/routing-api/assets/91580504/ab7ea650-018f-40b8-afd4-280aa5d015a8)
