### PR TITLE
chore: Re-enable goerli on V2

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -375,6 +375,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
 
           const v2Supported = [
             ChainId.MAINNET,
+            ChainId.GOERLI,
             ChainId.SEPOLIA,
             ChainId.ARBITRUM_ONE,
             ChainId.OPTIMISM,


### PR DESCRIPTION
Swap on Goerli stops working, if the token pairs only have v2 pool. We decided to re-enable V2 support on [Goerli](https://uniswapteam.slack.com/archives/C021SU4PMR7/p1709074854035469?thread_ts=1708523311.172709&cid=C021SU4PMR7), because v2 sepolia is pointing to old 0x7a25 v2 router. 

One issue with enabling Goerli on V2 used to the v2 gas model throwing uncaught [exception](https://github.com/Uniswap/smart-order-router/blob/main/src/routers/alpha-router/gas-models/v2/v2-heuristic-gas-model.ts#L261), but that's [fixed](https://github.com/Uniswap/smart-order-router/pull/507/files#diff-2fe4a092f36b8091262f7035638dc00530816382f3a1cca86927a6fd712e9c04R2092) now, so that as long as the v2 pool exists, we can return a quote, even without good gas estimate.