### PR TITLE
[RPC Gateway] Optimize DB sync rate limit logic, add more metrics & dashboard graph

### DIFF
--- a/bin/stacks/rpc-gateway-dashboard.ts
+++ b/bin/stacks/rpc-gateway-dashboard.ts
@@ -138,8 +138,8 @@ function getDbSyncSuccessMetricsForChain(chainId: ChainId) {
       'RoutingAPI',
       {
         id: `db_sync_success_${chainId}_${providerName}`,
-        label: `${providerName} db sync success ${ID_TO_NETWORK_NAME(chainId)}`
-      }
+        label: `${providerName} db sync success ${ID_TO_NETWORK_NAME(chainId)}`,
+      },
     ])
   }
   return metrics
@@ -155,8 +155,8 @@ function getDbSyncFailMetricsForChain(chainId: ChainId) {
       'RoutingAPI',
       {
         id: `db_sync_fail_${chainId}_${providerName}`,
-        label: `${providerName} db sync fail ${ID_TO_NETWORK_NAME(chainId)}`
-      }
+        label: `${providerName} db sync fail ${ID_TO_NETWORK_NAME(chainId)}`,
+      },
     ])
   }
   return metrics
@@ -172,8 +172,8 @@ function getEvaluateLatencyMetricsForChain(chainId: ChainId) {
       'RoutingAPI',
       {
         id: `evaluate_latency_${chainId}_${providerName}`,
-        label: `${providerName} (Shadow) Evaluate latency for ${ID_TO_NETWORK_NAME(chainId)}`
-      }
+        label: `${providerName} (Shadow) Evaluate latency for ${ID_TO_NETWORK_NAME(chainId)}`,
+      },
     ])
   }
   return metrics
@@ -189,8 +189,8 @@ function getCheckHealthMetricsForChain(chainId: ChainId) {
       'RoutingAPI',
       {
         id: `check_health_${chainId}_${providerName}`,
-        label: `${providerName} (Shadow) Check health for ${ID_TO_NETWORK_NAME(chainId)}`
-      }
+        label: `${providerName} (Shadow) Check health for ${ID_TO_NETWORK_NAME(chainId)}`,
+      },
     ])
   }
   return metrics

--- a/bin/stacks/rpc-gateway-dashboard.ts
+++ b/bin/stacks/rpc-gateway-dashboard.ts
@@ -128,6 +128,74 @@ function getFailedMetricsForChain(chainId: ChainId) {
   return metrics
 }
 
