### PR TITLE
fix: remove testnets

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -375,8 +375,6 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
 
           const v2Supported = [
             ChainId.MAINNET,
-            ChainId.GOERLI,
-            ChainId.SEPOLIA,
             ChainId.ARBITRUM_ONE,
             ChainId.OPTIMISM,
             ChainId.POLYGON,


### PR DESCRIPTION
We didn't deploy v2 factory or universal router to any testnets. V2 gas estimate [path](https://github.com/Uniswap/smart-order-router/blob/main/src/routers/alpha-router/gas-models/v2/v2-heuristic-gas-model.ts#L261) will fail:

```
INFO:  Got reserves for 2 pools as of block: 5342366.
INFO:  2 pools invalid after checking their slot0 and liquidity results. Dropping.
  invalidPools: ["USDC/WETH","DAI/WETH"]
DEBUG: Found 0 valid pools
  poolStrs: []
ERROR: Could not find a USD/WETH pool for computing gas costs.
  pools: []
```

We need to remove testnets from v2_supported array until we deploy v2 factory or universal router to the respective testnet(s).


