### PR TITLE
[RPC Gateway] Launch to 10% of Optimism

### DIFF
--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -19,7 +19,7 @@
   },
   {
     "chainId": 10,
-    "useMultiProviderProb": 0.01,
+    "useMultiProviderProb": 0.1,
     "providerInitialWeights": [1, 0, 0],
     "providerUrls": ["INFURA_10", "QUICKNODE_10", "ALCHEMY_10"]
   }


### PR DESCRIPTION
[**RPC Gateway Deployment Overall Progress Track**](https://docs.google.com/spreadsheets/d/1_pbkfn_dXDLgChfdtkWZqxl2SLfKyYDLbXe-8z3YQmo/edit#gid=0)

Yesterday we deployed to 1% of Optimism. Since then

The success rate is unstable, but it's irrelevant to the RPC gateway (deployment time is show in the graph)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/a40c4315-b9f6-42a0-8f16-90649873796d.png)

If we zoom out and look at latency change, there's no visible one in overall.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/313bb7d3-9a89-48ec-9a36-e0faf487ceb9.png)

If we only look at RPC gateway specific request,

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/30278203-d8b8-434f-8fbf-42233434fa84.png)

There's very few 5xx quote error. But if you look at the error from providers using RPC gateway path:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/f17b8679-ba37-487a-af07-38bc3943778e.png)

There are always random errors here and there in the last 24 hours. So I would consider this more of a downstream issue.

RPC gateway's quote p99 latency is about 2k to 4k ms

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/8a73c27e-9888-4435-8dcb-283b3edec65e.png)

This aligns with overall quote p99 latency

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/28b6017f-5b62-4a70-b614-e5355ea13c22.png)

