### PR TITLE
chore: bump lambda version to route Polygon RPC provider from QuickNode back to Infura

### DIFF
--- a/bin/stacks/routing-lambda-stack.ts
+++ b/bin/stacks/routing-lambda-stack.ts
@@ -107,7 +107,7 @@ export class RoutingLambdaStack extends cdk.NestedStack {
 
       description: 'Routing Lambda',
       environment: {
-        VERSION: '7',
+        VERSION: '8',
         NODE_OPTIONS: '--enable-source-maps',
         POOL_CACHE_BUCKET: poolCacheBucket.bucketName,
         POOL_CACHE_BUCKET_2: poolCacheBucket2.bucketName,


### PR DESCRIPTION
We want to route Polygon RPC provider from QuickNode back to Infura.