### PR TITLE
chore: bump sor to 3.20.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@uniswap/permit2-sdk": "^1.2.0",
         "@uniswap/router-sdk": "^1.6.0",
         "@uniswap/sdk-core": "^4.0.7",
-        "@uniswap/smart-order-router": "3.19.3",
+        "@uniswap/smart-order-router": "3.20.0",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^1.5.8",
         "@uniswap/v2-sdk": "^3.2.3",
@@ -4576,9 +4576,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.19.3",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.19.3.tgz",
-      "integrity": "sha512-tanJ8uflxaONaUVWhg8qzSvDoZnHQTR5CNGaRbzB0L/K/eZInXj+/7xv1QThKx/BeY7+5nX6phozvnpEXH/rdQ==",
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.20.0.tgz",
+      "integrity": "sha512-BZJDOw3o8QWzEPSfRCZuA4zys4Uc3SqZEoI4MVAkUaHLw+fSuszPh6GGUlN9QsAkUEdM2g+UrkIZAq4KanzOSA==",
       "dependencies": {
         "@uniswap/default-token-list": "^11.2.0",
         "@uniswap/permit2-sdk": "^1.2.0",
@@ -27818,9 +27818,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.19.3",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.19.3.tgz",
-      "integrity": "sha512-tanJ8uflxaONaUVWhg8qzSvDoZnHQTR5CNGaRbzB0L/K/eZInXj+/7xv1QThKx/BeY7+5nX6phozvnpEXH/rdQ==",
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.20.0.tgz",
+      "integrity": "sha512-BZJDOw3o8QWzEPSfRCZuA4zys4Uc3SqZEoI4MVAkUaHLw+fSuszPh6GGUlN9QsAkUEdM2g+UrkIZAq4KanzOSA==",
       "requires": {
         "@uniswap/default-token-list": "^11.2.0",
         "@uniswap/permit2-sdk": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@uniswap/permit2-sdk": "^1.2.0",
     "@uniswap/router-sdk": "^1.6.0",
     "@uniswap/sdk-core": "^4.0.7",
-    "@uniswap/smart-order-router": "3.19.3",
+    "@uniswap/smart-order-router": "3.20.0",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^1.5.8",
     "@uniswap/v2-sdk": "^3.2.3",


### PR DESCRIPTION
Release https://github.com/Uniswap/smart-order-router/pull/462, optional gas token support for gasless relayer.