### PR TITLE
Launch RPC gateway for Optimism with new providers

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -159,25 +159,29 @@ export class RoutingAPIPipeline extends Stack {
       secretCompleteArn: 'arn:aws:secretsmanager:us-east-2:644039819003:secret:routing-api-internal-api-key-Z68NmB',
     })
 
-    // Parse AWS Secret
+    // Load RPC provider URLs from AWS secret
     let jsonRpcProviders = {} as { [chainId: string]: string }
     SUPPORTED_CHAINS.forEach((chainId: ChainId) => {
       // TODO: Change this to `JSON_RPC_PROVIDER_${}` to be consistent with SOR
-      if (chainId === ChainId.AVALANCHE) {
-        jsonRpcProviders[`WEB3_RPC_${chainId}`] = jsonRpcProvidersSecret
-          .secretValueFromJson(`WEB3_RPC_${chainId}`)
-          .toString()
-        jsonRpcProviders[`WEB3_RPC_${chainId}_NIRVANA`] = jsonRpcProvidersSecret
-          .secretValueFromJson(`WEB3_RPC_${chainId}_NIRVANA`)
-          .toString()
-        jsonRpcProviders[`WEB3_RPC_${chainId}_QUICKNODE`] = jsonRpcProvidersSecret
-          .secretValueFromJson(`WEB3_RPC_${chainId}_QUICKNODE`)
-          .toString()
-      } else {
-        const key = `WEB3_RPC_${chainId}`
-        jsonRpcProviders[key] = jsonRpcProvidersSecret.secretValueFromJson(key).toString()
-      }
+      const key = `WEB3_RPC_${chainId}`
+      jsonRpcProviders[key] = jsonRpcProvidersSecret.secretValueFromJson(key).toString()
     })
