### PR TITLE
[RPC Gateway] Launch to 20% Optimism

### DIFF
--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -19,7 +19,7 @@
   },
   {
     "chainId": 10,
-    "useMultiProviderProb": 1,
+    "useMultiProviderProb": 0.2,
     "providerInitialWeights": [1, 0, 0],
     "providerUrls": ["INFURA_10", "QUICKNODE_10", "ALCHEMY_10"]
   }

--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -19,7 +19,7 @@
   },
   {
     "chainId": 10,
-    "useMultiProviderProb": 0.1,
+    "useMultiProviderProb": 1,
     "providerInitialWeights": [1, 0, 0],
     "providerUrls": ["INFURA_10", "QUICKNODE_10", "ALCHEMY_10"]
   }


### PR DESCRIPTION
We deployed to 10% Optimism on yesterday 16:35 UTC-7 time with https://github.com/Uniswap/routing-api/pull/552. After the deployment we do see a bit of latency increase

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/5c00dedb-b421-4d1b-9900-42ac00120c68.png)

It looks like both RPC gateway path and other code path has latency increases, because we even see the median latency has increased

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/015a63d5-df6d-44e6-b35c-36ed4ab9f5f8.png)

Considering RPC gateway only counts for 10% of the traffic, if only RPC gateway code path have higher latency, the median latency shouldn’t change. That’s why I think it’s caused by something else.

Then I found that the latency for send() api from Infura, which is our Optimism’s major provider, did increase around the end of 18 o’clock. 

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/65739916-433c-4b34-9e84-54f37be6da57.png)

This should explain the QUOTE latency increase that happened about 2 hours after deployment.

However, just to be safe, we will try 20% launch and see if the latency continue to rise.

