### PR TITLE
chore: bump sor to v3.24.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@uniswap/permit2-sdk": "^1.2.0",
         "@uniswap/router-sdk": "^1.8.0",
         "@uniswap/sdk-core": "^4.1.2",
-        "@uniswap/smart-order-router": "3.24.3",
+        "@uniswap/smart-order-router": "3.24.4",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^1.7.1",
         "@uniswap/v2-sdk": "^4.2.0",
@@ -4603,9 +4603,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.24.3",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.24.3.tgz",
-      "integrity": "sha512-mDthQcMPqrT9TGZSD4bhnQcXX45J54PGyi7yN262P8CMHo5pJItJEG7KQurhF/95FbvEYNXwef1/s2PBQzaOaw==",
+      "version": "3.24.4",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.24.4.tgz",
+      "integrity": "sha512-4Snow0iKcMRYrV3kJKGj53l07LvoaMUM5oXlRXpbLv9HYw6F5QF9K9PkvQlIn+I8IwbpHj5Nx0f706GYqiVDHw==",
       "dependencies": {
         "@types/brotli": "^1.3.4",
         "@uniswap/default-token-list": "^11.13.0",
@@ -28365,9 +28365,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.24.3",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.24.3.tgz",
-      "integrity": "sha512-mDthQcMPqrT9TGZSD4bhnQcXX45J54PGyi7yN262P8CMHo5pJItJEG7KQurhF/95FbvEYNXwef1/s2PBQzaOaw==",
+      "version": "3.24.4",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.24.4.tgz",
+      "integrity": "sha512-4Snow0iKcMRYrV3kJKGj53l07LvoaMUM5oXlRXpbLv9HYw6F5QF9K9PkvQlIn+I8IwbpHj5Nx0f706GYqiVDHw==",
       "requires": {
         "@types/brotli": "^1.3.4",
         "@uniswap/default-token-list": "^11.13.0",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@uniswap/permit2-sdk": "^1.2.0",
     "@uniswap/router-sdk": "^1.8.0",
     "@uniswap/sdk-core": "^4.1.2",
-    "@uniswap/smart-order-router": "3.24.3",
+    "@uniswap/smart-order-router": "3.24.4",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^1.7.1",
     "@uniswap/v2-sdk": "^4.2.0",


### PR DESCRIPTION
Release https://github.com/Uniswap/smart-order-router/pull/503. This PR should supposedly unblock quote on testnets.