### PR TITLE
[RPC Gateway] Add RPC Gateway specific Quote request count, fail count and latency metric

### DIFF
--- a/bin/stacks/rpc-gateway-dashboard.ts
+++ b/bin/stacks/rpc-gateway-dashboard.ts
@@ -196,6 +196,51 @@ function getCheckHealthMetricsForChain(chainId: ChainId) {
   return metrics
 }
 
+function getRpcGatewayQuoteCountForChain(chainId: ChainId) {
+  const metrics = []
+  metrics.push([
+    'Uniswap',
+    `RPC_GATEWAY_GET_QUOTE_REQUESTED_CHAINID: ${chainId}`,
+    'Service',
+    'RoutingAPI',
+    {
+      id: `quote_count_${chainId}`,
+      label: `Quote request count for ${ID_TO_NETWORK_NAME(chainId)}`
+    }
+  ])
+  return metrics
+}
+
+function getRpcGatewayQuoteLatencyForChain(chainId: ChainId) {
+  const metrics = []
+  metrics.push([
+    'Uniswap',
+    `RPC_GATEWAY_GET_QUOTE_LATENCY_CHAIN_${chainId}`,
+    'Service',
+    'RoutingAPI',
+    {
+      id: `quote_latency_${chainId}`,
+      label: `Quote latency for ${ID_TO_NETWORK_NAME(chainId)}`
+    }
+  ])
+  return metrics
+}
+
+function getRpcGatewayQuote5xxCountForChain(chainId: ChainId) {
+  const metrics = []
+  metrics.push([
+    'Uniswap',
+    `RPC_GATEWAY_GET_QUOTE_500_CHAINID: ${chainId}`,
+    'Service',
+    'RoutingAPI',
+    {
+      id: `quote_5xx_count_${chainId}`,
+      label: `Quote request 5xx count for ${ID_TO_NETWORK_NAME(chainId)}`
+    }
+  ])
+  return metrics
+}
+
 export class RpcGatewayDashboardStack extends cdk.NestedStack {
   constructor(scope: Construct, name: string) {
     super(scope, name)
@@ -452,6 +497,111 @@ export class RpcGatewayDashboardStack extends cdk.NestedStack {
             left: {
               showUnits: false,
               label: 'Occurrences',
+            },
+          },
+        },
+      },
+      {
+        height: 8,
+        width: 24,
+        type: 'metric',
+        properties: {
+          metrics: getRpcGatewayQuoteCountForChain(chainId),
+          view: 'timeSeries',
+          stacked: false,
+          region,
+          stat: 'Sum',
+          period: 300,
+          title: `Quote count for ${ID_TO_NETWORK_NAME(chainId)}`,
+          setPeriodToTimeRange: true,
+          yAxis: {
+            left: {
+              showUnits: false,
+              label: 'Occurrences',
+            },
+          },
+        },
+      },
+      {
+        height: 8,
+        width: 24,
+        type: 'metric',
+        properties: {
+          metrics: getRpcGatewayQuote5xxCountForChain(chainId),
+          view: 'timeSeries',
+          stacked: false,
+          region,
+          stat: 'Sum',
+          period: 300,
+          title: `Quote 5xx count for ${ID_TO_NETWORK_NAME(chainId)}`,
+          setPeriodToTimeRange: true,
+          yAxis: {
+            left: {
+              showUnits: false,
+              label: 'Occurrences',
+            },
+          },
+        },
+      },
+      {
+        height: 8,
+        width: 24,
+        type: 'metric',
+        properties: {
+          metrics: getRpcGatewayQuoteLatencyForChain(chainId),
+          view: 'timeSeries',
+          stacked: false,
+          region,
+          stat: 'p99',
+          period: 300,
+          title: `Quote p99 latency for ${ID_TO_NETWORK_NAME(chainId)}`,
+          setPeriodToTimeRange: true,
+          yAxis: {
+            left: {
+              showUnits: false,
+              label: 'Ms',
+            },
+          },
+        },
+      },
+      {
+        height: 8,
+        width: 24,
+        type: 'metric',
+        properties: {
+          metrics: getRpcGatewayQuoteLatencyForChain(chainId),
+          view: 'timeSeries',
+          stacked: false,
+          region,
+          stat: 'p90',
+          period: 300,
+          title: `Quote p90 latency for ${ID_TO_NETWORK_NAME(chainId)}`,
+          setPeriodToTimeRange: true,
+          yAxis: {
+            left: {
+              showUnits: false,
+              label: 'Ms',
+            },
+          },
+        },
+      },
+      {
+        height: 8,
+        width: 24,
+        type: 'metric',
+        properties: {
+          metrics: getRpcGatewayQuoteLatencyForChain(chainId),
+          view: 'timeSeries',
+          stacked: false,
+          region,
+          stat: 'p50',
+          period: 300,
+          title: `Quote p50 latency for ${ID_TO_NETWORK_NAME(chainId)}`,
+          setPeriodToTimeRange: true,
+          yAxis: {
+            left: {
+              showUnits: false,
+              label: 'Ms',
             },
           },
         },

--- a/bin/stacks/rpc-gateway-dashboard.ts
+++ b/bin/stacks/rpc-gateway-dashboard.ts
@@ -205,8 +205,8 @@ function getRpcGatewayQuoteCountForChain(chainId: ChainId) {
     'RoutingAPI',
     {
       id: `quote_count_${chainId}`,
-      label: `Quote request count for ${ID_TO_NETWORK_NAME(chainId)}`
-    }
+      label: `Quote request count for ${ID_TO_NETWORK_NAME(chainId)}`,
+    },
   ])
   return metrics
 }
