### PR TITLE
Chore: reduce tenderly timeout from 5s to 4s

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -338,7 +338,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
             portionProvider,
             { [ChainId.ARBITRUM_ONE]: 2.5 },
             // The timeout for the underlying axios call to Tenderly, measured in milliseconds.
-            5 * 1000
+            4 * 1000
           )
 
           const ethEstimateGasSimulator = new EthEstimateGasSimulator(


### PR DESCRIPTION
We have HTTP-level Tenderly success rate monitoring and alarm in prod now:
![Screenshot 2023-11-17 at 9 36 55 AM](https://github.com/Uniswap/routing-api/assets/91580504/26eade98-7310-4ff3-aac4-5d2b49bf58f1)

We can start to reduce the tenderly timeout from 5s to 4s. Right now the simulation request volume is < 1k/5min:
![Screenshot 2023-11-17 at 9 39 40 AM](https://github.com/Uniswap/routing-api/assets/91580504/34ce3dd3-868b-4cee-a678-b1fc63162188)

Based on P90, P95, and P99, I expect only occassionally P99 might get impacted, so that's less than 10 simulation per 5min:

![Screenshot 2023-11-17 at 9 41 12 AM](https://github.com/Uniswap/routing-api/assets/91580504/1e4c7bce-771e-459f-af32-fbbdac9f5580)
![Screenshot 2023-11-17 at 9 41 16 AM](https://github.com/Uniswap/routing-api/assets/91580504/cf81f80a-b9ab-4940-823d-fcef7a5d2392)
![Screenshot 2023-11-17 at 9 41 21 AM](https://github.com/Uniswap/routing-api/assets/91580504/e0b6dd9f-9ac5-4aea-a831-3b59445e2e2b)

