### PR TITLE
chore: increase beta provisioned concurrency to 10

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -174,7 +174,7 @@ export class RoutingAPIPipeline extends Stack {
       env: { account: '145079444317', region: 'us-east-2' },
       jsonRpcProviders: jsonRpcProviders,
       internalApiKey: internalApiKey.secretValue.toString(),
-      provisionedConcurrency: 5,
+      provisionedConcurrency: 10,
       ethGasStationInfoUrl: ethGasStationInfoUrl.secretValue.toString(),
       stage: STAGE.BETA,
       route53Arn: route53Arn.secretValueFromJson('arn').toString(),


### PR DESCRIPTION
beta integ-tests keep failing with 502 during before hook. I checked beta metrics, and still see some spillovers:

<img width="1199" alt="Screenshot 2024-03-26 at 11 15 58 AM" src="https://github.com/Uniswap/routing-api/assets/91580504/acb3e178-f30e-4ffd-8c72-dd4c21f26889">