@@ -220,8 +220,8 @@ function getRpcGatewayQuoteLatencyForChain(chainId: ChainId) {
     'RoutingAPI',
     {
       id: `quote_latency_${chainId}`,
-      label: `Quote latency for ${ID_TO_NETWORK_NAME(chainId)}`
-    }
+      label: `Quote latency for ${ID_TO_NETWORK_NAME(chainId)}`,
+    },
   ])
   return metrics
 }
@@ -235,8 +235,8 @@ function getRpcGatewayQuote5xxCountForChain(chainId: ChainId) {
     'RoutingAPI',
     {
       id: `quote_5xx_count_${chainId}`,
-      label: `Quote request 5xx count for ${ID_TO_NETWORK_NAME(chainId)}`
-    }
+      label: `Quote request 5xx count for ${ID_TO_NETWORK_NAME(chainId)}`,
+    },
   ])
   return metrics
 }

--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -10,11 +10,5 @@
     "useMultiProviderProb": 0.1,
     "providerInitialWeights": [1, 0, 0],
     "providerUrls": ["INFURA_43114", "QUICKNODE_43114", "NIRVANA_43114"]
-  },
-  {
-    "chainId": 137,
-    "useMultiProviderProb": 1,
-    "providerInitialWeights": [1, 0, 0],
-    "providerUrls": ["QUICKNODE_137", "INFURA_137", "ALCHEMY_137"]
   }
 ]

--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -10,5 +10,11 @@
     "useMultiProviderProb": 0.1,
     "providerInitialWeights": [1, 0, 0],
     "providerUrls": ["INFURA_43114", "QUICKNODE_43114", "NIRVANA_43114"]
+  },
+  {
+    "chainId": 137,
+    "useMultiProviderProb": 1,
+    "providerInitialWeights": [1, 0, 0],
+    "providerUrls": ["QUICKNODE_137", "INFURA_137", "ALCHEMY_137"]
   }
 ]

--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -56,9 +56,10 @@ export class QuoteHandler extends APIGLambdaHandler<
     const startTime = Date.now()
 
     let result: Response<QuoteResponse> | ErrorResponse
