### PR TITLE
[RPC Gateway] Turn off DB sync on already launched chains

### DIFF
--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -3,29 +3,25 @@
     "chainId": 42220,
     "useMultiProviderProb": 1,
     "providerInitialWeights": [1, 0],
-    "providerUrls": ["QUICKNODE_42220", "INFURA_42220"],
-    "enableDbSync": true
+    "providerUrls": ["QUICKNODE_42220", "INFURA_42220"]
   },
   {
     "chainId": 43114,
     "useMultiProviderProb": 1,
     "providerInitialWeights": [1, 0, 0],
-    "providerUrls": ["INFURA_43114", "QUICKNODE_43114", "NIRVANA_43114"],
-    "enableDbSync": true
+    "providerUrls": ["INFURA_43114", "QUICKNODE_43114", "NIRVANA_43114"]
   },
   {
     "chainId": 56,
     "useMultiProviderProb": 1,
     "providerInitialWeights": [1],
-    "providerUrls": ["QUICKNODE_56"],
-    "enableDbSync": true
+    "providerUrls": ["QUICKNODE_56"]
   },
   {
     "chainId": 10,
     "useMultiProviderProb": 1,
     "providerInitialWeights": [1, 0, 0],
-    "providerUrls": ["INFURA_10", "QUICKNODE_10", "ALCHEMY_10"],
-    "enableDbSync": true
+    "providerUrls": ["INFURA_10", "QUICKNODE_10", "ALCHEMY_10"]
   },
   {
     "chainId": 11155111,


### PR DESCRIPTION
After we deployed https://github.com/Uniswap/routing-api/pull/566 (Turn off DB sync for Sepolia), we verified that DB sync for Sepolia indeed dropped to zero:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/e93ea9ad-ed68-494b-af56-facdb8007735.png)

While other chains, such as Avalanche, it's DB sync isn't affected

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/6a29e6ff-b10d-433a-8799-f72e70a2a036.png)

Latency reporting for different providers isn't affected:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/e1e75808-e163-4670-aa5b-88871eb0bb3d.png)


So it worked as expected. As a follow up, we will disable DB sync for other launched chains in this PR.