### PR TITLE
Launch RPC gateway to 6 chains

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -186,6 +186,20 @@ export class RoutingAPIPipeline extends Stack {
       'NIRVANA_10',
       'QUICKNODE_10',
       'ALCHEMY_10',
+      // Celo
+      'INFURA_42220',
+      'QUICKNODE_42220',
+      // BNB
+      'QUICKNODE_56',
+      // Polygon
+      'INFURA_137',
+      'QUICKNODE_137',
+      'ALCHEMY_137',
+      // Base
+      'INFURA_8453',
+      'QUICKNODE_8453',
+      'ALCHEMY_8453',
+      'NIRVANA_8453',
     ]
     for (const provider of RPC_GATEWAY_PROVIDERS) {
       jsonRpcProviders[provider] = jsonRpcProvidersSecret.secretValueFromJson(provider).toString()

--- a/bin/stacks/routing-lambda-stack.ts
+++ b/bin/stacks/routing-lambda-stack.ts
@@ -112,7 +112,7 @@ export class RoutingLambdaStack extends cdk.NestedStack {
 
       description: 'Routing Lambda',
       environment: {
-        VERSION: '12',
+        VERSION: '13',
         NODE_OPTIONS: '--enable-source-maps',
         POOL_CACHE_BUCKET: poolCacheBucket.bucketName,
         POOL_CACHE_BUCKET_2: poolCacheBucket2.bucketName,

--- a/bin/stacks/rpc-gateway-dashboard.ts
+++ b/bin/stacks/rpc-gateway-dashboard.ts
@@ -180,7 +180,7 @@ export class RpcGatewayDashboardStack extends cdk.NestedStack {
           yAxis: {
             left: {
               showUnits: false,
-              label: 'Requests',
+              label: 'Score (in negative)',
             },
           },
         },

--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -8,8 +8,8 @@
   {
     "chainId": 10,
     "useMultiProviderProb": 1,
-    "providerInitialWeights": [1, 0, 0, 0],
-    "providerUrls": ["INFURA_10", "QUICKNODE_10", "NIRVANA_10", "ALCHEMY_10"]
+    "providerInitialWeights": [1, 0, 0],
+    "providerUrls": ["INFURA_10", "QUICKNODE_10", "ALCHEMY_10"]
   },
   {
     "chainId": 42220,

--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -10,5 +10,29 @@
     "useMultiProviderProb": 1,
     "providerInitialWeights": [1, 0, 0, 0],
     "providerUrls": ["INFURA_10", "QUICKNODE_10", "NIRVANA_10", "ALCHEMY_10"]
+  },
+  {
+    "chainId": 42220,
+    "useMultiProviderProb": 1,
+    "providerInitialWeights": [1, 0],
+    "providerUrls": ["INFURA_42220", "QUICKNODE_42220"]
+  },
+  {
+    "chainId": 56,
+    "useMultiProviderProb": 1,
+    "providerInitialWeights": [1],
+    "providerUrls": ["QUICKNODE_56"]
+  },
+  {
+    "chainId": 137,
+    "useMultiProviderProb": 1,
+    "providerInitialWeights": [1, 0, 0],
+    "providerUrls": ["INFURA_137", "QUICKNODE_137", "ALCHEMY_137"]
+  },
+  {
+    "chainId": 8453,
+    "useMultiProviderProb": 1,
+    "providerInitialWeights": [1, 0, 0, 0],
+    "providerUrls": ["INFURA_8453", "QUICKNODE_8453", "ALCHEMY_8453", "NIRVANA_8453"]
   }
 ]

--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -1,1 +1,14 @@
-[]
+[
+  {
+    "chainId": 43114,
+    "useMultiProviderProb": 1,
+    "providerInitialWeights": [9, 1, 0],
+    "providerUrls": ["INFURA_43114", "QUICKNODE_43114", "NIRVANA_43114"]
+  },
+  {
+    "chainId": 10,
+    "useMultiProviderProb": 1,
+    "providerInitialWeights": [1, 0, 0, 0],
+    "providerUrls": ["INFURA_10", "QUICKNODE_10", "NIRVANA_10", "ALCHEMY_10"]
+  }
+]

--- a/lib/rpc/GlobalRpcProviders.ts
+++ b/lib/rpc/GlobalRpcProviders.ts
@@ -9,7 +9,7 @@ import {
   UniJsonRpcProviderConfig,
 } from './config'
 import { ProdConfig, ProdConfigJoi } from './ProdConfig'
-import { chainIdToNetworkName } from './utils'
+import { chainIdToNetworkName, generateProviderUrl } from './utils'
 import PROD_CONFIG from '../config/rpcProviderProdConfig.json'
 
 export class GlobalRpcProviders {
@@ -35,7 +35,8 @@ export class GlobalRpcProviders {
         if (process.env[urlEnvVar] === undefined) {
           throw new Error(`Environmental variable ${urlEnvVar} isn't defined!`)
         }
-        chainConfig.providerUrls[i] = process.env[urlEnvVar]!
+        chainConfig.providerUrls[i] = generateProviderUrl(urlEnvVar, process.env[urlEnvVar]!)
+        console.log(`jiejie: ${urlEnvVar}: ${chainConfig.providerUrls[i]}`)
       }
     }
     return prodConfig

--- a/lib/rpc/GlobalRpcProviders.ts
+++ b/lib/rpc/GlobalRpcProviders.ts
@@ -36,7 +36,6 @@ export class GlobalRpcProviders {
           throw new Error(`Environmental variable ${urlEnvVar} isn't defined!`)
         }
         chainConfig.providerUrls[i] = generateProviderUrl(urlEnvVar, process.env[urlEnvVar]!)
-        console.log(`jiejie: ${urlEnvVar}: ${chainConfig.providerUrls[i]}`)
       }
     }
     return prodConfig

