### PR TITLE
feat: shadow quote new quoter v2 on Polygon Mumbai and Sepolia

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -307,6 +307,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
               quoteProvider = new TrafficSwitchOnChainQuoteProvider({
                 currentQuoteProvider: currentQuoteProvider,
                 targetQuoteProvider: targetQuoteProvider,
+                chainId: chainId,
               })
               break
             case ChainId.BASE:

--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -280,7 +280,8 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
           // 200*725k < 150m
           let quoteProvider: IOnChainQuoteProvider | undefined = undefined
           switch (chainId) {
-            case ChainId.POLYGON:
+            case ChainId.SEPOLIA:
+            case ChainId.POLYGON_MUMBAI:
               const currentQuoteProvider = new OnChainQuoteProvider(
                 chainId,
                 provider,

--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -271,7 +271,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
           // 200*725k < 150m
           let quoteProvider: IOnChainQuoteProvider | undefined = undefined
           switch (chainId) {
-            case ChainId.MAINNET:
+            case ChainId.POLYGON:
               const currentQuoteProvider = new OnChainQuoteProvider(
                 chainId,
                 provider,

--- a/lib/handlers/quote/provider-migration/v3/traffic-switch-on-chain-quote-provider.ts
+++ b/lib/handlers/quote/provider-migration/v3/traffic-switch-on-chain-quote-provider.ts
@@ -14,10 +14,14 @@ export class TrafficSwitchOnChainQuoteProvider implements IOnChainQuoteProvider 
   private readonly currentQuoteProvider: IOnChainQuoteProvider
   private readonly targetQuoteProvider: IOnChainQuoteProvider
 
-  protected readonly SHOULD_SWITCH_TRAFFIC = () =>
-    QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION.switchPercentage > this.getRandomPercentage()
-  protected readonly SHOULD_SAMPLE_TRAFFIC = () =>
-    QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION.samplingPercentage > this.getRandomPercentage()
+  protected readonly SHOULD_SWITCH_EXACT_IN_TRAFFIC = () =>
+    QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION.switchExactInPercentage > this.getRandomPercentage()
+  protected readonly SHOULD_SAMPLE_EXACT_IN_TRAFFIC = () =>
+    QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION.samplingExactInPercentage > this.getRandomPercentage()
+  protected readonly SHOULD_SWITCH_EXACT_OUT_TRAFFIC = () =>
+    QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION.switchExactOutPercentage > this.getRandomPercentage()
+  protected readonly SHOULD_SAMPLE_EXACT_OUT_TRAFFIC = () =>
+    QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION.samplingExactOutPercentage > this.getRandomPercentage()
 
   constructor(props: TrafficSwitchOnChainQuoteProviderProps) {
     this.currentQuoteProvider = props.currentQuoteProvider
@@ -32,8 +36,8 @@ export class TrafficSwitchOnChainQuoteProvider implements IOnChainQuoteProvider 
     routesWithQuotes: RouteWithQuotes<TRoute>[]
     blockNumber: BigNumber
   }> {
-    const sampleTraffic = this.SHOULD_SAMPLE_TRAFFIC()
-    const switchTraffic = this.SHOULD_SWITCH_TRAFFIC()
+    const sampleTraffic = this.SHOULD_SAMPLE_EXACT_IN_TRAFFIC()
+    const switchTraffic = this.SHOULD_SWITCH_EXACT_IN_TRAFFIC()
 
     let currentQuote
     let targetQuote
@@ -66,8 +70,8 @@ export class TrafficSwitchOnChainQuoteProvider implements IOnChainQuoteProvider 
     routesWithQuotes: RouteWithQuotes<TRoute>[]
     blockNumber: BigNumber
   }> {
-    const sampleTraffic = this.SHOULD_SAMPLE_TRAFFIC()
-    const switchTraffic = this.SHOULD_SWITCH_TRAFFIC()
+    const sampleTraffic = this.SHOULD_SWITCH_EXACT_OUT_TRAFFIC()
+    const switchTraffic = this.SHOULD_SAMPLE_EXACT_OUT_TRAFFIC()
 
     let currentQuote
     let targetQuote

--- a/lib/handlers/quote/provider-migration/v3/traffic-switch-on-chain-quote-provider.ts
+++ b/lib/handlers/quote/provider-migration/v3/traffic-switch-on-chain-quote-provider.ts
@@ -1,0 +1,91 @@
+import { IOnChainQuoteProvider, metric, MetricLoggerUnit, RouteWithQuotes } from '@uniswap/smart-order-router'
+import { MixedRoute, V2Route, V3Route } from '@uniswap/smart-order-router/build/main/routers'
+import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
+import { ProviderConfig } from '@uniswap/smart-order-router/build/main/providers/provider'
+import { BigNumber } from 'ethers'
+import { QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION } from '../../util/quote-provider-traffic-switch-configuration'
+
+export type TrafficSwitchOnChainQuoteProviderProps = {
+  currentQuoteProvider: IOnChainQuoteProvider
+  targetQuoteProvider: IOnChainQuoteProvider
+}
+
+export class TrafficSwitchOnChainQuoteProvider implements IOnChainQuoteProvider {
+  private readonly currentQuoteProvider: IOnChainQuoteProvider
+  private readonly targetQuoteProvider: IOnChainQuoteProvider
+
+  protected readonly SHOULD_SWITCH_TRAFFIC = () =>
+    QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION.switchPercentage > this.getRandomPercentage()
+  protected readonly SHOULD_SAMPLE_TRAFFIC = () =>
+    QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION.samplingPercentage > this.getRandomPercentage()
+
+
+  constructor(props: TrafficSwitchOnChainQuoteProviderProps) {
+    this.currentQuoteProvider = props.currentQuoteProvider
+    this.targetQuoteProvider = props.targetQuoteProvider
+  }
+
+  async getQuotesManyExactIn<TRoute extends V3Route | V2Route | MixedRoute>(amountIns: CurrencyAmount<Currency>[], routes: TRoute[], providerConfig?: ProviderConfig): Promise<{
+    routesWithQuotes: RouteWithQuotes<TRoute>[];
+    blockNumber: BigNumber
+  }> {
+    const sampleTraffic = this.SHOULD_SAMPLE_TRAFFIC()
+    const switchTraffic = this.SHOULD_SWITCH_TRAFFIC()
+
+    let currentQuote;
+    let targetQuote;
+
+    metric.putMetric('ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_TOTAL', 1, MetricLoggerUnit.None)
+
+    if (sampleTraffic) {
+      metric.putMetric('ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_SAMPLING', 1, MetricLoggerUnit.None)
+
+      currentQuote = await this.currentQuoteProvider.getQuotesManyExactIn(amountIns, routes, providerConfig)
+      targetQuote = await this.targetQuoteProvider.getQuotesManyExactIn(amountIns, routes, providerConfig)
+    }
+
+    if (switchTraffic) {
+      metric.putMetric('ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_TARGET', 1, MetricLoggerUnit.None)
+
+      return targetQuote ?? await this.targetQuoteProvider.getQuotesManyExactIn(amountIns, routes, providerConfig)
+    } else {
+      metric.putMetric('ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT', 1, MetricLoggerUnit.None)
+
+      return currentQuote ?? await this.currentQuoteProvider.getQuotesManyExactIn(amountIns, routes, providerConfig)
+    }
+  }
+
+  async getQuotesManyExactOut<TRoute extends V3Route>(amountOuts: CurrencyAmount<Currency>[], routes: TRoute[], providerConfig?: ProviderConfig): Promise<{
+    routesWithQuotes: RouteWithQuotes<TRoute>[];
+    blockNumber: BigNumber
+  }> {
+    const sampleTraffic = this.SHOULD_SAMPLE_TRAFFIC()
+    const switchTraffic = this.SHOULD_SWITCH_TRAFFIC()
+
+    let currentQuote;
+    let targetQuote;
+
+    metric.putMetric('ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_TOTAL', 1, MetricLoggerUnit.None)
+
+    if (sampleTraffic) {
+      metric.putMetric('ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_SAMPLING', 1, MetricLoggerUnit.None)
+
+      currentQuote = await this.currentQuoteProvider.getQuotesManyExactOut(amountOuts, routes, providerConfig)
+      targetQuote = await this.targetQuoteProvider.getQuotesManyExactOut(amountOuts, routes, providerConfig)
+    }
+
+    if (switchTraffic) {
+      metric.putMetric('ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_TARGET', 1, MetricLoggerUnit.None)
+
+      return targetQuote ?? await this.targetQuoteProvider.getQuotesManyExactOut(amountOuts, routes, providerConfig)
+    } else {
+      metric.putMetric('ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_CURRENT', 1, MetricLoggerUnit.None)
+
+      return currentQuote ?? await this.currentQuoteProvider.getQuotesManyExactOut(amountOuts, routes, providerConfig)
+    }
+  }
+
+  private getRandomPercentage(): number {
+    return Math.floor(Math.random() * 100)
+  }
+}

--- a/lib/handlers/quote/provider-migration/v3/traffic-switch-on-chain-quote-provider.ts
+++ b/lib/handlers/quote/provider-migration/v3/traffic-switch-on-chain-quote-provider.ts
@@ -1,9 +1,9 @@
-import { IOnChainQuoteProvider, metric, MetricLoggerUnit, RouteWithQuotes } from '@uniswap/smart-order-router'
+import { IOnChainQuoteProvider, log, metric, MetricLoggerUnit, OnChainQuotes } from '@uniswap/smart-order-router'
 import { MixedRoute, V2Route, V3Route } from '@uniswap/smart-order-router/build/main/routers'
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 import { ProviderConfig } from '@uniswap/smart-order-router/build/main/providers/provider'
-import { BigNumber } from 'ethers'
 import { QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION } from '../../util/quote-provider-traffic-switch-configuration'
+import { BigNumber } from 'ethers'
 
 export type TrafficSwitchOnChainQuoteProviderProps = {
   currentQuoteProvider: IOnChainQuoteProvider
@@ -23,6 +23,9 @@ export class TrafficSwitchOnChainQuoteProvider implements IOnChainQuoteProvider 
   protected readonly SHOULD_SAMPLE_EXACT_OUT_TRAFFIC = () =>
     QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION.samplingExactOutPercentage > this.getRandomPercentage()
 
+  private readonly EXACT_IN_METRIC = 'EXACT_IN'
+  private readonly EXACT_OUT_METRIC = 'EXACT_OUT'
+
   constructor(props: TrafficSwitchOnChainQuoteProviderProps) {
     this.currentQuoteProvider = props.currentQuoteProvider
     this.targetQuoteProvider = props.targetQuoteProvider
@@ -32,33 +35,80 @@ export class TrafficSwitchOnChainQuoteProvider implements IOnChainQuoteProvider 
     amountIns: CurrencyAmount<Currency>[],
     routes: TRoute[],
     providerConfig?: ProviderConfig
-  ): Promise<{
-    routesWithQuotes: RouteWithQuotes<TRoute>[]
-    blockNumber: BigNumber
-  }> {
+  ): Promise<OnChainQuotes<TRoute>> {
     const sampleTraffic = this.SHOULD_SAMPLE_EXACT_IN_TRAFFIC()
     const switchTraffic = this.SHOULD_SWITCH_EXACT_IN_TRAFFIC()
 
-    let currentQuote
-    let targetQuote
+    let [currentRoutesWithQuotes, targetRoutesWithQuotes]: [
+      OnChainQuotes<TRoute> | undefined,
+      OnChainQuotes<TRoute> | undefined
+    ] = [undefined, undefined]
 
-    metric.putMetric('ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_TOTAL', 1, MetricLoggerUnit.None)
+    metric.putMetric(`ON_CHAIN_QUOTE_PROVIDER_${this.EXACT_IN_METRIC}_TRAFFIC_TOTAL`, 1, MetricLoggerUnit.None)
 
     if (sampleTraffic) {
-      metric.putMetric('ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_SAMPLING', 1, MetricLoggerUnit.None)
+      metric.putMetric(`ON_CHAIN_QUOTE_PROVIDER_${this.EXACT_IN_METRIC}_TRAFFIC_SAMPLING`, 1, MetricLoggerUnit.None)
+      const startTime = Date.now()
+      let targetQuoteFailedError = undefined
 
-      currentQuote = await this.currentQuoteProvider.getQuotesManyExactIn(amountIns, routes, providerConfig)
-      targetQuote = await this.targetQuoteProvider.getQuotesManyExactIn(amountIns, routes, providerConfig)
+      ;[currentRoutesWithQuotes, targetRoutesWithQuotes] = await Promise.all([
+        this.currentQuoteProvider.getQuotesManyExactIn(amountIns, routes, providerConfig).then((res) => {
+          const endTime = Date.now()
+          metric.putMetric(
+            `ON_CHAIN_QUOTE_PROVIDER_${this.EXACT_IN_METRIC}_TRAFFIC_CURRENT_LATENCIES`,
+            endTime - startTime,
+            MetricLoggerUnit.Milliseconds
+          )
+          return res
+        }),
+        this.targetQuoteProvider
+          .getQuotesManyExactIn(amountIns, routes, providerConfig)
+          .then((res) => {
+            const endTime = Date.now()
+            metric.putMetric(
+              `ON_CHAIN_QUOTE_PROVIDER_${this.EXACT_IN_METRIC}_TRAFFIC_TARGET_LATENCIES`,
+              endTime - startTime,
+              MetricLoggerUnit.Milliseconds
+            )
+            return res
+          })
+          .catch((error) => {
+            // Since we are sampling the target quoter here, if it throws error, we should swallow and track it.
+            targetQuoteFailedError = error
+            return undefined
+          }),
+      ])
+
+      if (targetQuoteFailedError) {
+        // If we can enter here, it means the current quoter can return without throwing error,
+        // but the new quoter threw error, and we swallowed exception here. This is the case worth tracking.
+        log.error({ targetQuoteFailedError }, 'Target quoter failed to return quotes')
+        metric.putMetric(
+          `ON_CHAIN_QUOTE_PROVIDER_${this.EXACT_IN_METRIC}_TRAFFIC_TARGET_FAILED`,
+          1,
+          MetricLoggerUnit.None
+        )
+      }
+
+      if (currentRoutesWithQuotes && targetRoutesWithQuotes) {
+        this.compareQuotes(this.EXACT_IN_METRIC, currentRoutesWithQuotes, targetRoutesWithQuotes)
+      }
     }
 
     if (switchTraffic) {
-      metric.putMetric('ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_TARGET', 1, MetricLoggerUnit.None)
+      metric.putMetric(`ON_CHAIN_QUOTE_PROVIDER_${this.EXACT_IN_METRIC}_TRAFFIC_TARGET`, 1, MetricLoggerUnit.None)
 
-      return targetQuote ?? (await this.targetQuoteProvider.getQuotesManyExactIn(amountIns, routes, providerConfig))
+      return (
+        targetRoutesWithQuotes ??
+        (await this.targetQuoteProvider.getQuotesManyExactIn(amountIns, routes, providerConfig))
+      )
     } else {
-      metric.putMetric('ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT', 1, MetricLoggerUnit.None)
+      metric.putMetric(`ON_CHAIN_QUOTE_PROVIDER_${this.EXACT_IN_METRIC}_TRAFFIC_CURRENT`, 1, MetricLoggerUnit.None)
 
-      return currentQuote ?? (await this.currentQuoteProvider.getQuotesManyExactIn(amountIns, routes, providerConfig))
+      return (
+        currentRoutesWithQuotes ??
+        (await this.currentQuoteProvider.getQuotesManyExactIn(amountIns, routes, providerConfig))
+      )
     }
   }
 
@@ -66,33 +116,154 @@ export class TrafficSwitchOnChainQuoteProvider implements IOnChainQuoteProvider 
     amountOuts: CurrencyAmount<Currency>[],
     routes: TRoute[],
     providerConfig?: ProviderConfig
-  ): Promise<{
-    routesWithQuotes: RouteWithQuotes<TRoute>[]
-    blockNumber: BigNumber
-  }> {
+  ): Promise<OnChainQuotes<TRoute>> {
     const sampleTraffic = this.SHOULD_SWITCH_EXACT_OUT_TRAFFIC()
     const switchTraffic = this.SHOULD_SAMPLE_EXACT_OUT_TRAFFIC()
 
-    let currentQuote
-    let targetQuote
-
-    metric.putMetric('ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_TOTAL', 1, MetricLoggerUnit.None)
+    let [currentRoutesWithQuotes, targetRoutesWithQuotes]: [
+      OnChainQuotes<TRoute> | undefined,
+      OnChainQuotes<TRoute> | undefined
+    ] = [undefined, undefined]
+    metric.putMetric(`ON_CHAIN_QUOTE_PROVIDER_${this.EXACT_OUT_METRIC}_TRAFFIC_TOTAL`, 1, MetricLoggerUnit.None)
 
     if (sampleTraffic) {
-      metric.putMetric('ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_SAMPLING', 1, MetricLoggerUnit.None)
+      metric.putMetric(`ON_CHAIN_QUOTE_PROVIDER_${this.EXACT_OUT_METRIC}_TRAFFIC_SAMPLING`, 1, MetricLoggerUnit.None)
+      const startTime = Date.now()
+      let targetQuoteFailedError = undefined
 
-      currentQuote = await this.currentQuoteProvider.getQuotesManyExactOut(amountOuts, routes, providerConfig)
-      targetQuote = await this.targetQuoteProvider.getQuotesManyExactOut(amountOuts, routes, providerConfig)
+      ;[currentRoutesWithQuotes, targetRoutesWithQuotes] = await Promise.all([
+        await this.currentQuoteProvider.getQuotesManyExactOut(amountOuts, routes, providerConfig).then((res) => {
+          const endTime = Date.now()
+          metric.putMetric(
+            `ON_CHAIN_QUOTE_PROVIDER_${this.EXACT_OUT_METRIC}_TRAFFIC_CURRENT_LATENCIES`,
+            endTime - startTime,
+            MetricLoggerUnit.Milliseconds
+          )
+          return res
+        }),
+        await this.targetQuoteProvider
+          .getQuotesManyExactOut(amountOuts, routes, providerConfig)
+          .then((res) => {
+            const endTime = Date.now()
+            metric.putMetric(
+              `ON_CHAIN_QUOTE_PROVIDER_${this.EXACT_OUT_METRIC}_TRAFFIC_TARGET_LATENCIES`,
+              endTime - startTime,
+              MetricLoggerUnit.Milliseconds
+            )
+            return res
+          })
+          .catch((error) => {
+            // Since we are sampling the target quoter here, if it throws error, we should swallow and track it.
+            targetQuoteFailedError = error
+            return undefined
+          }),
+      ])
+
+      if (targetQuoteFailedError) {
+        // If we can enter here, it means the current quoter can return without throwing error,
+        // but the new quoter threw error, and we swallowed exception here. This is the case worth tracking.
+        log.error({ targetQuoteFailedError }, 'Target quoter failed to return quotes')
+        metric.putMetric(
+          `ON_CHAIN_QUOTE_PROVIDER_${this.EXACT_OUT_METRIC}_TRAFFIC_TARGET_FAILED`,
+          1,
+          MetricLoggerUnit.None
+        )
+      }
+
+      if (currentRoutesWithQuotes && targetRoutesWithQuotes) {
+        this.compareQuotes(this.EXACT_OUT_METRIC, currentRoutesWithQuotes, targetRoutesWithQuotes)
+      }
     }
 
     if (switchTraffic) {
-      metric.putMetric('ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_TARGET', 1, MetricLoggerUnit.None)
+      metric.putMetric(`ON_CHAIN_QUOTE_PROVIDER_${this.EXACT_OUT_METRIC}_TRAFFIC_TARGET`, 1, MetricLoggerUnit.None)
 
-      return targetQuote ?? (await this.targetQuoteProvider.getQuotesManyExactOut(amountOuts, routes, providerConfig))
+      return (
+        targetRoutesWithQuotes ??
+        (await this.targetQuoteProvider.getQuotesManyExactOut(amountOuts, routes, providerConfig))
+      )
     } else {
-      metric.putMetric('ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_CURRENT', 1, MetricLoggerUnit.None)
+      metric.putMetric(`ON_CHAIN_QUOTE_PROVIDER_${this.EXACT_OUT_METRIC}_TRAFFIC_CURRENT`, 1, MetricLoggerUnit.None)
 
-      return currentQuote ?? (await this.currentQuoteProvider.getQuotesManyExactOut(amountOuts, routes, providerConfig))
+      return (
+        currentRoutesWithQuotes ??
+        (await this.currentQuoteProvider.getQuotesManyExactOut(amountOuts, routes, providerConfig))
+      )
+    }
+  }
+
+  private compareQuotes<TRoute extends V3Route | V2Route | MixedRoute>(
+    tradeTypeMetric: string,
+    currentRoutesWithQuotes: OnChainQuotes<TRoute>,
+    targetRoutesWithQuotes: OnChainQuotes<TRoute>
+  ): void {
+    if (currentRoutesWithQuotes.routesWithQuotes.length !== targetRoutesWithQuotes.routesWithQuotes.length) {
+      log.error(
+        {
+          currentQuoteRoutesLength: currentRoutesWithQuotes.routesWithQuotes.length,
+          targetQuoteRoutesLength: targetRoutesWithQuotes.routesWithQuotes.length,
+        },
+        'Current and target quote providers returned different number of routes with quotes'
+      )
+      metric.putMetric(
+        `ON_CHAIN_QUOTE_PROVIDER_${tradeTypeMetric}_TRAFFIC_CURRENT_AND_TARGET_ROUTES_WITH_QUOTES_MISMATCH`,
+        1,
+        MetricLoggerUnit.None
+      )
+
+      return
+    }
+
+    const length = currentRoutesWithQuotes.routesWithQuotes.length
+
+    for (let i = 0; i < length; i++) {
+      if (currentRoutesWithQuotes.blockNumber !== targetRoutesWithQuotes.blockNumber) {
+        const currentRouteWithQuotes = currentRoutesWithQuotes.routesWithQuotes[i]
+        const targetRouteWithQuotes = targetRoutesWithQuotes.routesWithQuotes[i]
+        const [, currentQuotes] = currentRouteWithQuotes
+        const [, targetQuotes] = targetRouteWithQuotes
+
+        if (currentQuotes.length !== targetQuotes.length) {
+          log.error(
+            {
+              currentQuotesLength: currentQuotes.length,
+              targetQuotesLength: targetQuotes.length,
+            },
+            'Current and target quote providers returned different number of quotes'
+          )
+          metric.putMetric(
+            `ON_CHAIN_QUOTE_PROVIDER_${tradeTypeMetric}_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MISMATCH`,
+            1,
+            MetricLoggerUnit.None
+          )
+
+          return
+        }
+
+        const length = currentQuotes.length
+
+        for (let j = 0; j < length; j++) {
+          const currentQuote = currentQuotes[j]
+          const targetQuote = targetQuotes[j]
+
+          if (currentQuote.quote?.eq(targetQuote.quote ?? BigNumber.from(0))) {
+            log.error(
+              {
+                currentQuote: currentQuote.quote,
+                targetQuote: targetQuote.quote,
+              },
+              'Current and target quote providers returned different quotes'
+            )
+            metric.putMetric(
+              `ON_CHAIN_QUOTE_PROVIDER_${tradeTypeMetric}_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MISMATCH`,
+              1,
+              MetricLoggerUnit.None
+            )
+
+            return
+          }
+        }
+      }
     }
   }
 

--- a/lib/handlers/quote/provider-migration/v3/traffic-switch-on-chain-quote-provider.ts
+++ b/lib/handlers/quote/provider-migration/v3/traffic-switch-on-chain-quote-provider.ts
@@ -19,21 +19,24 @@ export class TrafficSwitchOnChainQuoteProvider implements IOnChainQuoteProvider 
   protected readonly SHOULD_SAMPLE_TRAFFIC = () =>
     QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION.samplingPercentage > this.getRandomPercentage()
 
-
   constructor(props: TrafficSwitchOnChainQuoteProviderProps) {
     this.currentQuoteProvider = props.currentQuoteProvider
     this.targetQuoteProvider = props.targetQuoteProvider
   }
 
-  async getQuotesManyExactIn<TRoute extends V3Route | V2Route | MixedRoute>(amountIns: CurrencyAmount<Currency>[], routes: TRoute[], providerConfig?: ProviderConfig): Promise<{
-    routesWithQuotes: RouteWithQuotes<TRoute>[];
+  async getQuotesManyExactIn<TRoute extends V3Route | V2Route | MixedRoute>(
+    amountIns: CurrencyAmount<Currency>[],
+    routes: TRoute[],
+    providerConfig?: ProviderConfig
+  ): Promise<{
+    routesWithQuotes: RouteWithQuotes<TRoute>[]
     blockNumber: BigNumber
   }> {
     const sampleTraffic = this.SHOULD_SAMPLE_TRAFFIC()
     const switchTraffic = this.SHOULD_SWITCH_TRAFFIC()
 
-    let currentQuote;
-    let targetQuote;
+    let currentQuote
+    let targetQuote
 
     metric.putMetric('ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_TOTAL', 1, MetricLoggerUnit.None)
 
@@ -47,23 +50,27 @@ export class TrafficSwitchOnChainQuoteProvider implements IOnChainQuoteProvider 
     if (switchTraffic) {
       metric.putMetric('ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_TARGET', 1, MetricLoggerUnit.None)
 
-      return targetQuote ?? await this.targetQuoteProvider.getQuotesManyExactIn(amountIns, routes, providerConfig)
+      return targetQuote ?? (await this.targetQuoteProvider.getQuotesManyExactIn(amountIns, routes, providerConfig))
     } else {
       metric.putMetric('ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT', 1, MetricLoggerUnit.None)
 
-      return currentQuote ?? await this.currentQuoteProvider.getQuotesManyExactIn(amountIns, routes, providerConfig)
+      return currentQuote ?? (await this.currentQuoteProvider.getQuotesManyExactIn(amountIns, routes, providerConfig))
     }
   }
 
-  async getQuotesManyExactOut<TRoute extends V3Route>(amountOuts: CurrencyAmount<Currency>[], routes: TRoute[], providerConfig?: ProviderConfig): Promise<{
-    routesWithQuotes: RouteWithQuotes<TRoute>[];
+  async getQuotesManyExactOut<TRoute extends V3Route>(
+    amountOuts: CurrencyAmount<Currency>[],
+    routes: TRoute[],
+    providerConfig?: ProviderConfig
+  ): Promise<{
+    routesWithQuotes: RouteWithQuotes<TRoute>[]
     blockNumber: BigNumber
   }> {
     const sampleTraffic = this.SHOULD_SAMPLE_TRAFFIC()
     const switchTraffic = this.SHOULD_SWITCH_TRAFFIC()
 
-    let currentQuote;
-    let targetQuote;
+    let currentQuote
+    let targetQuote
 
     metric.putMetric('ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_TOTAL', 1, MetricLoggerUnit.None)
 
@@ -77,11 +84,11 @@ export class TrafficSwitchOnChainQuoteProvider implements IOnChainQuoteProvider 
     if (switchTraffic) {
       metric.putMetric('ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_TARGET', 1, MetricLoggerUnit.None)
 
-      return targetQuote ?? await this.targetQuoteProvider.getQuotesManyExactOut(amountOuts, routes, providerConfig)
+      return targetQuote ?? (await this.targetQuoteProvider.getQuotesManyExactOut(amountOuts, routes, providerConfig))
     } else {
       metric.putMetric('ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_CURRENT', 1, MetricLoggerUnit.None)
 
-      return currentQuote ?? await this.currentQuoteProvider.getQuotesManyExactOut(amountOuts, routes, providerConfig)
+      return currentQuote ?? (await this.currentQuoteProvider.getQuotesManyExactOut(amountOuts, routes, providerConfig))
     }
   }
 

--- a/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
+++ b/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
@@ -11,7 +11,16 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
   chainId: ChainId
 ): QuoteProviderTrafficSwitchConfiguration => {
   switch (chainId) {
-    case ChainId.MAINNET:
+    // Mumbai and Sepolia together have well below 50 RPM, so we can shadow sample 100% of traffic
+    case ChainId.POLYGON_MUMBAI:
+    case ChainId.SEPOLIA:
+      return {
+        switchExactInPercentage: 0.0,
+        samplingExactInPercentage: 100,
+        switchExactOutPercentage: 0.0,
+        samplingExactOutPercentage: 100,
+      } as QuoteProviderTrafficSwitchConfiguration
+    // If we accidentally switch a traffic, we have the protection to shadow sample only 0.1% of traffic
     default:
       return {
         switchExactInPercentage: 0.0,

--- a/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
+++ b/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
@@ -1,0 +1,5 @@
+export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = {
+  switchPercentage: 0.0,
+  samplingPercentage: 0.1,
+}
+

--- a/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
+++ b/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
@@ -2,4 +2,3 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = {
   switchPercentage: 0.0,
   samplingPercentage: 0.1,
 }
-

--- a/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
+++ b/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
@@ -1,6 +1,23 @@
-export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = {
-  switchExactInPercentage: 0.0,
-  samplingExactInPercentage: 0.1,
-  switchExactOutPercentage: 0.0,
-  samplingExactOutPercentage: 0.1,
+import { ChainId } from '@uniswap/sdk-core'
+
+export type QuoteProviderTrafficSwitchConfiguration = {
+  switchExactInPercentage: number
+  samplingExactInPercentage: number
+  switchExactOutPercentage: number
+  samplingExactOutPercentage: number
+}
+
+export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
+  chainId: ChainId
+): QuoteProviderTrafficSwitchConfiguration => {
+  switch (chainId) {
+    case ChainId.MAINNET:
+    default:
+      return {
+        switchExactInPercentage: 0.0,
+        samplingExactInPercentage: 0.1,
+        switchExactOutPercentage: 0.0,
+        samplingExactOutPercentage: 0.1,
+      } as QuoteProviderTrafficSwitchConfiguration
+  }
 }

--- a/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
+++ b/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
@@ -1,4 +1,6 @@
 export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = {
-  switchPercentage: 0.0,
-  samplingPercentage: 0.1,
+  switchExactInPercentage: 0.0,
+  samplingExactInPercentage: 0.1,
+  switchExactOutPercentage: 0.0,
+  samplingExactOutPercentage: 0.1,
 }

--- a/lib/util/onChainQuoteProviderConfigs.ts
+++ b/lib/util/onChainQuoteProviderConfigs.ts
@@ -1,0 +1,32 @@
+import {
+  constructSameBatchParamsMap,
+  constructSameBlockNumberConfigsMap,
+  constructSameGasErrorFailureOverridesMap,
+  constructSameRetryOptionsMap,
+  constructSameSuccessRateFailureOverridesMap,
+  DEFAULT_BATCH_PARAMS,
+  DEFAULT_BLOCK_NUMBER_CONFIGS,
+  DEFAULT_GAS_ERROR_FAILURE_OVERRIDES,
+  DEFAULT_RETRY_OPTIONS,
+  DEFAULT_SUCCESS_RATE_FAILURE_OVERRIDES,
+} from '@uniswap/smart-order-router/build/main/util/onchainQuoteProviderConfigs'
+
+export const RETRY_OPTIONS = {
+  ...constructSameRetryOptionsMap(DEFAULT_RETRY_OPTIONS),
+}
+
+export const BATCH_PARAMS = {
+  ...constructSameBatchParamsMap(DEFAULT_BATCH_PARAMS),
+}
+
+export const GAS_ERROR_FAILURE_OVERRIDES = {
+  ...constructSameGasErrorFailureOverridesMap(DEFAULT_GAS_ERROR_FAILURE_OVERRIDES),
+}
+
+export const SUCCESS_RATE_FAILURE_OVERRIDES = {
+  ...constructSameSuccessRateFailureOverridesMap(DEFAULT_SUCCESS_RATE_FAILURE_OVERRIDES),
+}
+
+export const BLOCK_NUMBER_CONFIGS = {
+  ...constructSameBlockNumberConfigsMap(DEFAULT_BLOCK_NUMBER_CONFIGS),
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@uniswap/permit2-sdk": "^1.2.0",
         "@uniswap/router-sdk": "^1.9.0",
         "@uniswap/sdk-core": "^4.2.0",
-        "@uniswap/smart-order-router": "3.26.1",
+        "@uniswap/smart-order-router": "3.27.0",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^1.8.1",
         "@uniswap/v2-sdk": "^4.3.0",
@@ -4738,9 +4738,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.26.1",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.26.1.tgz",
-      "integrity": "sha512-UebeN1ZdZjQthO5c/4n2a+2F0qH9QD1fqaXlRvrq4iFO6kO63DsoyOGSgIGeRbCY9QI0a5ycJdZRlyADGifK1Q==",
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.27.0.tgz",
+      "integrity": "sha512-yKkv9HMroGnv8Q22Iyu5ApDfk9diB7AzfD7Z0oV1C67BxdvwRAm3krmdKSVvL0ewVHsaKTn1V7zaRio/N2xZyA==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -28346,9 +28346,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.26.1",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.26.1.tgz",
-      "integrity": "sha512-UebeN1ZdZjQthO5c/4n2a+2F0qH9QD1fqaXlRvrq4iFO6kO63DsoyOGSgIGeRbCY9QI0a5ycJdZRlyADGifK1Q==",
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.27.0.tgz",
+      "integrity": "sha512-yKkv9HMroGnv8Q22Iyu5ApDfk9diB7AzfD7Z0oV1C67BxdvwRAm3krmdKSVvL0ewVHsaKTn1V7zaRio/N2xZyA==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@uniswap/permit2-sdk": "^1.2.0",
     "@uniswap/router-sdk": "^1.9.0",
     "@uniswap/sdk-core": "^4.2.0",
-    "@uniswap/smart-order-router": "3.26.1",
+    "@uniswap/smart-order-router": "3.27.0",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^1.8.1",
     "@uniswap/v2-sdk": "^4.3.0",

--- a/test/mocha/integ/handlers/pools/provider-migration/traffic-switch-pool-provider.test.ts
+++ b/test/mocha/integ/handlers/pools/provider-migration/traffic-switch-pool-provider.test.ts
@@ -24,15 +24,15 @@ import {
 describe('TrafficSwitchV3PoolProvider', async () => {
   setupTables(TEST_ROUTE_TABLE)
 
-  let spy: SinonSpy;
+  let spy: SinonSpy
 
   beforeEach(() => {
     spy = sinon.spy(metric, 'putMetric')
-  });
+  })
 
   afterEach(() => {
     spy.restore()
-  });
+  })
 
   it('switch traffic and sample pools with accurate pricing and liquidity', async () => {
     spy.withArgs('V3_POOL_PROVIDER_POOL_CURRENT_QUOTE_MATCH', 1, MetricLoggerUnit.None)

--- a/test/mocha/integ/handlers/pools/provider-migration/traffic-switch-pool-provider.test.ts
+++ b/test/mocha/integ/handlers/pools/provider-migration/traffic-switch-pool-provider.test.ts
@@ -3,7 +3,7 @@ import { DynamoDBCachingV3PoolProvider } from '../../../../../../lib/handlers/po
 import { getMockedV3PoolProvider, TEST_ROUTE_TABLE } from '../../../../../test-utils/mocked-dependencies'
 import { CachingV3PoolProvider, MetricLoggerUnit, NodeJSCache } from '@uniswap/smart-order-router'
 import NodeCache from 'node-cache'
-import sinon from 'sinon'
+import sinon, { SinonSpy } from 'sinon'
 import { ChainId, Token } from '@uniswap/sdk-core'
 import { encodeSqrtRatioX96, FeeAmount, Pool } from '@uniswap/v3-sdk'
 import {
@@ -23,7 +23,16 @@ import {
 
 describe('TrafficSwitchV3PoolProvider', async () => {
   setupTables(TEST_ROUTE_TABLE)
-  const spy = sinon.spy(metric, 'putMetric')
+
+  let spy: SinonSpy;
+
+  beforeEach(() => {
+    spy = sinon.spy(metric, 'putMetric')
+  });
+
+  afterEach(() => {
+    spy.restore()
+  });
 
   it('switch traffic and sample pools with accurate pricing and liquidity', async () => {
     spy.withArgs('V3_POOL_PROVIDER_POOL_CURRENT_QUOTE_MATCH', 1, MetricLoggerUnit.None)

--- a/test/mocha/integ/handlers/quote/provider-migration/traffic-switch-quote-provider.test.ts
+++ b/test/mocha/integ/handlers/quote/provider-migration/traffic-switch-quote-provider.test.ts
@@ -1,4 +1,4 @@
-import sinon from 'sinon'
+import sinon, { SinonSpy } from 'sinon'
 import { metric } from '@uniswap/smart-order-router/build/main/util/metric'
 import { MetricLoggerUnit, USDC_MAINNET } from '@uniswap/smart-order-router'
 import { TrafficSwitchOnChainQuoteProvider } from '../../../../../../lib/handlers/quote/provider-migration/v3/traffic-switch-on-chain-quote-provider'
@@ -9,9 +9,19 @@ import { WRAPPED_NATIVE_CURRENCY } from '@uniswap/smart-order-router'
 import { getMockedOnChainQuoteProvider } from '../../../../../test-utils/mocked-dependencies'
 
 describe('TrafficSwitchOnChainQuoteProvider', () => {
-  const spy = sinon.spy(metric, 'putMetric')
   const amountIns = [CurrencyAmount.fromRawAmount(WRAPPED_NATIVE_CURRENCY[ChainId.MAINNET], '1000000000000000000')]
   const routes = [new V3Route([USDC_WETH_LOW], WRAPPED_NATIVE_CURRENCY[ChainId.MAINNET], USDC_MAINNET)]
+
+  let spy: SinonSpy;
+
+  beforeEach(() => {
+    spy = sinon.spy(metric, 'putMetric')
+  });
+
+  afterEach(() => {
+    spy.restore()
+  });
+
 
   it('switch exact in traffic and sample quotes', async () => {
     spy.withArgs('ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_TOTAL', 1, MetricLoggerUnit.None)

--- a/test/mocha/integ/handlers/quote/provider-migration/traffic-switch-quote-provider.test.ts
+++ b/test/mocha/integ/handlers/quote/provider-migration/traffic-switch-quote-provider.test.ts
@@ -12,16 +12,15 @@ describe('TrafficSwitchOnChainQuoteProvider', () => {
   const amountIns = [CurrencyAmount.fromRawAmount(WRAPPED_NATIVE_CURRENCY[ChainId.MAINNET], '1000000000000000000')]
   const routes = [new V3Route([USDC_WETH_LOW], WRAPPED_NATIVE_CURRENCY[ChainId.MAINNET], USDC_MAINNET)]
 
-  let spy: SinonSpy;
+  let spy: SinonSpy
 
   beforeEach(() => {
     spy = sinon.spy(metric, 'putMetric')
-  });
+  })
 
   afterEach(() => {
     spy.restore()
-  });
-
+  })
 
   it('switch exact in traffic and sample quotes', async () => {
     spy.withArgs('ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_TOTAL', 1, MetricLoggerUnit.None)

--- a/test/mocha/integ/handlers/quote/provider-migration/traffic-switch-quote-provider.test.ts
+++ b/test/mocha/integ/handlers/quote/provider-migration/traffic-switch-quote-provider.test.ts
@@ -1,0 +1,109 @@
+import sinon from 'sinon'
+import { metric } from '@uniswap/smart-order-router/build/main/util/metric'
+import { MetricLoggerUnit, USDC_MAINNET } from '@uniswap/smart-order-router'
+import { TrafficSwitchOnChainQuoteProvider } from '../../../../../../lib/handlers/quote/provider-migration/v3/traffic-switch-on-chain-quote-provider'
+import { ChainId, CurrencyAmount } from '@uniswap/sdk-core'
+import { V3Route } from '@uniswap/smart-order-router/build/main/routers'
+import { USDC_WETH_LOW } from '../../../../../test-utils/mocked-data'
+import { WRAPPED_NATIVE_CURRENCY } from '@uniswap/smart-order-router'
+import { getMockedOnChainQuoteProvider } from '../../../../../test-utils/mocked-dependencies'
+
+describe('TrafficSwitchOnChainQuoteProvider', () => {
+  const spy = sinon.spy(metric, 'putMetric')
+  const amountIns = [CurrencyAmount.fromRawAmount(WRAPPED_NATIVE_CURRENCY[ChainId.MAINNET], '1000000000000000000')]
+  const routes = [new V3Route([USDC_WETH_LOW], WRAPPED_NATIVE_CURRENCY[ChainId.MAINNET], USDC_MAINNET)]
+
+  it('switch exact in traffic and sample quotes', async () => {
+    spy.withArgs('ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_TOTAL', 1, MetricLoggerUnit.None)
+    spy.withArgs('ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_SAMPLING', 1, MetricLoggerUnit.None)
+    spy.withArgs('ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_TARGET', 1, MetricLoggerUnit.None)
+
+    const currentQuoteProvider = getMockedOnChainQuoteProvider()
+    const targetQuoteProvider = getMockedOnChainQuoteProvider()
+
+    const trafficSwitchProvider =
+      new (class SwitchTrafficSwitchOnChainQuoteProvider extends TrafficSwitchOnChainQuoteProvider {
+        override readonly SHOULD_SWITCH_EXACT_IN_TRAFFIC = () => true
+        override readonly SHOULD_SAMPLE_EXACT_IN_TRAFFIC = () => true
+      })({
+        currentQuoteProvider: currentQuoteProvider,
+        targetQuoteProvider: targetQuoteProvider,
+      })
+
+    await trafficSwitchProvider.getQuotesManyExactIn(amountIns, routes)
+
+    sinon.assert.called(spy)
+    sinon.assert.calledOnce(currentQuoteProvider.getQuotesManyExactIn)
+    sinon.assert.notCalled(targetQuoteProvider.getQuotesManyExactOut)
+  })
+
+  it('does not switch exact in traffic and sample quotes', async () => {
+    spy.withArgs('ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_TOTAL', 1, MetricLoggerUnit.None)
+    spy.withArgs('ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT', 1, MetricLoggerUnit.None)
+
+    const currentQuoteProvider = getMockedOnChainQuoteProvider()
+    const targetQuoteProvider = getMockedOnChainQuoteProvider()
+
+    const trafficSwitchProvider =
+      new (class SwitchTrafficSwitchOnChainQuoteProvider extends TrafficSwitchOnChainQuoteProvider {
+        override readonly SHOULD_SWITCH_EXACT_IN_TRAFFIC = () => true
+        override readonly SHOULD_SAMPLE_EXACT_IN_TRAFFIC = () => true
+      })({
+        currentQuoteProvider: currentQuoteProvider,
+        targetQuoteProvider: targetQuoteProvider,
+      })
+
+    await trafficSwitchProvider.getQuotesManyExactIn(amountIns, routes)
+
+    sinon.assert.called(spy)
+    sinon.assert.calledOnce(currentQuoteProvider.getQuotesManyExactIn)
+    sinon.assert.notCalled(targetQuoteProvider.getQuotesManyExactOut)
+  })
+
+  it('switch exact out traffic and sample quotes', async () => {
+    spy.withArgs('ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_TOTAL', 1, MetricLoggerUnit.None)
+    spy.withArgs('ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_SAMPLING', 1, MetricLoggerUnit.None)
+    spy.withArgs('ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_TARGET', 1, MetricLoggerUnit.None)
+
+    const currentQuoteProvider = getMockedOnChainQuoteProvider()
+    const targetQuoteProvider = getMockedOnChainQuoteProvider()
+
+    const trafficSwitchProvider =
+      new (class SwitchTrafficSwitchOnChainQuoteProvider extends TrafficSwitchOnChainQuoteProvider {
+        override readonly SHOULD_SWITCH_EXACT_OUT_TRAFFIC = () => true
+        override readonly SHOULD_SAMPLE_EXACT_OUT_TRAFFIC = () => true
+      })({
+        currentQuoteProvider: currentQuoteProvider,
+        targetQuoteProvider: targetQuoteProvider,
+      })
+
+    await trafficSwitchProvider.getQuotesManyExactOut(amountIns, routes)
+
+    sinon.assert.called(spy)
+    sinon.assert.calledOnce(currentQuoteProvider.getQuotesManyExactOut)
+    sinon.assert.notCalled(targetQuoteProvider.getQuotesManyExactIn)
+  })
+
+  it('does not switch exact out traffic and sample quotes', async () => {
+    spy.withArgs('ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_TOTAL', 1, MetricLoggerUnit.None)
+    spy.withArgs('ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_CURRENT', 1, MetricLoggerUnit.None)
+
+    const currentQuoteProvider = getMockedOnChainQuoteProvider()
+    const targetQuoteProvider = getMockedOnChainQuoteProvider()
+
+    const trafficSwitchProvider =
+      new (class SwitchTrafficSwitchOnChainQuoteProvider extends TrafficSwitchOnChainQuoteProvider {
+        override readonly SHOULD_SWITCH_EXACT_OUT_TRAFFIC = () => true
+        override readonly SHOULD_SAMPLE_EXACT_OUT_TRAFFIC = () => true
+      })({
+        currentQuoteProvider: currentQuoteProvider,
+        targetQuoteProvider: targetQuoteProvider,
+      })
+
+    await trafficSwitchProvider.getQuotesManyExactOut(amountIns, routes)
+
+    sinon.assert.called(spy)
+    sinon.assert.calledOnce(currentQuoteProvider.getQuotesManyExactOut)
+    sinon.assert.notCalled(targetQuoteProvider.getQuotesManyExactIn)
+  })
+})

--- a/test/mocha/integ/handlers/quote/provider-migration/traffic-switch-quote-provider.test.ts
+++ b/test/mocha/integ/handlers/quote/provider-migration/traffic-switch-quote-provider.test.ts
@@ -1,11 +1,10 @@
 import sinon, { SinonSpy } from 'sinon'
 import { metric } from '@uniswap/smart-order-router/build/main/util/metric'
-import { MetricLoggerUnit, USDC_MAINNET } from '@uniswap/smart-order-router'
+import { MetricLoggerUnit, USDC_MAINNET, WRAPPED_NATIVE_CURRENCY } from '@uniswap/smart-order-router'
 import { TrafficSwitchOnChainQuoteProvider } from '../../../../../../lib/handlers/quote/provider-migration/v3/traffic-switch-on-chain-quote-provider'
 import { ChainId, CurrencyAmount } from '@uniswap/sdk-core'
 import { V3Route } from '@uniswap/smart-order-router/build/main/routers'
 import { USDC_WETH_LOW } from '../../../../../test-utils/mocked-data'
-import { WRAPPED_NATIVE_CURRENCY } from '@uniswap/smart-order-router'
 import { getMockedOnChainQuoteProvider } from '../../../../../test-utils/mocked-dependencies'
 
 describe('TrafficSwitchOnChainQuoteProvider', () => {
@@ -23,9 +22,17 @@ describe('TrafficSwitchOnChainQuoteProvider', () => {
   })
 
   it('switch exact in traffic and sample quotes', async () => {
-    spy.withArgs('ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_TOTAL', 1, MetricLoggerUnit.None)
-    spy.withArgs('ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_SAMPLING', 1, MetricLoggerUnit.None)
-    spy.withArgs('ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_TARGET', 1, MetricLoggerUnit.None)
+    spy.withArgs(`ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_TOTAL_CHAIN_ID_${ChainId.MAINNET}`, 1, MetricLoggerUnit.None)
+    spy.withArgs(
+      `ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_SAMPLING_CHAIN_ID_${ChainId.MAINNET}`,
+      1,
+      MetricLoggerUnit.None
+    )
+    spy.withArgs(
+      `ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_TARGET_CHAIN_ID_${ChainId.MAINNET}`,
+      1,
+      MetricLoggerUnit.None
+    )
 
     const currentQuoteProvider = getMockedOnChainQuoteProvider()
     const targetQuoteProvider = getMockedOnChainQuoteProvider()
@@ -37,6 +44,7 @@ describe('TrafficSwitchOnChainQuoteProvider', () => {
       })({
         currentQuoteProvider: currentQuoteProvider,
         targetQuoteProvider: targetQuoteProvider,
+        chainId: ChainId.MAINNET,
       })
 
     await trafficSwitchProvider.getQuotesManyExactIn(amountIns, routes)
@@ -47,8 +55,12 @@ describe('TrafficSwitchOnChainQuoteProvider', () => {
   })
 
   it('does not switch exact in traffic and sample quotes', async () => {
-    spy.withArgs('ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_TOTAL', 1, MetricLoggerUnit.None)
-    spy.withArgs('ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT', 1, MetricLoggerUnit.None)
+    spy.withArgs(`ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_TOTAL_CHAIN_ID_${ChainId.MAINNET}`, 1, MetricLoggerUnit.None)
+    spy.withArgs(
+      `ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_CHAIN_ID_${ChainId.MAINNET}`,
+      1,
+      MetricLoggerUnit.None
+    )
 
     const currentQuoteProvider = getMockedOnChainQuoteProvider()
     const targetQuoteProvider = getMockedOnChainQuoteProvider()
@@ -60,6 +72,7 @@ describe('TrafficSwitchOnChainQuoteProvider', () => {
       })({
         currentQuoteProvider: currentQuoteProvider,
         targetQuoteProvider: targetQuoteProvider,
+        chainId: ChainId.MAINNET,
       })
 
     await trafficSwitchProvider.getQuotesManyExactIn(amountIns, routes)
@@ -70,9 +83,21 @@ describe('TrafficSwitchOnChainQuoteProvider', () => {
   })
 
   it('switch exact out traffic and sample quotes', async () => {
-    spy.withArgs('ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_TOTAL', 1, MetricLoggerUnit.None)
-    spy.withArgs('ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_SAMPLING', 1, MetricLoggerUnit.None)
-    spy.withArgs('ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_TARGET', 1, MetricLoggerUnit.None)
+    spy.withArgs(
+      `ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_TOTAL_CHAIN_ID_${ChainId.MAINNET}`,
+      1,
+      MetricLoggerUnit.None
+    )
+    spy.withArgs(
+      `ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_SAMPLING_CHAIN_ID_${ChainId.MAINNET}`,
+      1,
+      MetricLoggerUnit.None
+    )
+    spy.withArgs(
+      `ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_TARGET_CHAIN_ID_${ChainId.MAINNET}`,
+      1,
+      MetricLoggerUnit.None
+    )
 
     const currentQuoteProvider = getMockedOnChainQuoteProvider()
     const targetQuoteProvider = getMockedOnChainQuoteProvider()
@@ -84,6 +109,7 @@ describe('TrafficSwitchOnChainQuoteProvider', () => {
       })({
         currentQuoteProvider: currentQuoteProvider,
         targetQuoteProvider: targetQuoteProvider,
+        chainId: ChainId.MAINNET,
       })
 
     await trafficSwitchProvider.getQuotesManyExactOut(amountIns, routes)
@@ -94,8 +120,16 @@ describe('TrafficSwitchOnChainQuoteProvider', () => {
   })
 
   it('does not switch exact out traffic and sample quotes', async () => {
-    spy.withArgs('ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_TOTAL', 1, MetricLoggerUnit.None)
-    spy.withArgs('ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_CURRENT', 1, MetricLoggerUnit.None)
+    spy.withArgs(
+      `ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_TOTAL_CHAIN_ID_${ChainId.MAINNET}`,
+      1,
+      MetricLoggerUnit.None
+    )
+    spy.withArgs(
+      `ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_CURRENT_CHAIN_ID_${ChainId.MAINNET}`,
+      1,
+      MetricLoggerUnit.None
+    )
 
     const currentQuoteProvider = getMockedOnChainQuoteProvider()
     const targetQuoteProvider = getMockedOnChainQuoteProvider()
@@ -107,6 +141,7 @@ describe('TrafficSwitchOnChainQuoteProvider', () => {
       })({
         currentQuoteProvider: currentQuoteProvider,
         targetQuoteProvider: targetQuoteProvider,
+        chainId: ChainId.MAINNET,
       })
 
     await trafficSwitchProvider.getQuotesManyExactOut(amountIns, routes)


### PR DESCRIPTION
We want to switch to new view-only quoter. But we are not ready to live migrate yet. In this PR, we want to achieve:

1. Shadow request very small percent of Polygon quote against the new quoter v2, without impacting the routing-api endpoint success rate at all.
2. Make small refactoring in this PR, as well as based on https://github.com/Uniswap/smart-order-router/pull/510, so that it's easy to make incremental changes, when we roll out quoter to
   - same chain at incremental live traffic migration to new quoter v2
   - to new chain with the shadow quote, meanwhile using the correct quote config params without the manual copy-paste errors
3. Collect sampling metrics against the shadow new quoter v2, so as to understand
   - is new quoter faster than the existing quoter
   - is new quoter way gas-efficient than existing quoter
   - is new quoter retrying less frequent than exising quoter.

For Polygon, existing quoter batch size is about 200k/minute, so we choose 0.1% to have additional 200 batched inputs/minute:

<img width="1215" alt="Screenshot 2024-03-21 at 4 52 01 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/53df093d-cecd-4e30-ad18-a209c66f182a">

TODO:

- [x] check polygon quoter batch size metrics, so as to determine the actual sampling percent
- [x] refactor in SOR to have default configs, so that they can be reused by routing-api
- [x] add unit tests against traffic switch
- [x] merge https://github.com/Uniswap/smart-order-router/pull/510, so that this PR can compile. Some of this PR changes is assumed from https://github.com/Uniswap/smart-order-router/pull/510.