### PR TITLE
Feat: Change concurrency and memory for routing lambda

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -193,7 +193,7 @@ export class RoutingAPIPipeline extends Stack {
       env: { account: '606857263320', region: 'us-east-2' },
       jsonRpcProviders: jsonRpcProviders,
       internalApiKey: internalApiKey.secretValue.toString(),
-      provisionedConcurrency: 1000,
+      provisionedConcurrency: 500,
       ethGasStationInfoUrl: ethGasStationInfoUrl.secretValue.toString(),
       chatbotSNSArn: 'arn:aws:sns:us-east-2:644039819003:SlackChatbotTopic',
       stage: STAGE.PROD,

--- a/bin/stacks/routing-lambda-stack.ts
+++ b/bin/stacks/routing-lambda-stack.ts
@@ -1,5 +1,5 @@
 import * as cdk from 'aws-cdk-lib'
-import { Duration, Size } from 'aws-cdk-lib'
+import { Duration } from 'aws-cdk-lib'
 import * as aws_dynamodb from 'aws-cdk-lib/aws-dynamodb'
 import * as asg from 'aws-cdk-lib/aws-applicationautoscaling'
 import * as aws_cloudwatch from 'aws-cdk-lib/aws-cloudwatch'

--- a/bin/stacks/routing-lambda-stack.ts
+++ b/bin/stacks/routing-lambda-stack.ts
@@ -94,8 +94,7 @@ export class RoutingLambdaStack extends cdk.NestedStack {
       // Set this lambda's timeout to be slightly lower to give them time to
       // log the response in the event of a failure on our end.
       timeout: cdk.Duration.seconds(9),
-      memorySize: 1792,
-      ephemeralStorageSize: Size.gibibytes(1),
+      memorySize: 2048,
       deadLetterQueueEnabled: true,
       bundling: {
         minify: true,


### PR DESCRIPTION
Given the fact that the memory utilization is hovering over 50% for our lambda, this means that signifcant time is spent on garbage collection. Therefore, increasing the memory to notice if the performance will improve. Moreover, this should also decrease the time needed to execute, which might end up being cheaper all together.

<img width="1362" alt="Screenshot 2024-01-16 at 16 01 42" src="https://github.com/Uniswap/routing-api/assets/128516174/44670e65-8d30-42d3-8529-c27dc1c2ef56">

Secondly, reducing the concurrency limit from 1000 to 500. Running this script I found that only 64177 / 103698620 in the past week had a cold start, something that is WAY too small and we are spending too much money on it. 

```
# filter @type="REPORT" and ispresent(@initDuration)
filter @type="REPORT" and ispresent(@duration)
| stats count() as coldStarts, avg(@initDuration), min(@initDuration), max(@initDuration) # by bin(5m)
| order by coldStarts desc
```

TODO:

I want to tinker with scalable targets for provision concurrency to bring it even lower if possible. Currently, our concurrent executions for the past month are all mostly hovering around 500, so we can start frmo there and see where it takes us.

<img width="556" alt="Screenshot 2024-01-16 at 16 03 57" src="https://github.com/Uniswap/routing-api/assets/128516174/9ab40883-0775-4212-aa30-5c8075c059f4">

