### PR TITLE
chore: bump sor to 3.23.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@uniswap/permit2-sdk": "^1.2.0",
         "@uniswap/router-sdk": "^1.7.5",
         "@uniswap/sdk-core": "^4.0.7",
-        "@uniswap/smart-order-router": "3.22.0",
+        "@uniswap/smart-order-router": "3.23.0",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^1.6.1",
         "@uniswap/v2-sdk": "^4.0.1",
@@ -4603,9 +4603,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.22.0.tgz",
-      "integrity": "sha512-fHaj4jbo2IVvpiQOnYzFQejC9ghfwUUm27Z4XmJ/GGg9vshZ6o7/d8KDDkcJqoSRW7kTWS7DPZ0l1P0G6PxZjg==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.23.0.tgz",
+      "integrity": "sha512-xaSvm0lFZCLAMG57qCrEbiFGw3A8oEpZRyYUwh/Cl6wavzxTAgpNMS2WFXYIoG5KumLHr6oPoUNmEEUDn8upNQ==",
       "dependencies": {
         "@types/brotli": "^1.3.4",
         "@uniswap/default-token-list": "^11.2.0",
@@ -28436,9 +28436,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.22.0.tgz",
-      "integrity": "sha512-fHaj4jbo2IVvpiQOnYzFQejC9ghfwUUm27Z4XmJ/GGg9vshZ6o7/d8KDDkcJqoSRW7kTWS7DPZ0l1P0G6PxZjg==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.23.0.tgz",
+      "integrity": "sha512-xaSvm0lFZCLAMG57qCrEbiFGw3A8oEpZRyYUwh/Cl6wavzxTAgpNMS2WFXYIoG5KumLHr6oPoUNmEEUDn8upNQ==",
       "requires": {
         "@types/brotli": "^1.3.4",
         "@uniswap/default-token-list": "^11.2.0",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@uniswap/permit2-sdk": "^1.2.0",
     "@uniswap/router-sdk": "^1.7.5",
     "@uniswap/sdk-core": "^4.0.7",
-    "@uniswap/smart-order-router": "3.22.0",
+    "@uniswap/smart-order-router": "3.23.0",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^1.6.1",
     "@uniswap/v2-sdk": "^4.0.1",


### PR DESCRIPTION
Release https://github.com/Uniswap/smart-order-router/pull/488 - v2 gas model on L2 for project deploy v2 everywhere