### PR TITLE
Launch RPC Gateway to 1% of Celo traffic (with bug fix)

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -12,6 +12,7 @@ import 'source-map-support/register'
 import { SUPPORTED_CHAINS } from '../lib/handlers/injector-sor'
 import { STAGE } from '../lib/util/stage'
 import { RoutingAPIStack } from './stacks/routing-api-stack'
+import { getRpcGatewayEnabledChainIds } from '../lib/rpc/ProdConfig'
 
 dotenv.config()
 
@@ -159,15 +160,52 @@ export class RoutingAPIPipeline extends Stack {
       secretCompleteArn: 'arn:aws:secretsmanager:us-east-2:644039819003:secret:routing-api-internal-api-key-Z68NmB',
     })
 
+    // Read chains that uses RPC gateway.
+    const rpcGatewayEnabledChainIds = getRpcGatewayEnabledChainIds()
+
     // Load RPC provider URLs from AWS secret
     let jsonRpcProviders = {} as { [chainId: string]: string }
     SUPPORTED_CHAINS.forEach((chainId: ChainId) => {
-      const key = `WEB3_RPC_${chainId}`
-      jsonRpcProviders[key] = jsonRpcProvidersSecret.secretValueFromJson(key).toString()
-      new CfnOutput(this, key, {
-        value: jsonRpcProviders[key],
-      })
+      if (!rpcGatewayEnabledChainIds.includes(chainId)) {
+        const key = `WEB3_RPC_${chainId}`
+        jsonRpcProviders[key] = jsonRpcProvidersSecret.secretValueFromJson(key).toString()
+        new CfnOutput(this, key, {
+          value: jsonRpcProviders[key],
+        })
+      }
     })
