### PR TITLE
[RPC Gateway] Turn off DB sync for Sepolia

### DIFF
--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -31,7 +31,6 @@
     "chainId": 11155111,
     "useMultiProviderProb": 1,
     "providerInitialWeights": [1, 0],
-    "providerUrls": ["INFURA_11155111", "ALCHEMY_11155111"],
-    "enableDbSync": true
+    "providerUrls": ["INFURA_11155111", "ALCHEMY_11155111"]
   }
 ]


### PR DESCRIPTION
Based on discussion with the team, we plan to roll up RPC gateway without using DB sync. This is the first PR to make sure no issue in production without DB sync on a testnet chain. If this works well, we will apply the same to other launched chains.