### PR TITLE
chore: bump sor to 3.20.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@uniswap/permit2-sdk": "^1.2.0",
         "@uniswap/router-sdk": "^1.6.0",
         "@uniswap/sdk-core": "^4.0.7",
-        "@uniswap/smart-order-router": "3.20.1",
+        "@uniswap/smart-order-router": "3.20.2",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^1.5.8",
         "@uniswap/v2-sdk": "^3.2.3",
@@ -3975,6 +3975,14 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/brotli": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@types/brotli/-/brotli-1.3.4.tgz",
+      "integrity": "sha512-cKYjgaS2DMdCKF7R0F5cgx1nfBYObN2ihIuPGQ4/dlIY6RpV7OWNwe9L8V4tTVKL2eZqOkNM9FM/rgTvLf4oXw==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/bunyan": {
       "version": "1.8.8",
       "resolved": "https://registry.npmjs.org/@types/bunyan/-/bunyan-1.8.8.tgz",
@@ -4576,10 +4584,11 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.20.1",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.20.1.tgz",
-      "integrity": "sha512-T+lKPthApVpWA2cV9svJRiIeqjtJSNq6OSA2J0fQjViQT1bYhwfBk6S+FaEHU780oRYpiRb7lBxhnRsSU6k99g==",
+      "version": "3.20.2",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.20.2.tgz",
+      "integrity": "sha512-97Xp9nHL6G7diWiq2LMafagfT2pH5yhMYtiS2gE70HwNw+OLq+ddsbSVi4+asvmUOBSxmlO1Ard4exv4ga9YJQ==",
       "dependencies": {
+        "@types/brotli": "^1.3.4",
         "@uniswap/default-token-list": "^11.2.0",
         "@uniswap/permit2-sdk": "^1.2.0",
         "@uniswap/router-sdk": "^1.6.0",
@@ -4593,6 +4602,7 @@
         "async-retry": "^1.3.1",
         "await-timeout": "^1.1.1",
         "axios": "^0.21.1",
+        "brotli": "^1.3.3",
         "bunyan": "^1.8.15",
         "bunyan-blackhole": "^1.1.1",
         "ethers": "^5.7.2",
@@ -6038,6 +6048,14 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
     },
     "node_modules/browser-level": {
       "version": "1.0.1",
@@ -27306,6 +27324,14 @@
         "@types/node": "*"
       }
     },
+    "@types/brotli": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@types/brotli/-/brotli-1.3.4.tgz",
+      "integrity": "sha512-cKYjgaS2DMdCKF7R0F5cgx1nfBYObN2ihIuPGQ4/dlIY6RpV7OWNwe9L8V4tTVKL2eZqOkNM9FM/rgTvLf4oXw==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/bunyan": {
       "version": "1.8.8",
       "resolved": "https://registry.npmjs.org/@types/bunyan/-/bunyan-1.8.8.tgz",
@@ -27818,10 +27844,11 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.20.1",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.20.1.tgz",
-      "integrity": "sha512-T+lKPthApVpWA2cV9svJRiIeqjtJSNq6OSA2J0fQjViQT1bYhwfBk6S+FaEHU780oRYpiRb7lBxhnRsSU6k99g==",
+      "version": "3.20.2",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.20.2.tgz",
+      "integrity": "sha512-97Xp9nHL6G7diWiq2LMafagfT2pH5yhMYtiS2gE70HwNw+OLq+ddsbSVi4+asvmUOBSxmlO1Ard4exv4ga9YJQ==",
       "requires": {
+        "@types/brotli": "^1.3.4",
         "@uniswap/default-token-list": "^11.2.0",
         "@uniswap/permit2-sdk": "^1.2.0",
         "@uniswap/router-sdk": "^1.6.0",
@@ -27835,6 +27862,7 @@
         "async-retry": "^1.3.1",
         "await-timeout": "^1.1.1",
         "axios": "^0.21.1",
+        "brotli": "^1.3.3",
         "bunyan": "^1.8.15",
         "bunyan-blackhole": "^1.1.1",
         "ethers": "^5.7.2",
@@ -28882,6 +28910,14 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
+    },
+    "brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "requires": {
+        "base64-js": "^1.1.2"
+      }
     },
     "browser-level": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@uniswap/permit2-sdk": "^1.2.0",
     "@uniswap/router-sdk": "^1.6.0",
     "@uniswap/sdk-core": "^4.0.7",
-    "@uniswap/smart-order-router": "3.20.1",
+    "@uniswap/smart-order-router": "3.20.2",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^1.5.8",
     "@uniswap/v2-sdk": "^3.2.3",


### PR DESCRIPTION
Release https://github.com/Uniswap/smart-order-router/pull/474, underlying change is to fix Arbitrum gas estimate