+
+    // Load RPC provider URLs from AWS secret (for RPC Gateway)
+    const RPC_GATEWAY_PROVIDERS = [
+      // Avalanche
+      'WEB3_RPC_43114_INFURA',
+      'WEB3_RPC_43114_NIRVANA',
+      'WEB3_RPC_43114_QUICKNODE',
+      // Optimism
+      'WEB3_RPC_10_INFURA',
+      'WEB3_RPC_10_NIRVANA',
+      'WEB3_RPC_10_QUICKNODE',
+      'WEB3_RPC_10_ALCHEMY',
+    ]
+    for (const provider of RPC_GATEWAY_PROVIDERS) {
+      jsonRpcProviders[provider] = jsonRpcProvidersSecret.secretValueFromJson(provider).toString()
+    }
 
     // Beta us-east-2
     const betaUsEast2Stage = new RoutingAPIStage(this, 'beta-us-east-2', {
@@ -293,9 +297,14 @@ const jsonRpcProviders = {
   WEB3_RPC_44787: process.env.JSON_RPC_PROVIDER_44787!,
   WEB3_RPC_56: process.env.JSON_RPC_PROVIDER_56!,
   WEB3_RPC_8453: process.env.JSON_RPC_PROVIDER_8453!,
-  WEB3_RPC_43114: process.env.JSON_RPC_PROVIDER_43114!,
-  WEB3_RPC_43114_NIRVANA: process.env.JSON_RPC_PROVIDER_43114_NIRVANA!,
-  WEB3_RPC_43114_QUICKNODE: process.env.JSON_RPC_PROVIDER_43114_QUICKNODE!,
+  // Following is for RPC Gateway
+  WEB3_RPC_43114_INFURA: process.env.WEB3_RPC_43114_INFURA!,
+  WEB3_RPC_43114_NIRVANA: process.env.WEB3_RPC_43114_NIRVANA!,
+  WEB3_RPC_43114_QUICKNODE: process.env.WEB3_RPC_43114_QUICKNODE!,
+  WEB3_RPC_10_INFURA: process.env.WEB3_RPC_10_INFURA!,
+  WEB3_RPC_10_NIRVANA: process.env.WEB3_RPC_10_NIRVANA!,
+  WEB3_RPC_10_QUICKNODE: process.env.WEB3_RPC_10_QUICKNODE!,
+  WEB3_RPC_10_ALCHEMY: process.env.WEB3_RPC_10_ALCHEMY!,
 }
 
 // Local dev stack

--- a/bin/stacks/rpc-gateway-dashboard.ts
+++ b/bin/stacks/rpc-gateway-dashboard.ts
@@ -5,7 +5,10 @@ import { Construct } from 'constructs'
 import _ from 'lodash'
 import { ID_TO_NETWORK_NAME } from '@uniswap/smart-order-router/build/main/util/chains'
 
-const providerForChain: Map<ChainId, string[]> = new Map([[ChainId.AVALANCHE, ['INFURA', 'QUIKNODE', 'NIRVANA']]])
+const providerForChain: Map<ChainId, string[]> = new Map([
+  [ChainId.AVALANCHE, ['INFURA', 'QUIKNODE', 'NIRVANA']],
+  [ChainId.OPTIMISM, ['INFURA', 'QUIKNODE', 'NIRVANA', 'ALCHEMY']],
+])
 
 function getSelectMetricsForChain(chainId: ChainId) {
   const metrics = []
@@ -73,7 +76,7 @@ export class RpcGatewayDashboardStack extends cdk.NestedStack {
     super(scope, name)
 
     const region = cdk.Stack.of(this).region
-    const NETWORKS = [ChainId.AVALANCHE]
+    const NETWORKS = [ChainId.AVALANCHE, ChainId.OPTIMISM]
 
     const perChainWidgets: any[] = _.flatMap(NETWORKS, (chainId) => [
       {

--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -3,6 +3,12 @@
     "chainId": 43114,
     "useMultiProviderProb": 1,
     "providerInitialWeights": [9, 1, 0],
-    "providerUrls": ["WEB3_RPC_43114", "WEB3_RPC_43114_QUICKNODE", "WEB3_RPC_43114_NIRVANA"]
+    "providerUrls": ["WEB3_RPC_43114_INFURA", "WEB3_RPC_43114_QUICKNODE", "WEB3_RPC_43114_NIRVANA"]
+  },
+  {
+    "chainId": 10,
+    "useMultiProviderProb": 1,
+    "providerInitialWeights": [1, 1, 1, 1],
+    "providerUrls": ["WEB3_RPC_10_INFURA", "WEB3_RPC_10_QUICKNODE", "WEB3_RPC_10_NIRVANA", "WEB3_RPC_10_ALCHEMY"]
   }
 ]

--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -8,7 +8,7 @@
   {
     "chainId": 10,
     "useMultiProviderProb": 1,
-    "providerInitialWeights": [1, 1, 1, 1],
+    "providerInitialWeights": [1, 0, 0, 0],
     "providerUrls": ["WEB3_RPC_10_INFURA", "WEB3_RPC_10_QUICKNODE", "WEB3_RPC_10_NIRVANA", "WEB3_RPC_10_ALCHEMY"]
   }
 ]

--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -121,7 +121,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
     const log: Logger = bunyan.createLogger({
       name: this.injectorName,
       serializers: bunyan.stdSerializers,
-      level: bunyan.INFO,
+      level: bunyan.DEBUG,
     })
     setGlobalLogger(log)
 
@@ -143,14 +143,20 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
 
       const dependenciesByChainArray = await Promise.all(
         _.map(SUPPORTED_CHAINS, async (chainId: ChainId) => {
-          const url = process.env[`WEB3_RPC_${chainId.toString()}`]!
-          if (!url) {
-            log.fatal({ chainId: chainId }, `Fatal: No Web3 RPC endpoint set for chain`)
-            return { chainId, dependencies: {} as ContainerDependencies }
-            // This router instance will not be able to route through any chain
-            // for which RPC URL is not set
-            // For now, if RPC URL is not set for a chain, a request to route
-            // on the chain will return Err 500
+          let url = ''
+          if (!GlobalRpcProviders.getGlobalUniRpcProviders(log).has(chainId)) {
+            // Check existence of env var for chain that doesn't use RPC gateway.
+            // (If use RPC gateway, the check for env var will be executed elsewhere.)
+            // TODO(jie): Remove this check once we migrate all chains to RPC gateway.
+            url = process.env[`WEB3_RPC_${chainId.toString()}`]!
+            if (!url) {
+              log.fatal({ chainId: chainId }, `Fatal: No Web3 RPC endpoint set for chain`)
+              return { chainId, dependencies: {} as ContainerDependencies }
+              // This router instance will not be able to route through any chain
+              // for which RPC URL is not set
+              // For now, if RPC URL is not set for a chain, a request to route
+              // on the chain will return Err 500
+            }
           }
 
           let timeout: number
@@ -165,6 +171,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
 
           let provider: StaticJsonRpcProvider
           if (GlobalRpcProviders.getGlobalUniRpcProviders(log).has(chainId)) {
+            // Use RPC gateway.
             provider = GlobalRpcProviders.getGlobalUniRpcProviders(log).get(chainId)!
           } else {
             provider = new DefaultEVMClient({

--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -121,7 +121,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
     const log: Logger = bunyan.createLogger({
       name: this.injectorName,
       serializers: bunyan.stdSerializers,
-      level: bunyan.DEBUG,
+      level: bunyan.INFO,
     })
     setGlobalLogger(log)
 

--- a/test/mocha/unit/rpc/GlobalRpcProviders.test.ts
+++ b/test/mocha/unit/rpc/GlobalRpcProviders.test.ts
@@ -103,9 +103,13 @@ describe('GlobalRpcProviders', () => {
   // You may need to update this test if you modified rpcProviderProdConfig.json
   it('Prepare global UniJsonRpcProvider by reading config file', () => {
     process.env = {
-      WEB3_RPC_43114: 'infura_43114',
+      WEB3_RPC_43114_INFURA: 'infura_43114',
       WEB3_RPC_43114_QUICKNODE: 'quicknode_43114',
       WEB3_RPC_43114_NIRVANA: 'nirvana_43114',
+      WEB3_RPC_10_INFURA: 'infura_10',
+      WEB3_RPC_10_QUICKNODE: 'quicknode_10',
+      WEB3_RPC_10_NIRVANA: 'nirvana_10',
+      WEB3_RPC_10_ALCHEMY: 'alchemy_10',
     }
 
     const randStub = sandbox.stub(Math, 'random')
@@ -119,23 +123,32 @@ describe('GlobalRpcProviders', () => {
 
     expect(
       GlobalRpcProviders.getGlobalUniRpcProviders(log, UNI_PROVIDER_TEST_CONFIG, SINGLE_PROVIDER_TEST_CONFIG).has(
-        ChainId.MAINNET
+        ChainId.OPTIMISM
       )
-    ).to.be.false
+    ).to.be.true
 
-    const uniRpcProvider = GlobalRpcProviders.getGlobalUniRpcProviders(
+    const uniRpcProviderAvalanche = GlobalRpcProviders.getGlobalUniRpcProviders(
       log,
       UNI_PROVIDER_TEST_CONFIG,
       SINGLE_PROVIDER_TEST_CONFIG
     ).get(ChainId.AVALANCHE)!
-    expect(uniRpcProvider['providers'][0].url).equal('infura_43114')
-    expect(uniRpcProvider['providers'][1].url).equal('quicknode_43114')
-    expect(uniRpcProvider['providers'][2].url).equal('nirvana_43114')
+    expect(uniRpcProviderAvalanche['providers'][0].url).equal('infura_43114')
+    expect(uniRpcProviderAvalanche['providers'][1].url).equal('quicknode_43114')
+    expect(uniRpcProviderAvalanche['providers'][2].url).equal('nirvana_43114')
+
+    const uniRpcProviderOptimism = GlobalRpcProviders.getGlobalUniRpcProviders(
+      log,
+      UNI_PROVIDER_TEST_CONFIG,
+      SINGLE_PROVIDER_TEST_CONFIG
+    ).get(ChainId.OPTIMISM)!!
+    expect(uniRpcProviderOptimism['providers'][0].url).equal('infura_10')
+    expect(uniRpcProviderOptimism['providers'][1].url).equal('quicknode_10')
+    expect(uniRpcProviderOptimism['providers'][2].url).equal('nirvana_10')
+    expect(uniRpcProviderOptimism['providers'][3].url).equal('alchemy_10')
 
     cleanUp()
 
     randStub.returns(1.0)
-
     expect(
       GlobalRpcProviders.getGlobalUniRpcProviders(log, UNI_PROVIDER_TEST_CONFIG, SINGLE_PROVIDER_TEST_CONFIG).has(
         ChainId.AVALANCHE


### PR DESCRIPTION
100% launch on Optimism traffic.
- Infura: 100% traffic
- Quicknode: 0% traffic, shadowing to collect latency metrics
- NirvanaLabs: 0% traffic, shadowing to collect latency metrics
- Alchemy: 0% traffic, shadowing to collect latency metrics

Also add related Optimism dashboard.

Manually tested on local environment.