### PR TITLE
Chore: reduce tenderly timeout 3s to 2.5s

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -338,7 +338,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
             portionProvider,
             { [ChainId.ARBITRUM_ONE]: 2.5 },
             // The timeout for the underlying axios call to Tenderly, measured in milliseconds.
-            3 * 1000
+            2.5 * 1000
           )
 
           const ethEstimateGasSimulator = new EthEstimateGasSimulator(


### PR DESCRIPTION
We have tenderly timeout metrics tracking, and we see in generally timeout happens less than 0.2% of total request:
<img width="1463" alt="Screenshot 2023-11-20 at 1 47 02 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/48c98c4c-e0d6-4ebb-a72f-f53a11100455">

We are going to further decrease the tenderly timeouts.