### PR TITLE
fix: remove zora sepolia from testnets

### DIFF
--- a/lib/util/testNets.ts
+++ b/lib/util/testNets.ts
@@ -11,5 +11,4 @@ export const TESTNETS = [
   ChainId.OPTIMISM_GOERLI,
   ChainId.ARBITRUM_SEPOLIA,
   ChainId.ARBITRUM_GOERLI,
-  ChainId.ZORA_SEPOLIA,
 ]


### PR DESCRIPTION
In the code pipeline, it failed building due to:

> Error: Unknown chain id: 999999999
>     at ID_TO_NETWORK_NAME (/codebuild/output/src3089245944/src/node_modules/@uniswap/smart-order-router/src/util/chains.ts:281:13)
>     at /codebuild/output/src3089245944/src/bin/stacks/routing-dashboard-stack.ts:113:78
>     at Array.map (<anonymous>)
>     at /codebuild/output/src3089245944/src/bin/stacks/routing-dashboard-stack.ts:108:27
>     at arrayMap (/codebuild/output/src3089245944/src/node_modules/lodash/lodash.js:653:23)
>     at map (/codebuild/output/src3089245944/src/node_modules/lodash/lodash.js:9622:14)
>     at Function.flatMap (/codebuild/output/src3089245944/src/node_modules/lodash/lodash.js:9325:26)
>     at new RoutingDashboardStack (/codebuild/output/src3089245944/src/bin/stacks/routing-dashboard-stack.ts:102:57)
>     at new RoutingAPIStack (/codebuild/output/src3089245944/src/bin/stacks/routing-api-stack.ts:225:5)
>     at Object.<anonymous> (/codebuild/output/src3089245944/src/bin/app.ts:297:1)
> 

The reason is because in SOR, [ID_TO_NETWORK_NAME](https://github.com/Uniswap/smart-order-router/blob/2a61d3b821fe9dafc631e38314af2565d1b953f3/src/util/chains.ts#L238) doesn't have the ZORA_SEPOLIA listed there. I think the right fix is to remove ZORA_SEPOLIA from the testnets, because SOR has an open PR about supporting ZORA https://github.com/Uniswap/smart-order-router/pull/501