### PR TITLE
[RPC Gateway] Full launch on Optimism

### DIFF
--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -19,7 +19,7 @@
   },
   {
     "chainId": 10,
-    "useMultiProviderProb": 0.2,
+    "useMultiProviderProb": 1,
     "providerInitialWeights": [1, 0, 0],
     "providerUrls": ["INFURA_10", "QUICKNODE_10", "ALCHEMY_10"]
   }


### PR DESCRIPTION
[RPC Gateway Per Chain Status]([url]
(https://docs.google.com/spreadsheets/d/1_pbkfn_dXDLgChfdtkWZqxl2SLfKyYDLbXe-8z3YQmo/edit#gid=0))

Previously we increased traffic from 10% to 20% on Optimism. https://github.com/Uniswap/routing-api/pull/554 The deployment happened at 12:17.

Latency looks stable after deployment

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/5c4acee6-c5ee-4972-ab3c-c9730a2f5482.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/b1bf5b01-e950-4a70-b850-53ac86ade260.png)

Success rate didn't change after deployment.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/20df66ac-c3c1-43b3-8bf2-69e3c76e2d25.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/88c9e353-71d6-4777-bb72-0b3ec8b4542e.png)

Code path that went through the RPC gateway shows no 5xx error after deployment.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/74c3b2a4-5643-44bf-95d5-995b2e19f5bc.png)