+
+    // Load RPC provider URLs from AWS secret (for RPC Gateway)
+    const RPC_GATEWAY_PROVIDERS = [
+      // Optimism
+      'INFURA_10',
+      'QUICKNODE_10',
+      'ALCHEMY_10',
+      // Polygon
+      'QUICKNODE_137',
+      'INFURA_137',
+      'ALCHEMY_137',
+      // Celo
+      'QUICKNODE_42220',
+      'INFURA_42220',
+      // Avalanche
+      'INFURA_43114',
+      'QUICKNODE_43114',
+      'NIRVANA_43114',
+      // BNB
+      'QUICKNODE_56',
+      // Base
+      'QUICKNODE_8453',
+      'INFURA_8453',
+      'ALCHEMY_8453',
+      'NIRVANA_8453',
+    ]
+    for (const provider of RPC_GATEWAY_PROVIDERS) {
+      jsonRpcProviders[provider] = jsonRpcProvidersSecret.secretValueFromJson(provider).toString()
+      new CfnOutput(this, provider, {
+        value: jsonRpcProviders[provider],
+      })
+    }
 
     // Beta us-east-2
     const betaUsEast2Stage = new RoutingAPIStage(this, 'beta-us-east-2', {
@@ -280,21 +318,26 @@ const jsonRpcProviders = {
   WEB3_RPC_56: process.env.WEB3_RPC_56!,
   WEB3_RPC_8453: process.env.WEB3_RPC_8453!,
   // The followings are for RPC Gateway
-  INFURA_43114: process.env.INFURA_43114!,
-  NIRVANA_43114: process.env.NIRVANA_43114!,
-  QUICKNODE_43114: process.env.QUICKNODE_43114!,
+  // Optimism
   INFURA_10: process.env.INFURA_10!,
-  NIRVANA_10: process.env.NIRVANA_10!,
   QUICKNODE_10: process.env.QUICKNODE_10!,
   ALCHEMY_10: process.env.ALCHEMY_10!,
-  INFURA_42220: process.env.INFURA_42220!,
-  QUICKNODE_42220: process.env.QUICKNODE_42220!,
-  QUICKNODE_56: process.env.QUICKNODE_56!,
-  INFURA_137: process.env.INFURA_137!,
+  // Polygon
   QUICKNODE_137: process.env.QUICKNODE_137!,
+  INFURA_137: process.env.INFURA_137!,
   ALCHEMY_137: process.env.ALCHEMY_137!,
-  INFURA_8453: process.env.INFURA_8453!,
+  // Celo
+  QUICKNODE_42220: process.env.QUICKNODE_42220!,
+  INFURA_42220: process.env.INFURA_42220!,
+  // Avalanche
+  INFURA_43114: process.env.INFURA_43114!,
+  QUICKNODE_43114: process.env.QUICKNODE_43114!,
+  NIRVANA_43114: process.env.NIRVANA_43114!,
+  // BNB
+  QUICKNODE_56: process.env.QUICKNODE_56!,
+  // Base
   QUICKNODE_8453: process.env.QUICKNODE_8453!,
+  INFURA_8453: process.env.INFURA_8453!,
   ALCHEMY_8453: process.env.ALCHEMY_8453!,
   NIRVANA_8453: process.env.NIRVANA_8453!,
 }

--- a/bin/app.ts
+++ b/bin/app.ts
@@ -12,7 +12,6 @@ import 'source-map-support/register'
 import { SUPPORTED_CHAINS } from '../lib/handlers/injector-sor'
 import { STAGE } from '../lib/util/stage'
 import { RoutingAPIStack } from './stacks/routing-api-stack'
-import { getRpcGatewayEnabledChainIds } from '../lib/rpc/ProdConfig'
 
 dotenv.config()
 
@@ -160,19 +159,14 @@ export class RoutingAPIPipeline extends Stack {
       secretCompleteArn: 'arn:aws:secretsmanager:us-east-2:644039819003:secret:routing-api-internal-api-key-Z68NmB',
     })
 
-    // Read chains that uses RPC gateway.
-    const rpcGatewayEnabledChainIds = getRpcGatewayEnabledChainIds()
-
     // Load RPC provider URLs from AWS secret
     let jsonRpcProviders = {} as { [chainId: string]: string }
     SUPPORTED_CHAINS.forEach((chainId: ChainId) => {
-      if (!rpcGatewayEnabledChainIds.includes(chainId)) {
-        const key = `WEB3_RPC_${chainId}`
-        jsonRpcProviders[key] = jsonRpcProvidersSecret.secretValueFromJson(key).toString()
-        new CfnOutput(this, key, {
-          value: jsonRpcProviders[key],
-        })
-      }
+      const key = `WEB3_RPC_${chainId}`
+      jsonRpcProviders[key] = jsonRpcProvidersSecret.secretValueFromJson(key).toString()
+      new CfnOutput(this, key, {
+        value: jsonRpcProviders[key],
+      })
     })
 
     // Load RPC provider URLs from AWS secret (for RPC Gateway)

--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -1,1 +1,8 @@
-[]
+[
+  {
+    "chainId": 42220,
+    "useMultiProviderProb": 0.01,
+    "providerInitialWeights": [1, 0],
+    "providerUrls": ["QUICKNODE_42220", "INFURA_42220"]
+  }
+]

--- a/lib/rpc/GlobalRpcProviders.ts
+++ b/lib/rpc/GlobalRpcProviders.ts
@@ -9,7 +9,7 @@ import {
   UniJsonRpcProviderConfig,
 } from './config'
 import { ProdConfig, ProdConfigJoi } from './ProdConfig'
-import { chainIdToNetworkName } from './utils'
+import { chainIdToNetworkName, generateProviderUrl } from './utils'
 import PROD_CONFIG from '../config/rpcProviderProdConfig.json'
 
 export class GlobalRpcProviders {
@@ -35,7 +35,7 @@ export class GlobalRpcProviders {
         if (process.env[urlEnvVar] === undefined) {
           throw new Error(`Environmental variable ${urlEnvVar} isn't defined!`)
         }
-        chainConfig.providerUrls[i] = process.env[urlEnvVar]!
+        chainConfig.providerUrls[i] = generateProviderUrl(urlEnvVar, process.env[urlEnvVar]!)
       }
     }
     return prodConfig

--- a/lib/rpc/utils.ts
+++ b/lib/rpc/utils.ts
@@ -22,3 +22,68 @@ export function chainIdToNetworkName(networkId: ChainId): string {
       return 'ethereum'
   }
 }