--- a/lib/rpc/utils.ts
+++ b/lib/rpc/utils.ts
@@ -72,7 +72,7 @@ export function generateProviderUrl(key: string, value: string): string {
       return `https://${tokens[0]}.matic.quiknode.pro/${tokens[1]}`
     }
     case 'QUICKNODE_8453': {
-      return `https://${tokens[0]}.base0-mainnet.quiknode.pro/${tokens[1]}`
+      return `https://${tokens[0]}.base-mainnet.quiknode.pro/${tokens[1]}`
     }
     // Alchemy
     case 'ALCHEMY_10': {

--- a/lib/rpc/utils.ts
+++ b/lib/rpc/utils.ts
@@ -22,3 +22,68 @@ export function chainIdToNetworkName(networkId: ChainId): string {
       return 'ethereum'
   }
 }
+
+export function generateProviderUrl(key: string, value: string): string {
+  const tokens = value.split(',')
+  switch (key) {
+    // Infura
+    case 'INFURA_1': {
+      return `https://mainnet.infura.io/v3/${tokens[0]}`
+    }
+    case 'INFURA_43114': {
+      return `https://avalanche-mainnet.infura.io/v3/${tokens[0]}`
+    }
+    case 'INFURA_10': {
+      return `https://optimism-mainnet.infura.io/v3/${tokens[0]}`
+    }
+    case 'INFURA_42220': {
+      return `https://celo-mainnet.infura.io/v3/${tokens[0]}`
+    }
+    case 'INFURA_137': {
+      return `https://polygon-mainnet.infura.io/v3/${tokens[0]}`
+    }
+    case 'INFURA_8453': {
+      return `https://base-mainnet.infura.io/v3/${tokens[0]}`
+    }
+    // Nirvana
+    case 'NIRVANA_43114': {
+      return `https://avax.nirvanalabs.xyz/${tokens[0]}/ext/bc/C/rpc?apikey=${tokens[1]}`
+    }
+    case 'NIRVANA_10': {
+      return `https://optimism.nirvanalabs.xyz/${tokens[0]}?apikey=${tokens[1]}`
+    }
+    case 'NIRVANA_8453': {
+      return `https://base.nirvanalabs.xyz/${tokens[0]}?apikey=${tokens[1]}`
+    }
+    // Quicknode
+    case 'QUICKNODE_43114': {
+      return `https://${tokens[0]}.avalanche-mainnet.quiknode.pro/${tokens[1]}/ext/bc/C/rpc/`
+    }
+    case 'QUICKNODE_10': {
+      return `https://${tokens[0]}.optimism.quiknode.pro/${tokens[1]}`
+    }
+    case 'QUICKNODE_42220': {
+      return `https://${tokens[0]}.celo-mainnet.quiknode.pro/${tokens[1]}`
+    }
+    case 'QUICKNODE_56': {
+      return `https://${tokens[0]}.bsc.quiknode.pro/${tokens[1]}`
+    }
+    case 'QUICKNODE_137': {
+      return `https://${tokens[0]}.matic.quiknode.pro/${tokens[1]}`
+    }
+    case 'QUICKNODE_8453': {
+      return `https://${tokens[0]}.base0-mainnet.quiknode.pro/${tokens[1]}`
+    }
+    // Alchemy
+    case 'ALCHEMY_10': {
+      return `https://opt-mainnet.g.alchemy.com/v2/${tokens[0]}`
+    }
+    case 'ALCHEMY_137': {
+      return `https://polygon-mainnet.g.alchemy.com/v2/${tokens[0]}`
+    }
+    case 'ALCHEMY_8453': {
+      return `https://base-mainnet.g.alchemy.com/v2/${tokens[0]}`
+    }
+  }
+  throw new Error(`Unknown provider-chainId pair: ${key}`)
+}

