### PR TITLE
fix: arbitrum use default multipler and integ-tests retry 3 times

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -343,7 +343,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
             v3PoolProvider,
             provider,
             portionProvider,
-            { [ChainId.ARBITRUM_ONE]: 2.5 },
+            undefined,
             // The timeout for the underlying axios call to Tenderly, measured in milliseconds.
             2.5 * 1000
           )

--- a/test/mocha/e2e/quote.test.ts
+++ b/test/mocha/e2e/quote.test.ts
@@ -2486,7 +2486,7 @@ describe('quote', function () {
 
       describe(`${ID_TO_NETWORK_NAME(chain)} ${type} 2xx`, function () {
         // Help with test flakiness by retrying.
-        this.retries(0)
+        this.retries(5)
         const wrappedNative = WNATIVE_ON(chain)
 
         it(`${wrappedNative.symbol} -> erc20`, async () => {

--- a/test/mocha/e2e/quote.test.ts
+++ b/test/mocha/e2e/quote.test.ts
@@ -2486,7 +2486,7 @@ describe('quote', function () {
 
       describe(`${ID_TO_NETWORK_NAME(chain)} ${type} 2xx`, function () {
         // Help with test flakiness by retrying.
-        this.retries(5)
+        this.retries(3)
         const wrappedNative = WNATIVE_ON(chain)
 
         it(`${wrappedNative.symbol} -> erc20`, async () => {


### PR DESCRIPTION
Wallet uses tenderly simulation. Default multipler is [1.3](https://github.com/Uniswap/smart-order-router/blob/main/src/providers/tenderly-simulation-provider.ts#L96). Routing-api overrides Arbitrum to 2.5, and this was to account for a bug on Tenderly back then after Nitro upgrade. Tenderly have fixed their side of bugs, so routing-api can remove 2.5 multipler. 

Also enable retry on integ-tests level.