### PR TITLE
[RPC gateway] Fully launch on Celo

### DIFF
--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -1,7 +1,7 @@
 [
   {
     "chainId": 42220,
-    "useMultiProviderProb": 0.1,
+    "useMultiProviderProb": 1,
     "providerInitialWeights": [1, 0],
     "providerUrls": ["QUICKNODE_42220", "INFURA_42220"]
   },


### PR DESCRIPTION
10% of Celo's traffic have been on RPC gateway for a day and the latency and success rate looks normal.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/ee07f95d-8ff2-48c8-930c-435df240a8ad.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/f57caa7f-805f-49dd-9d07-260e124bf55a.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/9a079d8f-4a49-4f95-900a-610af06756d2.png)

Fully launch won't increase the pressure to the major provider for Celo (Quicknode), but will increase the traffic for shadow provider (Infura). However we've seen very little shadow call made to Infura in the last few days after launch.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/1a96cd61-9e37-4918-acf7-d8c1efe7cb07.png)

The QPS is about 0.1. So it won't add much pressure to Infura even if we turn it to full.