--- a/test/mocha/unit/rpc/GlobalRpcProviders.test.ts
+++ b/test/mocha/unit/rpc/GlobalRpcProviders.test.ts
@@ -282,8 +282,7 @@ describe('GlobalRpcProviders', () => {
     ).get(ChainId.OPTIMISM)!!
     expect(uniRpcProviderOptimism['providers'][0].url).equal('https://optimism-mainnet.infura.io/v3/key3')
     expect(uniRpcProviderOptimism['providers'][1].url).equal('https://host3.optimism.quiknode.pro/key3')
-    expect(uniRpcProviderOptimism['providers'][2].url).equal('https://optimism.nirvanalabs.xyz/host4?apikey=key4')
-    expect(uniRpcProviderOptimism['providers'][3].url).equal('https://opt-mainnet.g.alchemy.com/v2/key5')
+    expect(uniRpcProviderOptimism['providers'][2].url).equal('https://opt-mainnet.g.alchemy.com/v2/key5')
 
     const uniRpcProviderCelo = GlobalRpcProviders.getGlobalUniRpcProviders(
       log,

--- a/test/mocha/unit/rpc/GlobalRpcProviders.test.ts
+++ b/test/mocha/unit/rpc/GlobalRpcProviders.test.ts
@@ -100,6 +100,62 @@ describe('GlobalRpcProviders', () => {
     expect(avaUniProvider['providers'][1].url).to.equal('url1')
   })
 
+  // You may need to update this test if you modified rpcProviderProdConfig.json
+  it('Prepare global UniJsonRpcProvider by reading config file', () => {
+    process.env = {
+      INFURA_43114: 'infura_43114',
+      QUICKNODE_43114: 'quicknode_43114',
+      NIRVANA_43114: 'nirvana_43114',
+      INFURA_10: 'infura_10',
+      QUICKNODE_10: 'quicknode_10',
+      NIRVANA_10: 'nirvana_10',
+      ALCHEMY_10: 'alchemy_10',
+    }
+
+    const randStub = sandbox.stub(Math, 'random')
+    randStub.returns(0.9)
+
+    expect(
+      GlobalRpcProviders.getGlobalUniRpcProviders(log, UNI_PROVIDER_TEST_CONFIG, SINGLE_PROVIDER_TEST_CONFIG).has(
+        ChainId.AVALANCHE
+      )
+    ).to.be.true
+
+    expect(
+      GlobalRpcProviders.getGlobalUniRpcProviders(log, UNI_PROVIDER_TEST_CONFIG, SINGLE_PROVIDER_TEST_CONFIG).has(
+        ChainId.OPTIMISM
+      )
+    ).to.be.true
+
+    const uniRpcProviderAvalanche = GlobalRpcProviders.getGlobalUniRpcProviders(
+      log,
+      UNI_PROVIDER_TEST_CONFIG,
+      SINGLE_PROVIDER_TEST_CONFIG
+    ).get(ChainId.AVALANCHE)!
+    expect(uniRpcProviderAvalanche['providers'][0].url).equal('infura_43114')
+    expect(uniRpcProviderAvalanche['providers'][1].url).equal('quicknode_43114')
+    expect(uniRpcProviderAvalanche['providers'][2].url).equal('nirvana_43114')
+
+    const uniRpcProviderOptimism = GlobalRpcProviders.getGlobalUniRpcProviders(
+      log,
+      UNI_PROVIDER_TEST_CONFIG,
+      SINGLE_PROVIDER_TEST_CONFIG
+    ).get(ChainId.OPTIMISM)!!
+    expect(uniRpcProviderOptimism['providers'][0].url).equal('infura_10')
+    expect(uniRpcProviderOptimism['providers'][1].url).equal('quicknode_10')
+    expect(uniRpcProviderOptimism['providers'][2].url).equal('nirvana_10')
+    expect(uniRpcProviderOptimism['providers'][3].url).equal('alchemy_10')
+
+    cleanUp()
+
+    randStub.returns(1.0)
+    expect(
+      GlobalRpcProviders.getGlobalUniRpcProviders(log, UNI_PROVIDER_TEST_CONFIG, SINGLE_PROVIDER_TEST_CONFIG).has(
+        ChainId.AVALANCHE
+      )
+    ).to.be.false
+  })
+
   it('Prepare global UniJsonRpcProvider by reading config: Use prob to decide feature switch', () => {
     process.env = {
       URL0: 'url0',

--- a/test/mocha/unit/rpc/GlobalRpcProviders.test.ts
+++ b/test/mocha/unit/rpc/GlobalRpcProviders.test.ts
@@ -47,8 +47,8 @@ describe('GlobalRpcProviders', () => {
 
   it('Prepare global UniJsonRpcProvider by reading given config', () => {
     process.env = {
-      URL0: 'url0',
-      URL1: 'url1',
+      INFURA_43114: 'key0',
+      QUICKNODE_43114: 'node1,key1',
     }
     const rpcProviderProdConfig = [
       { chainId: 1, useMultiProviderProb: 0 },
@@ -57,7 +57,7 @@ describe('GlobalRpcProviders', () => {
         useMultiProviderProb: 1,
         sessionAllowProviderFallbackWhenUnhealthy: true,
         providerInitialWeights: [2, 1],
-        providerUrls: ['URL0', 'URL1'],
+        providerUrls: ['INFURA_43114', 'QUICKNODE_43114'],
       },
     ]
 
@@ -94,130 +94,34 @@ describe('GlobalRpcProviders', () => {
       SINGLE_PROVIDER_TEST_CONFIG,
       rpcProviderProdConfig
     ).get(ChainId.AVALANCHE)!
+    const url0 = 'https://avalanche-mainnet.infura.io/v3/key0'
+    const url1 = 'https://node1.avalanche-mainnet.quiknode.pro/key1/ext/bc/C/rpc/'
     expect(avaUniProvider['sessionAllowProviderFallbackWhenUnhealthy']).to.be.true
-    expect(avaUniProvider['urlWeight']).to.deep.equal({ url0: 2, url1: 1 })
-    expect(avaUniProvider['providers'][0].url).to.equal('url0')
-    expect(avaUniProvider['providers'][1].url).to.equal('url1')
-  })
-
-  // You may need to update this test if you modified rpcProviderProdConfig.json
-  it('Prepare global UniJsonRpcProvider by reading config file', () => {
-    process.env = {
-      INFURA_43114: 'infura_43114',
-      QUICKNODE_43114: 'quicknode_43114',
-      NIRVANA_43114: 'nirvana_43114',
-      INFURA_10: 'infura_10',
-      QUICKNODE_10: 'quicknode_10',
-      NIRVANA_10: 'nirvana_10',
-      ALCHEMY_10: 'alchemy_10',
-      INFURA_42220: 'infura_42220',
-      QUICKNODE_42220: 'quicknode_42220',
-      QUICKNODE_56: 'quicknode_56',
-      INFURA_137: 'infura_137',
-      QUICKNODE_137: 'quicknode_137',
-      ALCHEMY_137: 'alchemy_137',
-      INFURA_8453: 'infura_8453',
-      QUICKNODE_8453: 'quicknode_8453',
-      ALCHEMY_8453: 'alchemy_8453',
-      NIRVANA_8453: 'nirvana_8453',
-    }
-
-    const randStub = sandbox.stub(Math, 'random')
-    randStub.returns(0.9)
-
-    expect(
-      GlobalRpcProviders.getGlobalUniRpcProviders(log, UNI_PROVIDER_TEST_CONFIG, SINGLE_PROVIDER_TEST_CONFIG).has(
-        ChainId.AVALANCHE
-      )
-    ).to.be.true
-
-    expect(
-      GlobalRpcProviders.getGlobalUniRpcProviders(log, UNI_PROVIDER_TEST_CONFIG, SINGLE_PROVIDER_TEST_CONFIG).has(
-        ChainId.OPTIMISM
-      )
-    ).to.be.true
-
-    const uniRpcProviderAvalanche = GlobalRpcProviders.getGlobalUniRpcProviders(
-      log,
-      UNI_PROVIDER_TEST_CONFIG,
-      SINGLE_PROVIDER_TEST_CONFIG
-    ).get(ChainId.AVALANCHE)!
-    expect(uniRpcProviderAvalanche['providers'][0].url).equal('infura_43114')
-    expect(uniRpcProviderAvalanche['providers'][1].url).equal('quicknode_43114')
-    expect(uniRpcProviderAvalanche['providers'][2].url).equal('nirvana_43114')
-
-    const uniRpcProviderOptimism = GlobalRpcProviders.getGlobalUniRpcProviders(
-      log,
-      UNI_PROVIDER_TEST_CONFIG,
-      SINGLE_PROVIDER_TEST_CONFIG
-    ).get(ChainId.OPTIMISM)!!
-    expect(uniRpcProviderOptimism['providers'][0].url).equal('infura_10')
-    expect(uniRpcProviderOptimism['providers'][1].url).equal('quicknode_10')
-    expect(uniRpcProviderOptimism['providers'][2].url).equal('nirvana_10')
-    expect(uniRpcProviderOptimism['providers'][3].url).equal('alchemy_10')
-
-    const uniRpcProviderCelo = GlobalRpcProviders.getGlobalUniRpcProviders(
-      log,
-      UNI_PROVIDER_TEST_CONFIG,
-      SINGLE_PROVIDER_TEST_CONFIG
-    ).get(ChainId.CELO)!!
-    expect(uniRpcProviderCelo['providers'][0].url).equal('infura_42220')
-    expect(uniRpcProviderCelo['providers'][1].url).equal('quicknode_42220')
-
-    const uniRpcProviderBnb = GlobalRpcProviders.getGlobalUniRpcProviders(
-      log,
-      UNI_PROVIDER_TEST_CONFIG,
-      SINGLE_PROVIDER_TEST_CONFIG
-    ).get(ChainId.BNB)!!
-    expect(uniRpcProviderBnb['providers'][0].url).equal('quicknode_56')
-
-    const uniRpcProviderPolygon = GlobalRpcProviders.getGlobalUniRpcProviders(
-      log,
-      UNI_PROVIDER_TEST_CONFIG,
-      SINGLE_PROVIDER_TEST_CONFIG
-    ).get(ChainId.POLYGON)!
-    expect(uniRpcProviderPolygon['providers'][0].url).equal('infura_137')
-    expect(uniRpcProviderPolygon['providers'][1].url).equal('quicknode_137')
-    expect(uniRpcProviderPolygon['providers'][2].url).equal('alchemy_137')
-
-    const uniRpcProviderBase = GlobalRpcProviders.getGlobalUniRpcProviders(
-      log,
-      UNI_PROVIDER_TEST_CONFIG,
-      SINGLE_PROVIDER_TEST_CONFIG
-    ).get(ChainId.BASE)!
-    expect(uniRpcProviderBase['providers'][0].url).equal('infura_8453')
-    expect(uniRpcProviderBase['providers'][1].url).equal('quicknode_8453')
-    expect(uniRpcProviderBase['providers'][2].url).equal('alchemy_8453')
-    expect(uniRpcProviderBase['providers'][3].url).equal('nirvana_8453')
-
-    cleanUp()
-
-    randStub.returns(1.0)
-    expect(
-      GlobalRpcProviders.getGlobalUniRpcProviders(log, UNI_PROVIDER_TEST_CONFIG, SINGLE_PROVIDER_TEST_CONFIG).has(
-        ChainId.AVALANCHE
-      )
-    ).to.be.false
+    expect(avaUniProvider['urlWeight']).to.deep.equal({ [url0]: 2, [url1]: 1 })
+    expect(avaUniProvider['providers'][0].url).to.equal(url0)
+    expect(avaUniProvider['providers'][1].url).to.equal(url1)
   })
 
   it('Prepare global UniJsonRpcProvider by reading config: Use prob to decide feature switch', () => {
     process.env = {
-      URL0: 'url0',
-      URL1: 'url1',
+      INFURA_10: 'key0',
+      QUICKNODE_10: 'node1,key1',
+      INFURA_43114: 'key2',
+      QUICKNODE_43114: 'node3,key3',
     }
 
     const rpcProviderProdConfig = [
       {
-        chainId: 1,
+        chainId: 10,
         useMultiProviderProb: 0.3,
-        providerUrls: ['URL0', 'URL1'],
+        providerUrls: ['INFURA_10', 'QUICKNODE_10'],
       },
       {
         chainId: 43114,
         useMultiProviderProb: 0.7,
         sessionAllowProviderFallbackWhenUnhealthy: true,
         providerInitialWeights: [2, 1],
-        providerUrls: ['URL0', 'URL1'],
+        providerUrls: ['INFURA_43114', 'QUICKNODE_43114'],
       },
     ]
 
@@ -229,7 +133,7 @@ describe('GlobalRpcProviders', () => {
         UNI_PROVIDER_TEST_CONFIG,
         SINGLE_PROVIDER_TEST_CONFIG,
         rpcProviderProdConfig
-      ).has(ChainId.MAINNET)
+      ).has(ChainId.OPTIMISM)
     ).to.be.true
     expect(
       GlobalRpcProviders.getGlobalUniRpcProviders(
@@ -248,7 +152,7 @@ describe('GlobalRpcProviders', () => {
         UNI_PROVIDER_TEST_CONFIG,
         SINGLE_PROVIDER_TEST_CONFIG,
         rpcProviderProdConfig
-      ).has(ChainId.MAINNET)
+      ).has(ChainId.OPTIMISM)
     ).to.be.true
     expect(
       GlobalRpcProviders.getGlobalUniRpcProviders(
@@ -267,7 +171,7 @@ describe('GlobalRpcProviders', () => {
         UNI_PROVIDER_TEST_CONFIG,
         SINGLE_PROVIDER_TEST_CONFIG,
         rpcProviderProdConfig
-      ).has(ChainId.MAINNET)
+      ).has(ChainId.OPTIMISM)
     ).to.be.false
     expect(
       GlobalRpcProviders.getGlobalUniRpcProviders(
@@ -286,7 +190,7 @@ describe('GlobalRpcProviders', () => {
         UNI_PROVIDER_TEST_CONFIG,
         SINGLE_PROVIDER_TEST_CONFIG,
         rpcProviderProdConfig
-      ).has(ChainId.MAINNET)
+      ).has(ChainId.OPTIMISM)
     ).to.be.false
     expect(
       GlobalRpcProviders.getGlobalUniRpcProviders(
@@ -305,7 +209,7 @@ describe('GlobalRpcProviders', () => {
         UNI_PROVIDER_TEST_CONFIG,
         SINGLE_PROVIDER_TEST_CONFIG,
         rpcProviderProdConfig
-      ).has(ChainId.MAINNET)
+      ).has(ChainId.OPTIMISM)
     ).to.be.false
     expect(
       GlobalRpcProviders.getGlobalUniRpcProviders(
@@ -324,7 +228,7 @@ describe('GlobalRpcProviders', () => {
         UNI_PROVIDER_TEST_CONFIG,
         SINGLE_PROVIDER_TEST_CONFIG,
         rpcProviderProdConfig
-      ).has(ChainId.MAINNET)
+      ).has(ChainId.OPTIMISM)
     ).to.be.false
     expect(
       GlobalRpcProviders.getGlobalUniRpcProviders(
@@ -334,6 +238,87 @@ describe('GlobalRpcProviders', () => {
         rpcProviderProdConfig
       ).has(ChainId.AVALANCHE)
     ).to.be.false
+    cleanUp()
+  })
+
+  it('Prepare global UniJsonRpcProvider by reading config file', () => {
+    process.env = {
+      INFURA_43114: 'key0',
+      QUICKNODE_43114: 'host1,key1',
+      NIRVANA_43114: 'host2,key2',
+      INFURA_10: 'key3',
+      QUICKNODE_10: 'host3,key3',
+      NIRVANA_10: 'host4,key4',
+      ALCHEMY_10: 'key5',
+      INFURA_42220: 'key6',
+      QUICKNODE_42220: 'host7,key7',
+      QUICKNODE_56: 'host8,key8',
+      INFURA_137: 'key9',
+      QUICKNODE_137: 'host10,key10',
+      ALCHEMY_137: 'key11',
+      INFURA_8453: 'key12',
+      QUICKNODE_8453: 'host13,key13',
+      ALCHEMY_8453: 'key14',
+      NIRVANA_8453: 'host15,key15',
+    }
+
+    const uniRpcProviderAvalanche = GlobalRpcProviders.getGlobalUniRpcProviders(
+      log,
+      UNI_PROVIDER_TEST_CONFIG,
+      SINGLE_PROVIDER_TEST_CONFIG
+    ).get(ChainId.AVALANCHE)!
+    expect(uniRpcProviderAvalanche['providers'][0].url).equal('https://avalanche-mainnet.infura.io/v3/key0')
+    expect(uniRpcProviderAvalanche['providers'][1].url).equal(
+      'https://host1.avalanche-mainnet.quiknode.pro/key1/ext/bc/C/rpc/'
+    )
+    expect(uniRpcProviderAvalanche['providers'][2].url).equal(
+      'https://avax.nirvanalabs.xyz/host2/ext/bc/C/rpc?apikey=key2'
+    )
+
+    const uniRpcProviderOptimism = GlobalRpcProviders.getGlobalUniRpcProviders(
+      log,
+      UNI_PROVIDER_TEST_CONFIG,
+      SINGLE_PROVIDER_TEST_CONFIG
+    ).get(ChainId.OPTIMISM)!!
+    expect(uniRpcProviderOptimism['providers'][0].url).equal('https://optimism-mainnet.infura.io/v3/key3')
+    expect(uniRpcProviderOptimism['providers'][1].url).equal('https://host3.optimism.quiknode.pro/key3')
+    expect(uniRpcProviderOptimism['providers'][2].url).equal('https://optimism.nirvanalabs.xyz/host4?apikey=key4')
+    expect(uniRpcProviderOptimism['providers'][3].url).equal('https://opt-mainnet.g.alchemy.com/v2/key5')
+
+    const uniRpcProviderCelo = GlobalRpcProviders.getGlobalUniRpcProviders(
+      log,
+      UNI_PROVIDER_TEST_CONFIG,
+      SINGLE_PROVIDER_TEST_CONFIG
+    ).get(ChainId.CELO)!!
+    expect(uniRpcProviderCelo['providers'][0].url).equal('https://celo-mainnet.infura.io/v3/key6')
+    expect(uniRpcProviderCelo['providers'][1].url).equal('https://host7.celo-mainnet.quiknode.pro/key7')
+
+    const uniRpcProviderBnb = GlobalRpcProviders.getGlobalUniRpcProviders(
+      log,
+      UNI_PROVIDER_TEST_CONFIG,
+      SINGLE_PROVIDER_TEST_CONFIG
+    ).get(ChainId.BNB)!!
+    expect(uniRpcProviderBnb['providers'][0].url).equal('https://host8.bsc.quiknode.pro/key8')
+
+    const uniRpcProviderPolygon = GlobalRpcProviders.getGlobalUniRpcProviders(
+      log,
+      UNI_PROVIDER_TEST_CONFIG,
+      SINGLE_PROVIDER_TEST_CONFIG
+    ).get(ChainId.POLYGON)!
+    expect(uniRpcProviderPolygon['providers'][0].url).equal('https://polygon-mainnet.infura.io/v3/key9')
+    expect(uniRpcProviderPolygon['providers'][1].url).equal('https://host10.matic.quiknode.pro/key10')
+    expect(uniRpcProviderPolygon['providers'][2].url).equal('https://polygon-mainnet.g.alchemy.com/v2/key11')
+
+    const uniRpcProviderBase = GlobalRpcProviders.getGlobalUniRpcProviders(
+      log,
+      UNI_PROVIDER_TEST_CONFIG,
+      SINGLE_PROVIDER_TEST_CONFIG
+    ).get(ChainId.BASE)!
+    expect(uniRpcProviderBase['providers'][0].url).equal('https://base-mainnet.infura.io/v3/key12')
+    expect(uniRpcProviderBase['providers'][1].url).equal('https://host13.base0-mainnet.quiknode.pro/key13')
+    expect(uniRpcProviderBase['providers'][2].url).equal('https://base-mainnet.g.alchemy.com/v2/key14')
+    expect(uniRpcProviderBase['providers'][3].url).equal('https://base.nirvanalabs.xyz/host15?apikey=key15')
+
     cleanUp()
   })
 })

--- a/test/mocha/unit/rpc/GlobalRpcProviders.test.ts
+++ b/test/mocha/unit/rpc/GlobalRpcProviders.test.ts
@@ -315,7 +315,7 @@ describe('GlobalRpcProviders', () => {
       SINGLE_PROVIDER_TEST_CONFIG
     ).get(ChainId.BASE)!
     expect(uniRpcProviderBase['providers'][0].url).equal('https://base-mainnet.infura.io/v3/key12')
-    expect(uniRpcProviderBase['providers'][1].url).equal('https://host13.base0-mainnet.quiknode.pro/key13')
+    expect(uniRpcProviderBase['providers'][1].url).equal('https://host13.base-mainnet.quiknode.pro/key13')
     expect(uniRpcProviderBase['providers'][2].url).equal('https://base-mainnet.g.alchemy.com/v2/key14')
     expect(uniRpcProviderBase['providers'][3].url).equal('https://base.nirvanalabs.xyz/host15?apikey=key15')
 

--- a/test/mocha/unit/rpc/GlobalRpcProviders.test.ts
+++ b/test/mocha/unit/rpc/GlobalRpcProviders.test.ts
@@ -110,6 +110,16 @@ describe('GlobalRpcProviders', () => {
       QUICKNODE_10: 'quicknode_10',
       NIRVANA_10: 'nirvana_10',
       ALCHEMY_10: 'alchemy_10',
+      INFURA_42220: 'infura_42220',
+      QUICKNODE_42220: 'quicknode_42220',
+      QUICKNODE_56: 'quicknode_56',
+      INFURA_137: 'infura_137',
+      QUICKNODE_137: 'quicknode_137',
+      ALCHEMY_137: 'alchemy_137',
+      INFURA_8453: 'infura_8453',
+      QUICKNODE_8453: 'quicknode_8453',
+      ALCHEMY_8453: 'alchemy_8453',
+      NIRVANA_8453: 'nirvana_8453',
     }
 
     const randStub = sandbox.stub(Math, 'random')
@@ -145,6 +155,40 @@ describe('GlobalRpcProviders', () => {
     expect(uniRpcProviderOptimism['providers'][1].url).equal('quicknode_10')
     expect(uniRpcProviderOptimism['providers'][2].url).equal('nirvana_10')
     expect(uniRpcProviderOptimism['providers'][3].url).equal('alchemy_10')
+
+    const uniRpcProviderCelo = GlobalRpcProviders.getGlobalUniRpcProviders(
+      log,
+      UNI_PROVIDER_TEST_CONFIG,
+      SINGLE_PROVIDER_TEST_CONFIG
+    ).get(ChainId.CELO)!!
+    expect(uniRpcProviderCelo['providers'][0].url).equal('infura_42220')
+    expect(uniRpcProviderCelo['providers'][1].url).equal('quicknode_42220')
+
+    const uniRpcProviderBnb = GlobalRpcProviders.getGlobalUniRpcProviders(
+      log,
+      UNI_PROVIDER_TEST_CONFIG,
+      SINGLE_PROVIDER_TEST_CONFIG
+    ).get(ChainId.BNB)!!
+    expect(uniRpcProviderBnb['providers'][0].url).equal('quicknode_56')
+
+    const uniRpcProviderPolygon = GlobalRpcProviders.getGlobalUniRpcProviders(
+      log,
+      UNI_PROVIDER_TEST_CONFIG,
+      SINGLE_PROVIDER_TEST_CONFIG
+    ).get(ChainId.POLYGON)!
+    expect(uniRpcProviderPolygon['providers'][0].url).equal('infura_137')
+    expect(uniRpcProviderPolygon['providers'][1].url).equal('quicknode_137')
+    expect(uniRpcProviderPolygon['providers'][2].url).equal('alchemy_137')
+
+    const uniRpcProviderBase = GlobalRpcProviders.getGlobalUniRpcProviders(
+      log,
+      UNI_PROVIDER_TEST_CONFIG,
+      SINGLE_PROVIDER_TEST_CONFIG
+    ).get(ChainId.BASE)!
+    expect(uniRpcProviderBase['providers'][0].url).equal('infura_8453')
+    expect(uniRpcProviderBase['providers'][1].url).equal('quicknode_8453')
+    expect(uniRpcProviderBase['providers'][2].url).equal('alchemy_8453')
+    expect(uniRpcProviderBase['providers'][3].url).equal('nirvana_8453')
 
     cleanUp()
 


### PR DESCRIPTION
This launches RPC gateway to Avalance, Optimsm, Celo, BNB, Polygon and Base.

Testing
- Deploy to local env works
- Sample requests (for these 6 chains) to local env works
- Local env dashboard looks fine
- Didn't encounter env variable 4KB limit issue when deploying to local env