### PR TITLE
Make `source` param optional in quote API

### DIFF
--- a/lib/handlers/quote/schema/quote-schema.ts
+++ b/lib/handlers/quote/schema/quote-schema.ts
@@ -70,7 +70,7 @@ export const QuoteQueryParamsJoi = Joi.object({
     .pattern(/^[0-9]+$/)
     .optional(),
   portionRecipient: Joi.string().alphanum().max(42).optional(),
-  source: Joi.string().max(20).required(),
+  source: Joi.string().max(20).optional(),
 })
 
 export type QuoteQueryParams = {


### PR DESCRIPTION
Since not all the clients have added the `source` param in their request, we have to make it optional to unblock deployment.