+function getDbSyncSuccessMetricsForChain(chainId: ChainId) {
+  const metrics = []
+  for (const providerName of providerForChain.get(chainId)!) {
+    metrics.push([
+      'Uniswap',
+      `RPC_GATEWAY_${chainId}_${providerName}_db_sync_SUCCESS`,
+      'Service',
+      'RoutingAPI',
+      {
+        id: `db_sync_success_${chainId}_${providerName}`,
+        label: `${providerName} db sync success ${ID_TO_NETWORK_NAME(chainId)}`
+      }
+    ])
+  }
+  return metrics
+}
+
+function getDbSyncFailMetricsForChain(chainId: ChainId) {
+  const metrics = []
+  for (const providerName of providerForChain.get(chainId)!) {
+    metrics.push([
+      'Uniswap',
+      `RPC_GATEWAY_${chainId}_${providerName}_db_sync_FAIL`,
+      'Service',
+      'RoutingAPI',
+      {
+        id: `db_sync_fail_${chainId}_${providerName}`,
+        label: `${providerName} db sync fail ${ID_TO_NETWORK_NAME(chainId)}`
+      }
+    ])
+  }
+  return metrics
+}
+
+function getEvaluateLatencyMetricsForChain(chainId: ChainId) {
+  const metrics = []
+  for (const providerName of providerForChain.get(chainId)!) {
+    metrics.push([
+      'Uniswap',
+      `RPC_GATEWAY_${chainId}_${providerName}_evaluate_latency`,
+      'Service',
+      'RoutingAPI',
+      {
+        id: `evaluate_latency_${chainId}_${providerName}`,
+        label: `${providerName} (Shadow) Evaluate latency for ${ID_TO_NETWORK_NAME(chainId)}`
+      }
+    ])
+  }
+  return metrics
+}
+
+function getCheckHealthMetricsForChain(chainId: ChainId) {
+  const metrics = []
+  for (const providerName of providerForChain.get(chainId)!) {
+    metrics.push([
+      'Uniswap',
+      `RPC_GATEWAY_${chainId}_${providerName}_check_health`,
+      'Service',
+      'RoutingAPI',
+      {
+        id: `check_health_${chainId}_${providerName}`,
+        label: `${providerName} (Shadow) Check health for ${ID_TO_NETWORK_NAME(chainId)}`
+      }
+    ])
+  }
+  return metrics
+}
+
 export class RpcGatewayDashboardStack extends cdk.NestedStack {
   constructor(scope: Construct, name: string) {
     super(scope, name)
@@ -300,6 +368,90 @@ export class RpcGatewayDashboardStack extends cdk.NestedStack {
             left: {
               showUnits: false,
               label: 'Requests',
+            },
+          },
+        },
+      },
+      {
+        height: 8,
+        width: 24,
+        type: 'metric',
+        properties: {
+          metrics: getDbSyncSuccessMetricsForChain(chainId),
+          view: 'timeSeries',
+          stacked: false,
+          region,
+          stat: 'Sum',
+          period: 300,
+          title: `DB sync success for ${ID_TO_NETWORK_NAME(chainId)}`,
+          setPeriodToTimeRange: true,
+          yAxis: {
+            left: {
+              showUnits: false,
+              label: 'Occurrences',
+            },
+          },
+        },
+      },
+      {
+        height: 8,
+        width: 24,
+        type: 'metric',
+        properties: {
+          metrics: getDbSyncFailMetricsForChain(chainId),
+          view: 'timeSeries',
+          stacked: false,
+          region,
+          stat: 'Sum',
+          period: 300,
+          title: `DB sync fail for ${ID_TO_NETWORK_NAME(chainId)}`,
+          setPeriodToTimeRange: true,
+          yAxis: {
+            left: {
+              showUnits: false,
+              label: 'Occurrences',
+            },
+          },
+        },
+      },
+      {
+        height: 8,
+        width: 24,
+        type: 'metric',
+        properties: {
+          metrics: getEvaluateLatencyMetricsForChain(chainId),
+          view: 'timeSeries',
+          stacked: false,
+          region,
+          stat: 'Sum',
+          period: 300,
+          title: `(Shadow) Evaluate latency call for ${ID_TO_NETWORK_NAME(chainId)}`,
+          setPeriodToTimeRange: true,
+          yAxis: {
+            left: {
+              showUnits: false,
+              label: 'Occurrences',
+            },
+          },
+        },
+      },
+      {
+        height: 8,
+        width: 24,
+        type: 'metric',
+        properties: {
+          metrics: getCheckHealthMetricsForChain(chainId),
+          view: 'timeSeries',
+          stacked: false,
+          region,
+          stat: 'Sum',
+          period: 300,
+          title: `(Shadow) Check health call for ${ID_TO_NETWORK_NAME(chainId)}`,
+          setPeriodToTimeRange: true,
+          yAxis: {
+            left: {
+              showUnits: false,
+              label: 'Occurrences',
             },
           },
         },

--- a/lib/rpc/ProviderStateSyncer.ts
+++ b/lib/rpc/ProviderStateSyncer.ts
@@ -7,13 +7,11 @@ import { LatencyEvaluation, ProviderState, ProviderStateDiff } from './ProviderS
 // The frequency of sync is controlled by syncInterval.
 // If lambda is recycled before the next successful sync, the unsynced data may be lost.
 export class ProviderStateSyncer {
-  lastSyncTimestampInMs: number = 0
   stateRepository: ProviderStateRepository
 
   constructor(
     dbTableName: string,
     private readonly providerId: string,
-    private readonly syncIntervalInS: number,
     private readonly latencyStatHistoryWindowLengthInS: number,
     private readonly log: Logger
   ) {
@@ -25,7 +23,7 @@ export class ProviderStateSyncer {
   // 2. Add local accumulated health score diff to the DB stored health score to get new health score
   // 3. Write back new health score to DB
   // 4. Update local health score with the new health score and refresh healthy state accordingly
-  async maybeSyncWithRepository(
+  async syncWithRepository(
     localHealthScoreDiff: number,
     localHealthScore: number,
     lastEvaluatedLatencyInMs: number,
@@ -33,10 +31,6 @@ export class ProviderStateSyncer {
     lastLatencyEvaluationApiName: string
   ): Promise<ProviderState | null> {
     const timestampInMs = Date.now()
-
-    if (!this.shouldSync(timestampInMs)) {
-      return null
-    }
 
     let storedState: ProviderStateWithTimestamp | null = null
     try {
@@ -68,7 +62,6 @@ export class ProviderStateSyncer {
 
     try {
       await this.stateRepository.write(this.providerId, newState, timestampInMs, prevUpdatedAtInMs)
-      this.lastSyncTimestampInMs = timestampInMs
       return newState
     } catch (err: any) {
       this.log.error(`Failed to write to sync storage: ${JSON.stringify(err)}. Sync failed.`)
@@ -103,10 +96,5 @@ export class ProviderStateSyncer {
       healthScore: newHealthScore,
       latencies: latencies,
     }
-  }
-
-  private shouldSync(timestampNowInMs: number): boolean {
-    // Limit sync frequency to at most every syncIntervalInS seconds
-    return timestampNowInMs - this.lastSyncTimestampInMs >= 1000 * this.syncIntervalInS
   }
 }

--- a/lib/rpc/SingleJsonRpcProvider.ts
+++ b/lib/rpc/SingleJsonRpcProvider.ts
@@ -228,6 +228,7 @@ export class SingleJsonRpcProvider extends StaticJsonRpcProvider {
 
   async evaluateHealthiness() {
     this.log.debug(`${this.url}: Evaluate healthiness for unhealthy provider...`)
+    this.logCheckHealth()
     this.evaluatingHealthiness = true
     try {
       await this.getBlockNumber_EvaluateHealthiness()
@@ -239,6 +240,7 @@ export class SingleJsonRpcProvider extends StaticJsonRpcProvider {
 
   async evaluateLatency(methodName: string, ...args: any[]) {
     this.log.debug(`${this.url}: Evaluate for latency... methodName: ${methodName}`)
+    this.logEvaluateLatency()
     this.evaluatingLatency = true
     try {
       await (this as any)[`${methodName}_EvaluateLatency`](...args)
@@ -269,16 +271,24 @@ export class SingleJsonRpcProvider extends StaticJsonRpcProvider {
     )
   }
 
+  logCheckHealth() {
+    metric.putMetric(`${this.metricPrefix}_check_health`, 1, MetricLoggerUnit.Count)
+  }
+
+  logEvaluateLatency() {
+    metric.putMetric(`${this.metricPrefix}_evaluate_latency`, 1, MetricLoggerUnit.Count)
+  }
+
   logProviderSelection() {
     metric.putMetric(`${this.metricPrefix}_selected`, 1, MetricLoggerUnit.Count)
   }
 
   logDbSyncSuccess() {
-    metric.putMetric(`${this.metricPrefix}_db_sync_success`, 1, MetricLoggerUnit.Count)
+    metric.putMetric(`${this.metricPrefix}_db_sync_SUCCESS`, 1, MetricLoggerUnit.Count)
   }
 
   logDbSyncFailure() {
-    metric.putMetric(`${this.metricPrefix}_db_sync_fail`, 1, MetricLoggerUnit.Count)
+    metric.putMetric(`${this.metricPrefix}_db_sync_FAIL`, 1, MetricLoggerUnit.Count)
   }
 
   private async wrappedFunctionCall(
@@ -341,6 +351,7 @@ export class SingleJsonRpcProvider extends StaticJsonRpcProvider {
         // Update latency stat
         this.updateLatencyStat(newState)
       }
+      this.log.debug('Successfully synced with DB and updated states')
       this.logDbSyncSuccess()
     } catch (err: any) {
       this.log.error(`Encountered unhandled error when sync provider state: ${JSON.stringify(err)}`)

--- a/lib/rpc/SingleJsonRpcProvider.ts
+++ b/lib/rpc/SingleJsonRpcProvider.ts
@@ -334,8 +334,7 @@ export class SingleJsonRpcProvider extends StaticJsonRpcProvider {
       this.updateHealthyStatus()
       if (this.enableDbSync) {
         if (
-          (!this.syncingDb && this.hasEnoughWaitSinceLastDbSync(1000 * this.config.DB_SYNC_INTERVAL_IN_S))
-          ||
+          (!this.syncingDb && this.hasEnoughWaitSinceLastDbSync(1000 * this.config.DB_SYNC_INTERVAL_IN_S)) ||
           this.hasEnoughWaitSinceLastDbSync(2 * 1000 * this.config.DB_SYNC_INTERVAL_IN_S)
         ) {
           this.syncingDb = true

--- a/lib/rpc/SingleJsonRpcProvider.ts
+++ b/lib/rpc/SingleJsonRpcProvider.ts
@@ -333,10 +333,7 @@ export class SingleJsonRpcProvider extends StaticJsonRpcProvider {
       this.checkLastCallPerformance(perf)
       this.updateHealthyStatus()
       if (this.enableDbSync) {
-        if (
-          (!this.syncingDb && this.hasEnoughWaitSinceLastDbSync(1000 * this.config.DB_SYNC_INTERVAL_IN_S)) ||
-          this.hasEnoughWaitSinceLastDbSync(2 * 1000 * this.config.DB_SYNC_INTERVAL_IN_S)
-        ) {
+        if (!this.syncingDb && this.hasEnoughWaitSinceLastDbSync(1000 * this.config.DB_SYNC_INTERVAL_IN_S)) {
           this.syncingDb = true
           // Fire and forget. Won't check the sync result.
           this.syncAndUpdateProviderState()

--- a/lib/rpc/UniJsonRpcProvider.ts
+++ b/lib/rpc/UniJsonRpcProvider.ts
@@ -182,13 +182,7 @@ export class UniJsonRpcProvider extends StaticJsonRpcProvider {
       if (provider.url === selectedProvider.url) {
         continue
       }
-      if (
-        (!provider.isEvaluatingHealthiness() &&
-          provider.hasEnoughWaitSinceLastHealthinessEvaluation(
-            1000 * this.config.HEALTH_EVALUATION_WAIT_PERIOD_IN_S
-          )) ||
-        provider.hasEnoughWaitSinceLastHealthinessEvaluation(2 * 1000 * this.config.HEALTH_EVALUATION_WAIT_PERIOD_IN_S)
-      ) {
+      if (!provider.isEvaluatingHealthiness() && provider.hasEnoughWaitSinceLastHealthinessEvaluation(1000 * this.config.HEALTH_EVALUATION_WAIT_PERIOD_IN_S)) {
         // Fire and forget. Don't care about its result and it won't throw.
         // It's done this way because We don't want to block the return of this function.
         provider.evaluateHealthiness()
@@ -210,11 +204,7 @@ export class UniJsonRpcProvider extends StaticJsonRpcProvider {
       if (!MAJOR_METHOD_NAMES.includes(methodName)) {
         continue
       }
-      if (
-        (!provider.isEvaluatingLatency() &&
-          provider.hasEnoughWaitSinceLastLatencyEvaluation(1000 * this.config.LATENCY_EVALUATION_WAIT_PERIOD_IN_S)) ||
-        provider.hasEnoughWaitSinceLastLatencyEvaluation(2 * 1000 * this.config.LATENCY_EVALUATION_WAIT_PERIOD_IN_S)
-      ) {
+      if (!provider.isEvaluatingLatency() && provider.hasEnoughWaitSinceLastLatencyEvaluation(1000 * this.config.LATENCY_EVALUATION_WAIT_PERIOD_IN_S)) {
         // Fire and forget. Don't care about its result and it won't throw.
         // It's done this way because We don't want to block the return of this function.
         provider.evaluateLatency(methodName, args)

--- a/test/mocha/integ/rpc/ProviderStateSyncer.test.ts
+++ b/test/mocha/integ/rpc/ProviderStateSyncer.test.ts
@@ -12,7 +12,7 @@ const log = bunyan.createLogger({
 })
 
 describe('ProviderStateSyncer', () => {
-  const syncer = new ProviderStateSyncer(DynamoDBTableProps.RpcProviderStateDbTable.Name, 'providerId', 5, 300, log)
+  const syncer = new ProviderStateSyncer(DynamoDBTableProps.RpcProviderStateDbTable.Name, 'providerId', 300, log)
   let sandbox: SinonSandbox
 
   beforeEach(() => {
@@ -41,7 +41,7 @@ describe('ProviderStateSyncer', () => {
 
     let syncResult: ProviderState | null
     try {
-      syncResult = await syncer.maybeSyncWithRepository(
+      syncResult = await syncer.syncWithRepository(
         localHealthScoreDiff,
         localHealthScore,
         lastEvaluatedLatencyInMs,
@@ -54,7 +54,6 @@ describe('ProviderStateSyncer', () => {
 
     expect(syncResult !== null)
     expect(syncResult!.healthScore).equals(localHealthScore)
-    expect(syncer.lastSyncTimestampInMs).equals(timestamp)
 
     expect(writeStub.getCall(0).args[1]).deep.equals({
       healthScore: -1100,

--- a/test/mocha/unit/rpc/SingleJsonRpcProvider.test.ts
+++ b/test/mocha/unit/rpc/SingleJsonRpcProvider.test.ts
@@ -153,8 +153,7 @@ describe('SingleJsonRpcProvider', () => {
       provider.getBlockNumber(),
       provider.getBlockNumber(),
     ])
-    // All 5 calls end up with DB sync because provider's lastDbSyncTimestampInMs is too old.
-    expect(syncSpy.callCount).equals(5)
+    expect(syncSpy.callCount).equals(1)
     syncSpy.resetHistory()
 
     await Promise.all([

--- a/test/mocha/unit/rpc/SingleJsonRpcProvider.test.ts
+++ b/test/mocha/unit/rpc/SingleJsonRpcProvider.test.ts
@@ -90,7 +90,9 @@ describe('SingleJsonRpcProvider', () => {
     provider['enableDbSync'] = true
     const DB_HEALTH_SCORE = -1000
     const stubSyncer = sandbox.createStubInstance(ProviderStateSyncer)
-    stubSyncer.syncWithRepository.returns(Promise.resolve({ healthScore: DB_HEALTH_SCORE, latencies: [] } as ProviderState))
+    stubSyncer.syncWithRepository.returns(
+      Promise.resolve({ healthScore: DB_HEALTH_SCORE, latencies: [] } as ProviderState)
+    )
     provider['providerStateSyncer'] = stubSyncer
 
     const getBlockNumber = sandbox.stub(SingleJsonRpcProvider.prototype, '_getBlockNumber' as any)
@@ -107,7 +109,9 @@ describe('SingleJsonRpcProvider', () => {
     provider['enableDbSync'] = true
     const DB_HEALTH_SCORE = -1000
     const stubSyncer = sandbox.createStubInstance(ProviderStateSyncer)
-    stubSyncer.syncWithRepository.returns(Promise.resolve({ healthScore: DB_HEALTH_SCORE, latencies: [] } as ProviderState))
+    stubSyncer.syncWithRepository.returns(
+      Promise.resolve({ healthScore: DB_HEALTH_SCORE, latencies: [] } as ProviderState)
+    )
     provider['providerStateSyncer'] = stubSyncer
 
     const getBlockNumber = sandbox.stub(SingleJsonRpcProvider.prototype, '_getBlockNumber' as any)
@@ -132,7 +136,9 @@ describe('SingleJsonRpcProvider', () => {
     provider['enableDbSync'] = true
     const DB_HEALTH_SCORE = -1000
     const stubSyncer = sandbox.createStubInstance(ProviderStateSyncer)
-    stubSyncer.syncWithRepository.returns(Promise.resolve({ healthScore: DB_HEALTH_SCORE, latencies: [] } as ProviderState))
+    stubSyncer.syncWithRepository.returns(
+      Promise.resolve({ healthScore: DB_HEALTH_SCORE, latencies: [] } as ProviderState)
+    )
     provider['providerStateSyncer'] = stubSyncer
 
     const getBlockNumber = sandbox.stub(SingleJsonRpcProvider.prototype, '_getBlockNumber' as any)

--- a/test/mocha/unit/rpc/UniJsonRpcProvider.test.ts
+++ b/test/mocha/unit/rpc/UniJsonRpcProvider.test.ts
@@ -962,11 +962,10 @@ describe('UniJsonRpcProvider', () => {
       uniProvider.getBlockNumber(),
     ])
 
-    // Shadow evaluate call should be made because we are currently 2 times far away from last latency evaluation timestamp than the threshold.
     expect(spy0.callCount).to.equal(0)
-    expect(spy1.callCount).to.equal(5)
+    expect(spy1.callCount).to.equal(1)
     expect(spy1.getCalls()[0].firstArg).to.equal('getBlockNumber')
-    expect(spy2.callCount).to.equal(5)
+    expect(spy2.callCount).to.equal(1)
     expect(spy2.getCalls()[0].firstArg).to.equal('getBlockNumber')
 
     expect(uniProvider['providers'][0]['lastEvaluatedLatencyInMs']).equal(0)


### PR DESCRIPTION
The logic DB sync rate limit has been improved to make the ownership much clearer between `SingleJsonRpcProvider` and `ProviderStateSyncer`. Previously the rate limit logic spanned across these two classes but now it's all in `SingleJsonRpcProvider`. Vague words like `maybe` are also removed to make the code easier to follow.

Added more unit test for checking the effect of DB sync rate limit.

More Cloudwatch metrics and dashboard graphs have also been added to verify the effect of local env testing and it will be very useful for production deployment monitoring.

Tested and verified in local env.