### PR TITLE
chore(fix-cdk): Renaming the lambda back to Lambda2

### DIFF
--- a/bin/stacks/routing-lambda-stack.ts
+++ b/bin/stacks/routing-lambda-stack.ts
@@ -92,7 +92,7 @@ export class RoutingLambdaStack extends cdk.NestedStack {
 
     const region = cdk.Stack.of(this).region
 
-    this.routingLambda = new aws_lambda_nodejs.NodejsFunction(this, 'RoutingLambda3', {
+    this.routingLambda = new aws_lambda_nodejs.NodejsFunction(this, 'RoutingLambda2', {
       role: lambdaRole,
       runtime: aws_lambda.Runtime.NODEJS_18_X,
       entry: path.join(__dirname, '../../lib/handlers/index.ts'),


### PR DESCRIPTION
We are still trying to unblock the routing service, since the previos chave was successful at deploying beta we are gonna try to rename it back to see if we got out of some weiord AWS state