+    const useRpcGateway = GlobalRpcProviders.getGlobalUniRpcProviders(log).has(chainId)
 
     try {
-      if (GlobalRpcProviders.getGlobalUniRpcProviders(log).has(chainId)) {
+      if (useRpcGateway) {
         const provider = GlobalRpcProviders.getGlobalUniRpcProviders(log).get(chainId)!
         provider.forceAttachToNewSession()
       }
@@ -109,6 +110,9 @@ export class QuoteHandler extends APIGLambdaHandler<
           break
         case 500:
           metric.putMetric(`GET_QUOTE_500_CHAINID: ${chainId}`, 1, MetricLoggerUnit.Count)
+          if (useRpcGateway) {
+            metric.putMetric(`RPC_GATEWAY_GET_QUOTE_500_CHAINID: ${chainId}`, 1, MetricLoggerUnit.Count)
+          }
           metric.putMetric(
             `GET_QUOTE_500_REQUEST_SOURCE: ${params.requestQueryParams.source}`,
             1,
@@ -123,6 +127,9 @@ export class QuoteHandler extends APIGLambdaHandler<
       }
     } catch (err) {
       metric.putMetric(`GET_QUOTE_500_CHAINID: ${chainId}`, 1, MetricLoggerUnit.Count)
+      if (useRpcGateway) {
+        metric.putMetric(`RPC_GATEWAY_GET_QUOTE_500_CHAINID: ${chainId}`, 1, MetricLoggerUnit.Count)
+      }
       metric.putMetric(`GET_QUOTE_500_REQUEST_SOURCE: ${params.requestQueryParams.source}`, 1, MetricLoggerUnit.Count)
       metric.putMetric(
         `GET_QUOTE_500_REQUEST_SOURCE_AND_CHAINID: ${params.requestQueryParams.source} ${chainId}`,
@@ -135,6 +142,9 @@ export class QuoteHandler extends APIGLambdaHandler<
       // This metric is logged after calling the internal handler to correlate with the status metrics
       metric.putMetric(`GET_QUOTE_REQUEST_SOURCE: ${params.requestQueryParams.source}`, 1, MetricLoggerUnit.Count)
       metric.putMetric(`GET_QUOTE_REQUESTED_CHAINID: ${chainId}`, 1, MetricLoggerUnit.Count)
+      if (useRpcGateway) {
+        metric.putMetric(`RPC_GATEWAY_GET_QUOTE_REQUESTED_CHAINID: ${chainId}`, 1, MetricLoggerUnit.Count)
+      }
       metric.putMetric(
         `GET_QUOTE_REQUEST_SOURCE_AND_CHAINID: ${params.requestQueryParams.source} ${chainId}`,
         1,
@@ -142,6 +152,9 @@ export class QuoteHandler extends APIGLambdaHandler<
       )
 
       metric.putMetric(`GET_QUOTE_LATENCY_CHAIN_${chainId}`, Date.now() - startTime, MetricLoggerUnit.Milliseconds)
+      if (useRpcGateway) {
+        metric.putMetric(`RPC_GATEWAY_GET_QUOTE_LATENCY_CHAIN_${chainId}`, Date.now() - startTime, MetricLoggerUnit.Milliseconds)
+      }
 
       metric.putMetric(
         `GET_QUOTE_LATENCY_CHAIN_${chainId}_QUOTE_SPEED_${quoteSpeed ?? 'standard'}`,

--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -153,7 +153,11 @@ export class QuoteHandler extends APIGLambdaHandler<
 
       metric.putMetric(`GET_QUOTE_LATENCY_CHAIN_${chainId}`, Date.now() - startTime, MetricLoggerUnit.Milliseconds)
       if (useRpcGateway) {
-        metric.putMetric(`RPC_GATEWAY_GET_QUOTE_LATENCY_CHAIN_${chainId}`, Date.now() - startTime, MetricLoggerUnit.Milliseconds)
+        metric.putMetric(
+          `RPC_GATEWAY_GET_QUOTE_LATENCY_CHAIN_${chainId}`,
+          Date.now() - startTime,
+          MetricLoggerUnit.Milliseconds
+        )
       }
 
       metric.putMetric(


### PR DESCRIPTION
We add more RPC gateway specific metrics that measures from the input side (GET QUOTE). Previously the metrics focused too much on the downstream side (call vendors).

Related dashboard is also updated.

This should be even more helpful to monitor our RPC gateway launches.