### PR TITLE
[RPC gateway] Launch on 10% of Avalanche

### DIFF
--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -7,7 +7,7 @@
   },
   {
     "chainId": 43114,
-    "useMultiProviderProb": 1,
+    "useMultiProviderProb": 0.1,
     "providerInitialWeights": [1, 0, 0],
     "providerUrls": ["INFURA_43114", "QUICKNODE_43114", "NIRVANA_43114"]
   }

--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -7,7 +7,7 @@
   },
   {
     "chainId": 43114,
-    "useMultiProviderProb": 0.01,
+    "useMultiProviderProb": 1,
     "providerInitialWeights": [1, 0, 0],
     "providerUrls": ["INFURA_43114", "QUICKNODE_43114", "NIRVANA_43114"]
   }


### PR DESCRIPTION
Since we launch 1% to Avalanche yesterday (4/1) , we don't see major metrics diff.


![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/6feb4f3d-d849-4a37-810a-15ed3bb80001.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/6eb86067-88c7-4367-9270-59ee3cf33ea3.png)


![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/cd701b2d-dd26-421f-ad50-67a844a7fc52.png)

Now we want to slightly add some traffic to Avalanche. From 1% to 10%.