### PR TITLE
[RPC Gateway] Always record all latency metric for major provider

### DIFF
--- a/bin/stacks/routing-lambda-stack.ts
+++ b/bin/stacks/routing-lambda-stack.ts
@@ -100,7 +100,7 @@ export class RoutingLambdaStack extends cdk.NestedStack {
       // 11/8/23: URA currently calls the Routing API with a timeout of 10 seconds.
       // Set this lambda's timeout to be slightly lower to give them time to
       // log the response in the event of a failure on our end.
-      timeout: cdk.Duration.seconds(19),
+      timeout: cdk.Duration.seconds(9),
       memorySize: 2560,
       deadLetterQueueEnabled: true,
       bundling: {

--- a/bin/stacks/routing-lambda-stack.ts
+++ b/bin/stacks/routing-lambda-stack.ts
@@ -100,7 +100,7 @@ export class RoutingLambdaStack extends cdk.NestedStack {
       // 11/8/23: URA currently calls the Routing API with a timeout of 10 seconds.
       // Set this lambda's timeout to be slightly lower to give them time to
       // log the response in the event of a failure on our end.
-      timeout: cdk.Duration.seconds(9),
+      timeout: cdk.Duration.seconds(19),
       memorySize: 2560,
       deadLetterQueueEnabled: true,
       bundling: {

--- a/lib/rpc/SingleJsonRpcProvider.ts
+++ b/lib/rpc/SingleJsonRpcProvider.ts
@@ -156,20 +156,22 @@ export class SingleJsonRpcProvider extends StaticJsonRpcProvider {
       this.lastHealthinessEvaluationTimestampInMs = perf.startTimestampInMs
       this.evaluatingHealthiness = false
     } else if (perf.callType === CallType.LATENCY_EVALUATION) {
+      this.logLatencyMetrics(perf.methodName, perf.latencyInMs)
       this.lastEvaluatedLatencyInMs = perf.latencyInMs
       this.lastLatencyEvaluationTimestampInMs = perf.startTimestampInMs
       this.lastLatencyEvaluationApiName = perf.methodName
-      this.logLatencyMetrics()
       this.evaluatingLatency = false
-    } else if (
-      perf.startTimestampInMs - this.lastLatencyEvaluationTimestampInMs >
+    } else {
+      this.logLatencyMetrics(perf.methodName, perf.latencyInMs)
+      if (
+        perf.startTimestampInMs - this.lastLatencyEvaluationTimestampInMs >
         1000 * this.config.LATENCY_EVALUATION_WAIT_PERIOD_IN_S &&
-      MAJOR_METHOD_NAMES.includes(perf.methodName)
-    ) {
-      this.lastEvaluatedLatencyInMs = perf.latencyInMs
-      this.lastLatencyEvaluationTimestampInMs = perf.startTimestampInMs
-      this.lastLatencyEvaluationApiName = perf.methodName
-      this.logLatencyMetrics()
+        MAJOR_METHOD_NAMES.includes(perf.methodName)
+      ) {
+        this.lastEvaluatedLatencyInMs = perf.latencyInMs
+        this.lastLatencyEvaluationTimestampInMs = perf.startTimestampInMs
+        this.lastLatencyEvaluationApiName = perf.methodName
+      }
     }
 
     this.healthScore += this.config.HIGH_LATENCY_PENALTY
@@ -183,20 +185,22 @@ export class SingleJsonRpcProvider extends StaticJsonRpcProvider {
       this.lastHealthinessEvaluationTimestampInMs = perf.startTimestampInMs
       this.evaluatingHealthiness = false
     } else if (perf.callType === CallType.LATENCY_EVALUATION) {
+      this.logLatencyMetrics(perf.methodName, perf.latencyInMs)
       this.lastEvaluatedLatencyInMs = perf.latencyInMs
       this.lastLatencyEvaluationTimestampInMs = perf.startTimestampInMs
       this.lastLatencyEvaluationApiName = perf.methodName
-      this.logLatencyMetrics()
       this.evaluatingLatency = false
-    } else if (
-      perf.startTimestampInMs - this.lastLatencyEvaluationTimestampInMs >
+    } else {
+      this.logLatencyMetrics(perf.methodName, perf.latencyInMs)
+      if (
+        perf.startTimestampInMs - this.lastLatencyEvaluationTimestampInMs >
         1000 * this.config.LATENCY_EVALUATION_WAIT_PERIOD_IN_S &&
-      MAJOR_METHOD_NAMES.includes(perf.methodName)
-    ) {
-      this.lastEvaluatedLatencyInMs = perf.latencyInMs
-      this.lastLatencyEvaluationTimestampInMs = perf.startTimestampInMs
-      this.lastLatencyEvaluationApiName = perf.methodName
-      this.logLatencyMetrics()
+        MAJOR_METHOD_NAMES.includes(perf.methodName)
+      ) {
+        this.lastEvaluatedLatencyInMs = perf.latencyInMs
+        this.lastLatencyEvaluationTimestampInMs = perf.startTimestampInMs
+        this.lastLatencyEvaluationApiName = perf.methodName
+      }
     }
 
     if (this.healthScore === 0) {
@@ -264,19 +268,16 @@ export class SingleJsonRpcProvider extends StaticJsonRpcProvider {
     metric.putMetric(`${this.metricPrefix}_health_score`, -this.healthScore, MetricLoggerUnit.None)
   }
 
-  logLatencyMetrics() {
+  logLatencyMetrics(methodName: string, latencyInMs: number) {
+    // metric.putMetric(
+    //   `${this.metricPrefix}_evaluated_latency_${this.lastLatencyEvaluationApiName}`,
+    //   this.lastEvaluatedLatencyInMs,
+    //   MetricLoggerUnit.None
+    // )
     metric.putMetric(
-      `${this.metricPrefix}_evaluated_latency_${this.lastLatencyEvaluationApiName}`,
-      this.lastEvaluatedLatencyInMs,
+      `${this.metricPrefix}_evaluated_latency_${methodName}`,
+      latencyInMs,
       MetricLoggerUnit.None
-    )
-    this.log.debug(
-      {
-        lastEvaluatedLatencyInMs: this.lastEvaluatedLatencyInMs,
-        lastLatencyEvaluationTimestampInMs: this.lastLatencyEvaluationTimestampInMs,
-        lastLatencyEvaluationApiName: this.lastLatencyEvaluationApiName,
-      },
-      'Latency evaluation recorded'
     )
   }
 

--- a/lib/rpc/SingleJsonRpcProvider.ts
+++ b/lib/rpc/SingleJsonRpcProvider.ts
@@ -269,11 +269,6 @@ export class SingleJsonRpcProvider extends StaticJsonRpcProvider {
   }
 
   logLatencyMetrics(methodName: string, latencyInMs: number) {
-    // metric.putMetric(
-    //   `${this.metricPrefix}_evaluated_latency_${this.lastLatencyEvaluationApiName}`,
-    //   this.lastEvaluatedLatencyInMs,
-    //   MetricLoggerUnit.None
-    // )
     metric.putMetric(
       `${this.metricPrefix}_evaluated_latency_${methodName}`,
       latencyInMs,


### PR DESCRIPTION
Previously, for major providers, we only record latency metrics if this latency is going to be synced to DB. This will cause misses of latency metrics in AWS for certain APIs of major providers. For example, in production, we found that the major provider only published metrics for `send` call, no other calls.

This PR fixes this problem.

In local dev, you can see that we have more latencies for major providers recorded (the major provider here is Infura).

Before (For Infura we only recorded latency for `send`)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/23ed96c0-5730-4a5a-b867-dbd54bdd20c3.png)

After (For Infura we recorded latency for other APIs as well)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/bb34dabf-5744-4db0-921c-f6985debc4db.png)