+
+export function generateProviderUrl(key: string, value: string): string {
+  const tokens = value.split(',')
+  switch (key) {
+    // Infura
+    case 'INFURA_1': {
+      return `https://mainnet.infura.io/v3/${tokens[0]}`
+    }
+    case 'INFURA_43114': {
+      return `https://avalanche-mainnet.infura.io/v3/${tokens[0]}`
+    }
+    case 'INFURA_10': {
+      return `https://optimism-mainnet.infura.io/v3/${tokens[0]}`
+    }
+    case 'INFURA_42220': {
+      return `https://celo-mainnet.infura.io/v3/${tokens[0]}`
+    }
+    case 'INFURA_137': {
+      return `https://polygon-mainnet.infura.io/v3/${tokens[0]}`
+    }
+    case 'INFURA_8453': {
+      return `https://base-mainnet.infura.io/v3/${tokens[0]}`
+    }
+    // Nirvana
+    case 'NIRVANA_43114': {
+      return `https://avax.nirvanalabs.xyz/${tokens[0]}/ext/bc/C/rpc?apikey=${tokens[1]}`
+    }
+    case 'NIRVANA_10': {
+      return `https://optimism.nirvanalabs.xyz/${tokens[0]}?apikey=${tokens[1]}`
+    }
+    case 'NIRVANA_8453': {
+      return `https://base.nirvanalabs.xyz/${tokens[0]}?apikey=${tokens[1]}`
+    }
+    // Quicknode
+    case 'QUICKNODE_43114': {
+      return `https://${tokens[0]}.avalanche-mainnet.quiknode.pro/${tokens[1]}/ext/bc/C/rpc/`
+    }
+    case 'QUICKNODE_10': {
+      return `https://${tokens[0]}.optimism.quiknode.pro/${tokens[1]}`
+    }
+    case 'QUICKNODE_42220': {
+      return `https://${tokens[0]}.celo-mainnet.quiknode.pro/${tokens[1]}`
+    }
+    case 'QUICKNODE_56': {
+      return `https://${tokens[0]}.bsc.quiknode.pro/${tokens[1]}`
+    }
+    case 'QUICKNODE_137': {
+      return `https://${tokens[0]}.matic.quiknode.pro/${tokens[1]}`
+    }
+    case 'QUICKNODE_8453': {
+      return `https://${tokens[0]}.base-mainnet.quiknode.pro/${tokens[1]}`
+    }
+    // Alchemy
+    case 'ALCHEMY_10': {
+      return `https://opt-mainnet.g.alchemy.com/v2/${tokens[0]}`
+    }
+    case 'ALCHEMY_137': {
+      return `https://polygon-mainnet.g.alchemy.com/v2/${tokens[0]}`
+    }
+    case 'ALCHEMY_8453': {
+      return `https://base-mainnet.g.alchemy.com/v2/${tokens[0]}`
+    }
+  }
+  throw new Error(`Unknown provider-chainId pair: ${key}`)
+}

