### PR TITLE
Parallize currency lookup

### DIFF
--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -163,9 +163,10 @@ export class QuoteHandler extends APIGLambdaHandler<
     metric.putMetric(`GET_QUOTE_REQUEST_SOURCE: ${source}`, 1, MetricLoggerUnit.Count)
 
     const currencyLookup = new CurrencyLookup(tokenListProvider, tokenProvider, log)
-
-    const currencyIn = await currencyLookup.searchForToken(tokenInAddress, tokenInChainId)
-    const currencyOut = await currencyLookup.searchForToken(tokenOutAddress, tokenOutChainId)
+    const [currencyIn, currencyOut] = await Promise.all([
+      currencyLookup.searchForToken(tokenInAddress, tokenInChainId),
+      currencyLookup.searchForToken(tokenOutAddress, tokenOutChainId),
+    ])
 
     metric.putMetric('TokenInOutStrToToken', Date.now() - before, MetricLoggerUnit.Milliseconds)
 


### PR DESCRIPTION
Small improvement found during https://github.com/Uniswap/routing-api/pull/439. 

Previously, these methods would fire sequentially. If either resulted in an unexpected exception, it would be bubbled up to the calling `handleRequest`. This behavior is preserved, but the functions now fire in parallel. 