### PR TITLE
[RPC Gateway] Add method name check before DB sync for non-shadow call

### DIFF
--- a/lib/rpc/ProviderStateSyncer.ts
+++ b/lib/rpc/ProviderStateSyncer.ts
@@ -38,7 +38,7 @@ export class ProviderStateSyncer {
     } catch (err: any) {
       this.log.error(`Failed to read from sync storage: ${JSON.stringify(err)}. Sync failed.`)
     }
-    this.log.debug({ storedState }, 'Loaded stored state')
+    this.log.debug({ storedState }, `${this.providerId}: Loaded stored state`)
 
     const stateDiff: ProviderStateDiff = {
       healthScore: localHealthScore,
@@ -49,6 +49,7 @@ export class ProviderStateSyncer {
         apiName: lastLatencyEvaluationApiName,
       },
     }
+    this.log.debug({ stateDiff }, `${this.providerId}: State diff`)
 
     let newState: ProviderState
     let prevUpdatedAtInMs: number | undefined
@@ -59,6 +60,7 @@ export class ProviderStateSyncer {
       newState = this.calculateNewState(storedState.state, stateDiff)
       prevUpdatedAtInMs = storedState.updatedAtInMs
     }
+    this.log.debug({ newState }, `${this.providerId}: Calculated new state`)
 
     try {
       await this.stateRepository.write(this.providerId, newState, timestampInMs, prevUpdatedAtInMs)


### PR DESCRIPTION
We've seen cases where, for major provider, DB sync happens but `SingleJsonRpcProvider` doesn't have a latency record that belongs to the method name white list. Since we are only syncing latency for whitelisted methods with DB, this ends up being a wasted opportunity to sync. The result could be losing expected latency numbers in the DB for major providers.

We fix this issue by adding one more check on entering sync: The method name needs to be included in the whitelist.

Local test verified cases like mentioned above no longer happens.

Other small logging tweaks are added.