--- a/test/mocha/unit/rpc/GlobalRpcProviders.test.ts
+++ b/test/mocha/unit/rpc/GlobalRpcProviders.test.ts
@@ -48,8 +48,8 @@ describe('GlobalRpcProviders', () => {
 
   it('Prepare global UniJsonRpcProvider by reading given config', () => {
     process.env = {
-      URL0: 'url0',
-      URL1: 'url1',
+      INFURA_43114: 'key0',
+      QUICKNODE_43114: 'node1,key1',
     }
     const rpcProviderProdConfig = [
       { chainId: 1, useMultiProviderProb: 0 },
@@ -58,7 +58,7 @@ describe('GlobalRpcProviders', () => {
         useMultiProviderProb: 1,
         sessionAllowProviderFallbackWhenUnhealthy: true,
         providerInitialWeights: [2, 1],
-        providerUrls: ['URL0', 'URL1'],
+        providerUrls: ['INFURA_43114', 'QUICKNODE_43114'],
       },
     ]
 
@@ -95,30 +95,34 @@ describe('GlobalRpcProviders', () => {
       SINGLE_PROVIDER_TEST_CONFIG,
       rpcProviderProdConfig
     ).get(ChainId.AVALANCHE)!
+    const url0 = 'https://avalanche-mainnet.infura.io/v3/key0'
+    const url1 = 'https://node1.avalanche-mainnet.quiknode.pro/key1/ext/bc/C/rpc/'
     expect(avaUniProvider['sessionAllowProviderFallbackWhenUnhealthy']).to.be.true
-    expect(avaUniProvider['urlWeight']).to.deep.equal({ url0: 2, url1: 1 })
-    expect(avaUniProvider['providers'][0].url).to.equal('url0')
-    expect(avaUniProvider['providers'][1].url).to.equal('url1')
+    expect(avaUniProvider['urlWeight']).to.deep.equal({ [url0]: 2, [url1]: 1 })
+    expect(avaUniProvider['providers'][0].url).to.equal(url0)
+    expect(avaUniProvider['providers'][1].url).to.equal(url1)
   })
 
   it('Prepare global UniJsonRpcProvider by reading config: Use prob to decide feature switch', () => {
     process.env = {
-      URL0: 'url0',
-      URL1: 'url1',
+      INFURA_10: 'key0',
+      QUICKNODE_10: 'node1,key1',
+      INFURA_43114: 'key2',
+      QUICKNODE_43114: 'node3,key3',
     }
 
     const rpcProviderProdConfig = [
       {
-        chainId: 1,
+        chainId: 10,
         useMultiProviderProb: 0.3,
-        providerUrls: ['URL0', 'URL1'],
+        providerUrls: ['INFURA_10', 'QUICKNODE_10'],
       },
       {
         chainId: 43114,
         useMultiProviderProb: 0.7,
         sessionAllowProviderFallbackWhenUnhealthy: true,
         providerInitialWeights: [2, 1],
-        providerUrls: ['URL0', 'URL1'],
+        providerUrls: ['INFURA_43114', 'QUICKNODE_43114'],
       },
     ]
 
@@ -130,7 +134,7 @@ describe('GlobalRpcProviders', () => {
         UNI_PROVIDER_TEST_CONFIG,
         SINGLE_PROVIDER_TEST_CONFIG,
         rpcProviderProdConfig
-      ).has(ChainId.MAINNET)
+      ).has(ChainId.OPTIMISM)
     ).to.be.true
     expect(
       GlobalRpcProviders.getGlobalUniRpcProviders(
@@ -149,7 +153,7 @@ describe('GlobalRpcProviders', () => {
         UNI_PROVIDER_TEST_CONFIG,
         SINGLE_PROVIDER_TEST_CONFIG,
         rpcProviderProdConfig
-      ).has(ChainId.MAINNET)
+      ).has(ChainId.OPTIMISM)
     ).to.be.true
     expect(
       GlobalRpcProviders.getGlobalUniRpcProviders(
@@ -168,7 +172,7 @@ describe('GlobalRpcProviders', () => {
         UNI_PROVIDER_TEST_CONFIG,
         SINGLE_PROVIDER_TEST_CONFIG,
         rpcProviderProdConfig
-      ).has(ChainId.MAINNET)
+      ).has(ChainId.OPTIMISM)
     ).to.be.false
     expect(
       GlobalRpcProviders.getGlobalUniRpcProviders(
@@ -187,7 +191,7 @@ describe('GlobalRpcProviders', () => {
         UNI_PROVIDER_TEST_CONFIG,
         SINGLE_PROVIDER_TEST_CONFIG,
         rpcProviderProdConfig
-      ).has(ChainId.MAINNET)
+      ).has(ChainId.OPTIMISM)
     ).to.be.false
     expect(
       GlobalRpcProviders.getGlobalUniRpcProviders(
@@ -206,7 +210,7 @@ describe('GlobalRpcProviders', () => {
         UNI_PROVIDER_TEST_CONFIG,
         SINGLE_PROVIDER_TEST_CONFIG,
         rpcProviderProdConfig
-      ).has(ChainId.MAINNET)
+      ).has(ChainId.OPTIMISM)
     ).to.be.false
     expect(
       GlobalRpcProviders.getGlobalUniRpcProviders(
@@ -225,7 +229,7 @@ describe('GlobalRpcProviders', () => {
         UNI_PROVIDER_TEST_CONFIG,
         SINGLE_PROVIDER_TEST_CONFIG,
         rpcProviderProdConfig
-      ).has(ChainId.MAINNET)
+      ).has(ChainId.OPTIMISM)
     ).to.be.false
     expect(
       GlobalRpcProviders.getGlobalUniRpcProviders(
@@ -235,6 +239,41 @@ describe('GlobalRpcProviders', () => {
         rpcProviderProdConfig
       ).has(ChainId.AVALANCHE)
     ).to.be.false
+    cleanUp()
+  })
+
+  it('Prepare global UniJsonRpcProvider by reading config file', () => {
+    process.env = {
+      INFURA_43114: 'key0',
+      QUICKNODE_43114: 'host1,key1',
+      NIRVANA_43114: 'host2,key2',
+      INFURA_10: 'key3',
+      QUICKNODE_10: 'host3,key3',
+      NIRVANA_10: 'host4,key4',
+      ALCHEMY_10: 'key5',
+      INFURA_42220: 'key6',
+      QUICKNODE_42220: 'host7,key7',
+      QUICKNODE_56: 'host8,key8',
+      INFURA_137: 'key9',
+      QUICKNODE_137: 'host10,key10',
+      ALCHEMY_137: 'key11',
+      INFURA_8453: 'key12',
+      QUICKNODE_8453: 'host13,key13',
+      ALCHEMY_8453: 'key14',
+      NIRVANA_8453: 'host15,key15',
+    }
+
+    const randStub = sandbox.stub(Math, 'random')
+
+    randStub.returns(0.0)
+    const uniRpcProviderCelo = GlobalRpcProviders.getGlobalUniRpcProviders(
+      log,
+      UNI_PROVIDER_TEST_CONFIG,
+      SINGLE_PROVIDER_TEST_CONFIG
+    ).get(ChainId.CELO)!!
+    expect(uniRpcProviderCelo['providers'][0].url).equal('https://host7.celo-mainnet.quiknode.pro/key7')
+    expect(uniRpcProviderCelo['providers'][1].url).equal('https://celo-mainnet.infura.io/v3/key6')
+
     cleanUp()
   })
 })


### PR DESCRIPTION
This is a reworked version of https://github.com/Uniswap/routing-api/pull/523, with a bug fix to picking up enough secret key for prod.

The fix is https://github.com/Uniswap/routing-api/pull/536/commits/378e67e34882912c60b90576d832429e8cc5e06d.
Turns out if we roll out with a probability, we need to load both legacy and new RPC gateway secrets into environment variables.