### PR TITLE
Use probability control the turn on/off RPC Gateway for providers

### DIFF
--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -1,6 +1,6 @@
 [
   {
     "chainId": 43114,
-    "useMultiProvider": false
+    "useMultiProviderProb": 0
   }
 ]

--- a/lib/rpc/GlobalRpcProviders.ts
+++ b/lib/rpc/GlobalRpcProviders.ts
@@ -48,17 +48,16 @@ export class GlobalRpcProviders {
   ) {
     GlobalRpcProviders.SINGLE_RPC_PROVIDERS = new Map()
     for (const chainConfig of prodConfig) {
-      if (!chainConfig.useMultiProvider) {
-        continue
-      }
       const chainId = chainConfig.chainId as ChainId
-      let providers: SingleJsonRpcProvider[] = []
-      for (const providerUrl of chainConfig.providerUrls!) {
-        providers.push(
-          new SingleJsonRpcProvider({ name: chainIdToNetworkName(chainId), chainId }, providerUrl, log, singleConfig)
-        )
+      if (Math.random() < chainConfig.useMultiProviderProb) {
+        let providers: SingleJsonRpcProvider[] = []
+        for (const providerUrl of chainConfig.providerUrls!) {
+          providers.push(
+            new SingleJsonRpcProvider({ name: chainIdToNetworkName(chainId), chainId }, providerUrl, log, singleConfig)
+          )
+        }
+        GlobalRpcProviders.SINGLE_RPC_PROVIDERS.set(chainId, providers)
       }
-      GlobalRpcProviders.SINGLE_RPC_PROVIDERS.set(chainId, providers)
     }
   }
 
@@ -74,12 +73,9 @@ export class GlobalRpcProviders {
 
     GlobalRpcProviders.UNI_RPC_PROVIDERS = new Map()
     for (const chainConfig of prodConfig) {
-      if (!chainConfig.useMultiProvider) {
-        continue
-      }
       const chainId = chainConfig.chainId as ChainId
       if (!GlobalRpcProviders.SINGLE_RPC_PROVIDERS!.has(chainId)) {
-        throw new Error(`No RPC providers configured for chain ${chainId.toString()}`)
+        continue
       }
       GlobalRpcProviders.UNI_RPC_PROVIDERS.set(
         chainId,

--- a/lib/rpc/ProdConfig.ts
+++ b/lib/rpc/ProdConfig.ts
@@ -2,7 +2,7 @@ import Joi from '@hapi/joi'
 
 export interface ChainConfig {
   chainId: number
-  useMultiProvider: boolean
+  useMultiProviderProb: number
   sessionAllowProviderFallbackWhenUnhealthy?: boolean
   providerInitialWeights?: number[]
   providerUrls?: string[]
@@ -13,7 +13,7 @@ export type ProdConfig = ChainConfig[]
 export const ProdConfigJoi = Joi.array().items(
   Joi.object({
     chainId: Joi.number().required(),
-    useMultiProvider: Joi.boolean().required(),
+    useMultiProviderProb: Joi.number().required(),
     sessionAllowProviderFallbackWhenUnhealthy: Joi.boolean().optional(),
     providerInitialWeights: Joi.array().items(Joi.number()).optional(),
     providerUrls: Joi.array().items(Joi.string()).optional(),

--- a/test/mocha/unit/rpc/GlobalRpcProviders.test.ts
+++ b/test/mocha/unit/rpc/GlobalRpcProviders.test.ts
@@ -3,6 +3,7 @@ import { default as bunyan, default as Logger } from 'bunyan'
 import { ChainId } from '@uniswap/sdk-core'
 import { expect } from 'chai'
 import { SingleJsonRpcProviderConfig, UniJsonRpcProviderConfig } from '../../../../lib/rpc/config'
+import Sinon, { SinonSandbox } from 'sinon'
 
 const log: Logger = bunyan.createLogger({ name: 'test' })
 
@@ -33,7 +34,14 @@ const cleanUp = () => {
 }
 
 describe('GlobalRpcProviders', () => {
+  let sandbox: SinonSandbox
+
+  beforeEach(() => {
+    sandbox = Sinon.createSandbox()
+  })
+
   afterEach(() => {
+    sandbox.restore()
     cleanUp()
   })
 
@@ -43,10 +51,10 @@ describe('GlobalRpcProviders', () => {
       URL1: 'url1',
     }
     const rpcProviderProdConfig = [
-      { chainId: 1, useMultiProvider: false },
+      { chainId: 1, useMultiProviderProb: 0 },
       {
         chainId: 43114,
-        useMultiProvider: true,
+        useMultiProviderProb: 1,
         sessionAllowProviderFallbackWhenUnhealthy: true,
         providerInitialWeights: [2, 1],
         providerUrls: ['URL0', 'URL1'],
@@ -58,7 +66,7 @@ describe('GlobalRpcProviders', () => {
         log,
         UNI_PROVIDER_TEST_CONFIG,
         SINGLE_PROVIDER_TEST_CONFIG,
-        rpcProviderProdConfig
+        rpcProviderProdConfig,
       ).has(ChainId.MAINNET)
     ).to.be.false
 
@@ -83,7 +91,8 @@ describe('GlobalRpcProviders', () => {
     const avaUniProvider = GlobalRpcProviders.getGlobalUniRpcProviders(
       log,
       UNI_PROVIDER_TEST_CONFIG,
-      SINGLE_PROVIDER_TEST_CONFIG
+      SINGLE_PROVIDER_TEST_CONFIG,
+      rpcProviderProdConfig
     ).get(ChainId.AVALANCHE)!
     expect(avaUniProvider['sessionAllowProviderFallbackWhenUnhealthy']).to.be.true
     expect(avaUniProvider['urlWeight']).to.deep.equal({ url0: 2, url1: 1 })
@@ -92,11 +101,6 @@ describe('GlobalRpcProviders', () => {
   })
 
   it('Prepare global UniJsonRpcProvider by reading config file', () => {
-    process.env = {
-      URL0: 'url0',
-      URL1: 'url1',
-    }
-
     expect(
       GlobalRpcProviders.getGlobalUniRpcProviders(log, UNI_PROVIDER_TEST_CONFIG, SINGLE_PROVIDER_TEST_CONFIG).has(
         ChainId.MAINNET
@@ -114,5 +118,107 @@ describe('GlobalRpcProviders', () => {
         ChainId.AVALANCHE
       )
     ).to.be.false
+  })
+
+  it('Prepare global UniJsonRpcProvider by reading config: Use prob to decide feature switch', () => {
+    process.env = {
+      URL0: 'url0',
+      URL1: 'url1',
+    }
+
+    const rpcProviderProdConfig = [
+      {
+        chainId: 1,
+        useMultiProviderProb: 0.3,
+        providerUrls: ['URL0', 'URL1'],
+      },
+      {
+        chainId: 43114,
+        useMultiProviderProb: 0.7,
+        sessionAllowProviderFallbackWhenUnhealthy: true,
+        providerInitialWeights: [2, 1],
+        providerUrls: ['URL0', 'URL1'],
+      },
+    ]
+
+    const randStub = sandbox.stub(Math, 'random')
+    randStub.returns(0.0)
+    expect(
+      GlobalRpcProviders.getGlobalUniRpcProviders(log, UNI_PROVIDER_TEST_CONFIG, SINGLE_PROVIDER_TEST_CONFIG, rpcProviderProdConfig).has(
+        ChainId.MAINNET
+      )
+    ).to.be.true
+    expect(
+      GlobalRpcProviders.getGlobalUniRpcProviders(log, UNI_PROVIDER_TEST_CONFIG, SINGLE_PROVIDER_TEST_CONFIG, rpcProviderProdConfig).has(
+        ChainId.AVALANCHE
+      )
+    ).to.be.true
+    cleanUp()
+
+    randStub.returns(0.29)
+    expect(
+      GlobalRpcProviders.getGlobalUniRpcProviders(log, UNI_PROVIDER_TEST_CONFIG, SINGLE_PROVIDER_TEST_CONFIG, rpcProviderProdConfig).has(
+        ChainId.MAINNET
+      )
+    ).to.be.true
+    expect(
+      GlobalRpcProviders.getGlobalUniRpcProviders(log, UNI_PROVIDER_TEST_CONFIG, SINGLE_PROVIDER_TEST_CONFIG, rpcProviderProdConfig).has(
+        ChainId.AVALANCHE
+      )
+    ).to.be.true
+    cleanUp()
+
+    randStub.returns(0.3)
+    expect(
+      GlobalRpcProviders.getGlobalUniRpcProviders(log, UNI_PROVIDER_TEST_CONFIG, SINGLE_PROVIDER_TEST_CONFIG, rpcProviderProdConfig).has(
+        ChainId.MAINNET
+      )
+    ).to.be.false
+    expect(
+      GlobalRpcProviders.getGlobalUniRpcProviders(log, UNI_PROVIDER_TEST_CONFIG, SINGLE_PROVIDER_TEST_CONFIG, rpcProviderProdConfig).has(
+
+        ChainId.AVALANCHE
+      )
+    ).to.be.true
+    cleanUp()
+
+    randStub.returns(0.69)
+    expect(
+      GlobalRpcProviders.getGlobalUniRpcProviders(log, UNI_PROVIDER_TEST_CONFIG, SINGLE_PROVIDER_TEST_CONFIG, rpcProviderProdConfig).has(
+        ChainId.MAINNET
+      )
+    ).to.be.false
+    expect(
+      GlobalRpcProviders.getGlobalUniRpcProviders(log, UNI_PROVIDER_TEST_CONFIG, SINGLE_PROVIDER_TEST_CONFIG, rpcProviderProdConfig).has(
+        ChainId.AVALANCHE
+      )
+    ).to.be.true
+    cleanUp()
+
+    randStub.returns(0.7)
+    expect(
+      GlobalRpcProviders.getGlobalUniRpcProviders(log, UNI_PROVIDER_TEST_CONFIG, SINGLE_PROVIDER_TEST_CONFIG, rpcProviderProdConfig).has(
+        ChainId.MAINNET
+      )
+    ).to.be.false
+    expect(
+      GlobalRpcProviders.getGlobalUniRpcProviders(log, UNI_PROVIDER_TEST_CONFIG, SINGLE_PROVIDER_TEST_CONFIG, rpcProviderProdConfig).has(
+        ChainId.AVALANCHE
+      )
+    ).to.be.false
+    cleanUp()
+
+    randStub.returns(0.9)
+    expect(
+      GlobalRpcProviders.getGlobalUniRpcProviders(log, UNI_PROVIDER_TEST_CONFIG, SINGLE_PROVIDER_TEST_CONFIG, rpcProviderProdConfig).has(
+        ChainId.MAINNET
+      )
+    ).to.be.false
+    expect(
+      GlobalRpcProviders.getGlobalUniRpcProviders(log, UNI_PROVIDER_TEST_CONFIG, SINGLE_PROVIDER_TEST_CONFIG, rpcProviderProdConfig).has(
+        ChainId.AVALANCHE
+      )
+    ).to.be.false
+    cleanUp()
   })
 })

--- a/test/mocha/unit/rpc/GlobalRpcProviders.test.ts
+++ b/test/mocha/unit/rpc/GlobalRpcProviders.test.ts
@@ -66,7 +66,7 @@ describe('GlobalRpcProviders', () => {
         log,
         UNI_PROVIDER_TEST_CONFIG,
         SINGLE_PROVIDER_TEST_CONFIG,
-        rpcProviderProdConfig,
+        rpcProviderProdConfig
       ).has(ChainId.MAINNET)
     ).to.be.false
 
@@ -144,80 +144,115 @@ describe('GlobalRpcProviders', () => {
     const randStub = sandbox.stub(Math, 'random')
     randStub.returns(0.0)
     expect(
-      GlobalRpcProviders.getGlobalUniRpcProviders(log, UNI_PROVIDER_TEST_CONFIG, SINGLE_PROVIDER_TEST_CONFIG, rpcProviderProdConfig).has(
-        ChainId.MAINNET
-      )
+      GlobalRpcProviders.getGlobalUniRpcProviders(
+        log,
+        UNI_PROVIDER_TEST_CONFIG,
+        SINGLE_PROVIDER_TEST_CONFIG,
+        rpcProviderProdConfig
+      ).has(ChainId.MAINNET)
     ).to.be.true
     expect(
-      GlobalRpcProviders.getGlobalUniRpcProviders(log, UNI_PROVIDER_TEST_CONFIG, SINGLE_PROVIDER_TEST_CONFIG, rpcProviderProdConfig).has(
-        ChainId.AVALANCHE
-      )
+      GlobalRpcProviders.getGlobalUniRpcProviders(
+        log,
+        UNI_PROVIDER_TEST_CONFIG,
+        SINGLE_PROVIDER_TEST_CONFIG,
+        rpcProviderProdConfig
+      ).has(ChainId.AVALANCHE)
     ).to.be.true
     cleanUp()
 
     randStub.returns(0.29)
     expect(
-      GlobalRpcProviders.getGlobalUniRpcProviders(log, UNI_PROVIDER_TEST_CONFIG, SINGLE_PROVIDER_TEST_CONFIG, rpcProviderProdConfig).has(
-        ChainId.MAINNET
-      )
+      GlobalRpcProviders.getGlobalUniRpcProviders(
+        log,
+        UNI_PROVIDER_TEST_CONFIG,
+        SINGLE_PROVIDER_TEST_CONFIG,
+        rpcProviderProdConfig
+      ).has(ChainId.MAINNET)
     ).to.be.true
     expect(
-      GlobalRpcProviders.getGlobalUniRpcProviders(log, UNI_PROVIDER_TEST_CONFIG, SINGLE_PROVIDER_TEST_CONFIG, rpcProviderProdConfig).has(
-        ChainId.AVALANCHE
-      )
+      GlobalRpcProviders.getGlobalUniRpcProviders(
+        log,
+        UNI_PROVIDER_TEST_CONFIG,
+        SINGLE_PROVIDER_TEST_CONFIG,
+        rpcProviderProdConfig
+      ).has(ChainId.AVALANCHE)
     ).to.be.true
     cleanUp()
 
     randStub.returns(0.3)
     expect(
-      GlobalRpcProviders.getGlobalUniRpcProviders(log, UNI_PROVIDER_TEST_CONFIG, SINGLE_PROVIDER_TEST_CONFIG, rpcProviderProdConfig).has(
-        ChainId.MAINNET
-      )
+      GlobalRpcProviders.getGlobalUniRpcProviders(
+        log,
+        UNI_PROVIDER_TEST_CONFIG,
+        SINGLE_PROVIDER_TEST_CONFIG,
+        rpcProviderProdConfig
+      ).has(ChainId.MAINNET)
     ).to.be.false
     expect(
-      GlobalRpcProviders.getGlobalUniRpcProviders(log, UNI_PROVIDER_TEST_CONFIG, SINGLE_PROVIDER_TEST_CONFIG, rpcProviderProdConfig).has(
-
-        ChainId.AVALANCHE
-      )
+      GlobalRpcProviders.getGlobalUniRpcProviders(
+        log,
+        UNI_PROVIDER_TEST_CONFIG,
+        SINGLE_PROVIDER_TEST_CONFIG,
+        rpcProviderProdConfig
+      ).has(ChainId.AVALANCHE)
     ).to.be.true
     cleanUp()
 
     randStub.returns(0.69)
     expect(
-      GlobalRpcProviders.getGlobalUniRpcProviders(log, UNI_PROVIDER_TEST_CONFIG, SINGLE_PROVIDER_TEST_CONFIG, rpcProviderProdConfig).has(
-        ChainId.MAINNET
-      )
+      GlobalRpcProviders.getGlobalUniRpcProviders(
+        log,
+        UNI_PROVIDER_TEST_CONFIG,
+        SINGLE_PROVIDER_TEST_CONFIG,
+        rpcProviderProdConfig
+      ).has(ChainId.MAINNET)
     ).to.be.false
     expect(
-      GlobalRpcProviders.getGlobalUniRpcProviders(log, UNI_PROVIDER_TEST_CONFIG, SINGLE_PROVIDER_TEST_CONFIG, rpcProviderProdConfig).has(
-        ChainId.AVALANCHE
-      )
+      GlobalRpcProviders.getGlobalUniRpcProviders(
+        log,
+        UNI_PROVIDER_TEST_CONFIG,
+        SINGLE_PROVIDER_TEST_CONFIG,
+        rpcProviderProdConfig
+      ).has(ChainId.AVALANCHE)
     ).to.be.true
     cleanUp()
 
     randStub.returns(0.7)
     expect(
-      GlobalRpcProviders.getGlobalUniRpcProviders(log, UNI_PROVIDER_TEST_CONFIG, SINGLE_PROVIDER_TEST_CONFIG, rpcProviderProdConfig).has(
-        ChainId.MAINNET
-      )
+      GlobalRpcProviders.getGlobalUniRpcProviders(
+        log,
+        UNI_PROVIDER_TEST_CONFIG,
+        SINGLE_PROVIDER_TEST_CONFIG,
+        rpcProviderProdConfig
+      ).has(ChainId.MAINNET)
     ).to.be.false
     expect(
-      GlobalRpcProviders.getGlobalUniRpcProviders(log, UNI_PROVIDER_TEST_CONFIG, SINGLE_PROVIDER_TEST_CONFIG, rpcProviderProdConfig).has(
-        ChainId.AVALANCHE
-      )
+      GlobalRpcProviders.getGlobalUniRpcProviders(
+        log,
+        UNI_PROVIDER_TEST_CONFIG,
+        SINGLE_PROVIDER_TEST_CONFIG,
+        rpcProviderProdConfig
+      ).has(ChainId.AVALANCHE)
     ).to.be.false
     cleanUp()
 
     randStub.returns(0.9)
     expect(
-      GlobalRpcProviders.getGlobalUniRpcProviders(log, UNI_PROVIDER_TEST_CONFIG, SINGLE_PROVIDER_TEST_CONFIG, rpcProviderProdConfig).has(
-        ChainId.MAINNET
-      )
+      GlobalRpcProviders.getGlobalUniRpcProviders(
+        log,
+        UNI_PROVIDER_TEST_CONFIG,
+        SINGLE_PROVIDER_TEST_CONFIG,
+        rpcProviderProdConfig
+      ).has(ChainId.MAINNET)
     ).to.be.false
     expect(
-      GlobalRpcProviders.getGlobalUniRpcProviders(log, UNI_PROVIDER_TEST_CONFIG, SINGLE_PROVIDER_TEST_CONFIG, rpcProviderProdConfig).has(
-        ChainId.AVALANCHE
-      )
+      GlobalRpcProviders.getGlobalUniRpcProviders(
+        log,
+        UNI_PROVIDER_TEST_CONFIG,
+        SINGLE_PROVIDER_TEST_CONFIG,
+        rpcProviderProdConfig
+      ).has(ChainId.AVALANCHE)
     ).to.be.false
     cleanUp()
   })

--- a/test/mocha/unit/rpc/ProdConfig.test.ts
+++ b/test/mocha/unit/rpc/ProdConfig.test.ts
@@ -6,11 +6,11 @@ describe('ProdConfig', () => {
     const prodConfig: ProdConfig = [
       {
         chainId: 1,
-        useMultiProvider: false,
+        useMultiProviderProb: 0,
       },
       {
         chainId: 43114,
-        useMultiProvider: true,
+        useMultiProviderProb: 1,
         sessionAllowProviderFallbackWhenUnhealthy: true,
         providerInitialWeights: [-1, -1],
         providerUrls: ['url1', 'url2'],
@@ -19,13 +19,13 @@ describe('ProdConfig', () => {
 
     const jsonStr = JSON.stringify(prodConfig)
     expect(jsonStr).equal(
-      '[{"chainId":1,"useMultiProvider":false},{"chainId":43114,"useMultiProvider":true,"sessionAllowProviderFallbackWhenUnhealthy":true,"providerInitialWeights":[-1,-1],"providerUrls":["url1","url2"]}]'
+      '[{"chainId":1,"useMultiProviderProb":0},{"chainId":43114,"useMultiProviderProb":1,"sessionAllowProviderFallbackWhenUnhealthy":true,"providerInitialWeights":[-1,-1],"providerUrls":["url1","url2"]}]'
     )
   })
 
   it('test parse json string into ProdConfig with validation, good case', () => {
     const jsonStr =
-      '[{"chainId":1,"useMultiProvider":false},{"chainId":43114,"useMultiProvider":true,"sessionAllowProviderFallbackWhenUnhealthy":true,"providerInitialWeights":[-1,-1],"providerUrls":["url1","url2"]}]'
+      '[{"chainId":1,"useMultiProviderProb":0},{"chainId":43114,"useMultiProviderProb":1,"sessionAllowProviderFallbackWhenUnhealthy":true,"providerInitialWeights":[-1,-1],"providerUrls":["url1","url2"]}]'
     const object = JSON.parse(jsonStr)
     const validation = ProdConfigJoi.validate(object)
     if (validation.error) {
@@ -35,11 +35,11 @@ describe('ProdConfig', () => {
     expect(prodConfig.length).equal(2)
     expect(prodConfig[0]).deep.equal({
       chainId: 1,
-      useMultiProvider: false,
+      useMultiProviderProb: 0,
     })
     expect(prodConfig[1]).deep.equal({
       chainId: 43114,
-      useMultiProvider: true,
+      useMultiProviderProb: 1,
       sessionAllowProviderFallbackWhenUnhealthy: true,
       providerInitialWeights: [-1, -1],
       providerUrls: ['url1', 'url2'],


### PR DESCRIPTION
This is helpful to control graduate roll out of RPC Gateway. We can control the percentage of AWS lambdas that use RPC Gateway instead of default single provider.