### PR TITLE
docs: misspelt word in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Integration tests run against a local DynamoDB node deployed using [dynamodb-loc
 
 The end-to-end tests fetch quotes from your deployed API, then execute the swaps on a Hardhat mainnet fork.
 
-1. First deploy your test API using the intructions above. Then update your `.env` file with the URL of the API, and the RPC URL of an archive node:
+1. First deploy your test API using the instructions above. Then update your `.env` file with the URL of the API, and the RPC URL of an archive node:
 
    ```
    UNISWAP_ROUTING_API='...'


### PR DESCRIPTION
Tiny PR fixing a misspelt word that I found while working on forking this repo