### PR TITLE
Chore: bump sor to 3.19.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@uniswap/permit2-sdk": "^1.2.0",
         "@uniswap/router-sdk": "^1.6.0",
         "@uniswap/sdk-core": "^4.0.7",
-        "@uniswap/smart-order-router": "3.19.1",
+        "@uniswap/smart-order-router": "3.19.2",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^1.5.8",
         "@uniswap/v2-sdk": "^3.2.3",
@@ -4310,9 +4310,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.19.1",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.19.1.tgz",
-      "integrity": "sha512-B7jS1F3yvRkvb8l4luylIVLM7STjRLiFBKyFdM5GUIAEHF/TwhvmADpNxP+hVvNTJvb/QQ4jVrJRdNmQ6jmzYw==",
+      "version": "3.19.2",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.19.2.tgz",
+      "integrity": "sha512-aSQ5cKLmoan3v79L3FRRAwDs8Syi1jJJJ4whOG5+lIEBN0M6BoElhKtJ7SWvoz+LJhCYbUWZl+f44wCLUKOzvA==",
       "dependencies": {
         "@uniswap/default-token-list": "^11.2.0",
         "@uniswap/permit2-sdk": "^1.2.0",
@@ -27386,9 +27386,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.19.1",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.19.1.tgz",
-      "integrity": "sha512-B7jS1F3yvRkvb8l4luylIVLM7STjRLiFBKyFdM5GUIAEHF/TwhvmADpNxP+hVvNTJvb/QQ4jVrJRdNmQ6jmzYw==",
+      "version": "3.19.2",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.19.2.tgz",
+      "integrity": "sha512-aSQ5cKLmoan3v79L3FRRAwDs8Syi1jJJJ4whOG5+lIEBN0M6BoElhKtJ7SWvoz+LJhCYbUWZl+f44wCLUKOzvA==",
       "requires": {
         "@uniswap/default-token-list": "^11.2.0",
         "@uniswap/permit2-sdk": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@uniswap/permit2-sdk": "^1.2.0",
     "@uniswap/router-sdk": "^1.6.0",
     "@uniswap/sdk-core": "^4.0.7",
-    "@uniswap/smart-order-router": "3.19.1",
+    "@uniswap/smart-order-router": "3.19.2",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^1.5.8",
     "@uniswap/v2-sdk": "^3.2.3",


### PR DESCRIPTION
Release https://github.com/Uniswap/smart-order-router/pull/456