### PR TITLE
Test-Fix: fix bullet whale address insufficient gas

### DIFF
--- a/test/utils/forkAndFund.ts
+++ b/test/utils/forkAndFund.ts
@@ -63,11 +63,10 @@ export const resetAndFundAtBlock = async (
       const whaleAccount = ethers.provider.getSigner(whale)
       try {
         // Send native ETH from hardhat alice test address, so that whale accounts have sufficient ETH to pay for gas
-        await alice.sendTransaction(
-          {
-            to: whale,
-            value: ethers.utils.parseEther("0.1"), // Sends exactly 0.1 ether
-          });
+        await alice.sendTransaction({
+          to: whale,
+          value: ethers.utils.parseEther('0.1'), // Sends exactly 0.1 ether
+        })
 
         const whaleToken: Erc20 = Erc20__factory.connect(currency.wrapped.address, whaleAccount)
 
@@ -76,7 +75,9 @@ export const resetAndFundAtBlock = async (
         break
       } catch (err) {
         if (i == WHALES.length - 1) {
-          throw new Error(`Could not fund ${amount} ${currency.symbol} from any whales. Original error ${JSON.stringify(err)}`)
+          throw new Error(
+            `Could not fund ${amount} ${currency.symbol} from any whales. Original error ${JSON.stringify(err)}`
+          )
         }
       }
     }

--- a/test/utils/forkAndFund.ts
+++ b/test/utils/forkAndFund.ts
@@ -62,6 +62,13 @@ export const resetAndFundAtBlock = async (
       const whale = WHALES[i]
       const whaleAccount = ethers.provider.getSigner(whale)
       try {
+        // Send native ETH from hardhat alice test address, so that whale accounts have sufficient ETH to pay for gas
+        await alice.sendTransaction(
+          {
+            to: whale,
+            value: ethers.utils.parseEther("0.1"), // Sends exactly 0.1 ether
+          });
+
         const whaleToken: Erc20 = Erc20__factory.connect(currency.wrapped.address, whaleAccount)
 
         await whaleToken.transfer(alice.address, ethers.utils.parseUnits(amount, currency.decimals))
@@ -69,7 +76,7 @@ export const resetAndFundAtBlock = async (
         break
       } catch (err) {
         if (i == WHALES.length - 1) {
-          throw new Error(`Could not fund ${amount} ${currency.symbol} from any whales.`)
+          throw new Error(`Could not fund ${amount} ${currency.symbol} from any whales. Original error ${JSON.stringify(err)}`)
         }
       }
     }


### PR DESCRIPTION
routing-api release pipeline failed. There was insufficient error logs for debugging, so I added the original error and saw https://app.warp.dev/block/EQoDcTskq97QtG8bLCPndv.

Note the `BULLET` whale address `https://etherscan.io/address/0x171d311eacd2206d21cb462d661c33f0eddadc03` doesn't have sufficient native ETH to cover the BULLET token transfer to alice address. The fix is to let hardhat funded alice account sends 0.1ETH to each token whale address, so that each whale address has sufficient native ETH for token transfer gas.

After fixing the insufficient gas, all integ-test can pass https://app.warp.dev/block/scbZG6vBuR515Cbn0bUTtW.