### PR TITLE
chore: increase beta provisioned concurrency to 5

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -174,7 +174,7 @@ export class RoutingAPIPipeline extends Stack {
       env: { account: '145079444317', region: 'us-east-2' },
       jsonRpcProviders: jsonRpcProviders,
       internalApiKey: internalApiKey.secretValue.toString(),
-      provisionedConcurrency: 1,
+      provisionedConcurrency: 5,
       ethGasStationInfoUrl: ethGasStationInfoUrl.secretValue.toString(),
       stage: STAGE.BETA,
       route53Arn: route53Arn.secretValueFromJson('arn').toString(),


### PR DESCRIPTION
1 in beta lambda is too low. Recently we observe that the beta integ-test always fail in first couple times.

I can see spillovers:
<img width="757" alt="Screenshot 2024-03-20 at 2 51 56 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/1761b432-5ee2-40af-8169-ed168594296e">
