### PR TITLE
[RPC Gateway] Launch to 100% of BNB

### DIFF
--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -13,7 +13,7 @@
   },
   {
     "chainId": 56,
-    "useMultiProviderProb": 0.1,
+    "useMultiProviderProb": 1,
     "providerInitialWeights": [1],
     "providerUrls": ["QUICKNODE_56"]
   },


### PR DESCRIPTION
[RPC Gateway Per Chain Status]([url](https://docs.google.com/spreadsheets/d/1_pbkfn_dXDLgChfdtkWZqxl2SLfKyYDLbXe-8z3YQmo/edit#gid=0))

We deployed BNB from 1% to 10%. https://github.com/Uniswap/routing-api/pull/553. Prod updated happened at 8:47

Overall latency is stable

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/508e9f95-b5f5-42de-8152-bc734d2cf9bf.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/0e7eefbb-b975-4c91-83b7-23f13a088461.png)

Success rate 100%

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/7bf88938-00d6-4538-9b13-3db48b97c1e1.png)

No 5XX error

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/3184c0ab-d282-4f7c-adc1-cd88d38b87cb.png)

