### PR TITLE
Bump RoutingLambdaStack version

### DIFF
--- a/bin/stacks/routing-lambda-stack.ts
+++ b/bin/stacks/routing-lambda-stack.ts
@@ -112,7 +112,7 @@ export class RoutingLambdaStack extends cdk.NestedStack {
 
       description: 'Routing Lambda',
       environment: {
-        VERSION: '15',
+        VERSION: '16',
         NODE_OPTIONS: '--enable-source-maps',
         POOL_CACHE_BUCKET: poolCacheBucket.bucketName,
         POOL_CACHE_BUCKET_2: poolCacheBucket2.bucketName,


### PR DESCRIPTION
We need to do a re-roll of production secret. This PR is to make sure the lambda pick the new secret value.