### PR TITLE
chore: wrapped token quote 400

### DIFF
--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -275,7 +275,8 @@ export class QuoteHandler extends APIGLambdaHandler<
       }
     }
 
-    if (currencyIn.equals(currencyOut)) {
+    // We need bo wrap both tokens, because the comparison includes comparing native currency vs token.
+    if (currencyIn.wrapped.equals(currencyOut.wrapped)) {
       return {
         statusCode: 400,
         errorCode: 'TOKEN_IN_OUT_SAME',

--- a/test/mocha/e2e/quote.test.ts
+++ b/test/mocha/e2e/quote.test.ts
@@ -2365,6 +2365,29 @@ describe('quote', function () {
           })
         })
 
+        it(`tokens are the same after getting wrapped`, async () => {
+          const quoteReq: QuoteQueryParams = {
+            tokenInAddress: 'ETH',
+            tokenInChainId: 1,
+            tokenOutAddress: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+            tokenOutChainId: 1,
+            amount: await getAmount(1, type, 'ETH', 'WETH', '1'),
+            type,
+            recipient: alice.address,
+            slippageTolerance: SLIPPAGE,
+            deadline: '360',
+            algorithm,
+            enableUniversalRouter: true,
+          }
+          await callAndExpectFail(quoteReq, {
+            status: 400,
+            data: {
+              detail: 'tokenIn and tokenOut must be different',
+              errorCode: 'TOKEN_IN_OUT_SAME',
+            },
+          })
+        })
+
         it(`recipient is an invalid address`, async () => {
           const quoteReq: QuoteQueryParams = {
             tokenInAddress: 'USDT',


### PR DESCRIPTION
ETH/WETH quote returns 500, because `currencyIn.equals(currencyOut)` compares whether the instance is native currency or token:

- https://github.com/Uniswap/sdk-core/blob/main/src/entities/ether.ts#L28
- https://github.com/Uniswap/sdk-core/blob/main/src/entities/token.ts#L68

if currencyIn is ETH and currencyOut is WETH, both will never equal, because ETH is Ether instance amd WETH is token instance.