### PR TITLE
chore: remove sepolia from v2 routing

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -376,7 +376,6 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
           const v2Supported = [
             ChainId.MAINNET,
             ChainId.GOERLI,
-            ChainId.SEPOLIA,
             ChainId.ARBITRUM_ONE,
             ChainId.OPTIMISM,
             ChainId.POLYGON,


### PR DESCRIPTION
SDKs have the wrong deploy addresses for Sepolia for V2, resulting in fund loss on Sepolia, if the best swap route goes through V2.

We disable Sepolia v2 routing support for now.