### PR TITLE
[RPC Gateway] Launch to 10% of BNB

### DIFF
--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -13,7 +13,7 @@
   },
   {
     "chainId": 56,
-    "useMultiProviderProb": 0.01,
+    "useMultiProviderProb": 0.1,
     "providerInitialWeights": [1],
     "providerUrls": ["QUICKNODE_56"]
   },


### PR DESCRIPTION
[RPC Gateway Per Chain Status]([url](https://docs.google.com/spreadsheets/d/1_pbkfn_dXDLgChfdtkWZqxl2SLfKyYDLbXe-8z3YQmo/edit#gid=0))

Deployed to 1% BNB yesterday. Overall latency looks the same. Deploy time is 15:30

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/141f8c5d-482f-4e8f-b601-228b35c87746.png)

Look at RPC gateway specific latency. About 700ish ms, on par with total latency. Initial higher latency is supposed to be cold start of lambda after deployment.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/9cc8ca2e-24bc-46cb-9e23-84b8ecc95b8c.png)

No 5xx error from RPC gateway code path for Bnb

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/f4e50cf7-d4c6-4cfb-b681-10efeb28e454.png)

Overall BNB has the least risk because there's only one provider. No shadow call logic will be triggered.

