### PR TITLE
[RPC Gateway] Launch 1% to Arbitrum

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -196,6 +196,11 @@ export class RoutingAPIPipeline extends Stack {
       // Sepolia
       'INFURA_11155111',
       'ALCHEMY_11155111',
+      // Arbitrum
+      'INFURA_42161',
+      'QUICKNODE_42161',
+      'NIRVANA_42161',
+      'ALCHEMY_42161',
     ]
     for (const provider of RPC_GATEWAY_PROVIDERS) {
       jsonRpcProviders[provider] = jsonRpcProvidersSecret.secretValueFromJson(provider).toString()
@@ -340,6 +345,11 @@ const jsonRpcProviders = {
   // Sepolia
   INFURA_11155111: process.env.INFURA_11155111!,
   ALCHEMY_11155111: process.env.ALCHEMY_11155111!,
+  // Arbitrum
+  INFURA_42161: process.env.INFURA_42161!,
+  QUICKNODE_42161: process.env.QUICKNODE_42161!,
+  NIRVANA_42161: process.env.NIRVANA_42161!,
+  ALCHEMY_42161: process.env.ALCHEMY_42161!,
 }
 
 // Local dev stack

--- a/bin/stacks/routing-lambda-stack.ts
+++ b/bin/stacks/routing-lambda-stack.ts
@@ -100,7 +100,7 @@ export class RoutingLambdaStack extends cdk.NestedStack {
       // 11/8/23: URA currently calls the Routing API with a timeout of 10 seconds.
       // Set this lambda's timeout to be slightly lower to give them time to
       // log the response in the event of a failure on our end.
-      timeout: cdk.Duration.seconds(19),
+      timeout: cdk.Duration.seconds(9),
       memorySize: 2560,
       deadLetterQueueEnabled: true,
       bundling: {

--- a/bin/stacks/routing-lambda-stack.ts
+++ b/bin/stacks/routing-lambda-stack.ts
@@ -100,7 +100,7 @@ export class RoutingLambdaStack extends cdk.NestedStack {
       // 11/8/23: URA currently calls the Routing API with a timeout of 10 seconds.
       // Set this lambda's timeout to be slightly lower to give them time to
       // log the response in the event of a failure on our end.
-      timeout: cdk.Duration.seconds(9),
+      timeout: cdk.Duration.seconds(19),
       memorySize: 2560,
       deadLetterQueueEnabled: true,
       bundling: {

--- a/bin/stacks/rpc-gateway-dashboard.ts
+++ b/bin/stacks/rpc-gateway-dashboard.ts
@@ -17,6 +17,7 @@ const providerNameForChain: Map<ChainId, string[]> = new Map([
   [ChainId.POLYGON, ['INFURA', 'QUIKNODE', 'ALCHEMY']],
   [ChainId.BASE, ['INFURA', 'QUIKNODE', 'ALCHEMY', 'NIRVANA']],
   [ChainId.SEPOLIA, ['INFURA', 'ALCHEMY']],
+  [ChainId.ARBITRUM_ONE, ['INFURA', 'QUIKNODE', 'ALCHEMY', 'NIRVANA']],
 ])
 
 function getProviderNameForChain(chainId: ChainId): string[] {

--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -37,7 +37,7 @@
   },
   {
     "chainId": 42161,
-    "useMultiProviderProb": 1,
+    "useMultiProviderProb": 0.01,
     "providerInitialWeights": [1, 0, 0, 0],
     "providerUrls": ["INFURA_42161", "QUICKNODE_42161", "NIRVANA_42161", "ALCHEMY_42161"]
   }

--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -34,5 +34,11 @@
     "useMultiProviderProb": 0.01,
     "providerInitialWeights": [1, 0, 0],
     "providerUrls": ["QUICKNODE_137", "INFURA_137", "ALCHEMY_137"]
+  },
+  {
+    "chainId": 42161,
+    "useMultiProviderProb": 1,
+    "providerInitialWeights": [1, 0, 0, 0],
+    "providerUrls": ["INFURA_42161", "QUICKNODE_42161", "NIRVANA_42161", "ALCHEMY_42161"]
   }
 ]

--- a/lib/rpc/utils.ts
+++ b/lib/rpc/utils.ts
@@ -48,6 +48,9 @@ export function generateProviderUrl(key: string, value: string): string {
     case 'INFURA_11155111': {
       return `https://sepolia.infura.io/v3/${tokens[0]}`
     }
+    case 'INFURA_42161': {
+      return `https://arbitrum-mainnet.infura.io/v3/${tokens[0]}`
+    }
     // Nirvana
     case 'NIRVANA_43114': {
       return `https://avax.nirvanalabs.xyz/${tokens[0]}/ext/bc/C/rpc?apikey=${tokens[1]}`
@@ -57,6 +60,9 @@ export function generateProviderUrl(key: string, value: string): string {
     }
     case 'NIRVANA_8453': {
       return `https://base.nirvanalabs.xyz/${tokens[0]}?apikey=${tokens[1]}`
+    }
+    case 'NIRVANA_42161': {
+      return `https://arb.nirvanalabs.xyz/${tokens[0]}?apikey=${tokens[1]}`
     }
     // Quicknode
     case 'QUICKNODE_43114': {
@@ -77,6 +83,9 @@ export function generateProviderUrl(key: string, value: string): string {
     case 'QUICKNODE_8453': {
       return `https://${tokens[0]}.base-mainnet.quiknode.pro/${tokens[1]}`
     }
+    case 'QUICKNODE_42161': {
+      return `https://${tokens[0]}.arbitrum-mainnet.quiknode.pro/${tokens[1]}`
+    }
     // Alchemy
     case 'ALCHEMY_10': {
       return `https://opt-mainnet.g.alchemy.com/v2/${tokens[0]}`
@@ -89,6 +98,9 @@ export function generateProviderUrl(key: string, value: string): string {
     }
     case 'ALCHEMY_11155111': {
       return `https://eth-sepolia.g.alchemy.com/v2/${tokens[0]}`
+    }
+    case 'ALCHEMY_42161': {
+      return `https://arb-mainnet.g.alchemy.com/v2/${tokens[0]}`
     }
   }
   throw new Error(`Unknown provider-chainId pair: ${key}`)

--- a/test/mocha/unit/rpc/GlobalRpcProviders.test.ts
+++ b/test/mocha/unit/rpc/GlobalRpcProviders.test.ts
@@ -263,11 +263,15 @@ describe('GlobalRpcProviders', () => {
       NIRVANA_8453: 'host15,key15',
       INFURA_11155111: 'key16',
       ALCHEMY_11155111: 'key17',
+      INFURA_42161: 'key18',
+      QUICKNODE_42161: 'host19,key19',
+      NIRVANA_42161: 'host20,key20',
+      ALCHEMY_42161: 'key21',
     }
 
     const randStub = sandbox.stub(Math, 'random')
-
     randStub.returns(0.0)
+
     const uniRpcProviderCelo = GlobalRpcProviders.getGlobalUniRpcProviders(
       log,
       UNI_PROVIDER_TEST_CONFIG,
@@ -280,10 +284,22 @@ describe('GlobalRpcProviders', () => {
     const sepoliaRpcProvider = GlobalRpcProviders.getGlobalUniRpcProviders(
       log,
       UNI_PROVIDER_TEST_CONFIG,
-      SINGLE_PROVIDER_TEST_CONFIG
+      SINGLE_PROVIDER_TEST_CONFIG,
+      TEST_PROD_CONFIG
     ).get(ChainId.SEPOLIA)!!
     expect(sepoliaRpcProvider['providers'][0].url).equal('https://sepolia.infura.io/v3/key16')
     expect(sepoliaRpcProvider['providers'][1].url).equal('https://eth-sepolia.g.alchemy.com/v2/key17')
+
+    const arbitrumRpcProvider = GlobalRpcProviders.getGlobalUniRpcProviders(
+      log,
+      UNI_PROVIDER_TEST_CONFIG,
+      SINGLE_PROVIDER_TEST_CONFIG,
+      TEST_PROD_CONFIG
+    ).get(ChainId.ARBITRUM_ONE)!!
+    expect(arbitrumRpcProvider['providers'][0].url).equal('https://arbitrum-mainnet.infura.io/v3/key18')
+    expect(arbitrumRpcProvider['providers'][1].url).equal('https://host19.arbitrum-mainnet.quiknode.pro/key19')
+    expect(arbitrumRpcProvider['providers'][2].url).equal('https://arb.nirvanalabs.xyz/host20?apikey=key20')
+    expect(arbitrumRpcProvider['providers'][3].url).equal('https://arb-mainnet.g.alchemy.com/v2/key21')
 
     cleanUp()
   })

--- a/test/mocha/unit/rpc/rpcProviderTestProdConfig.json
+++ b/test/mocha/unit/rpc/rpcProviderTestProdConfig.json
@@ -28,5 +28,11 @@
     "useMultiProviderProb": 1,
     "providerInitialWeights": [1, 0],
     "providerUrls": ["INFURA_11155111", "ALCHEMY_11155111"]
+  },
+  {
+    "chainId": 42161,
+    "useMultiProviderProb": 1,
+    "providerInitialWeights": [1, 1, 1, 1],
+    "providerUrls": ["INFURA_42161", "QUICKNODE_42161", "NIRVANA_42161", "ALCHEMY_42161"]
   }
 ]

--- a/test/mocha/unit/rpc/rpcProviderTestProdConfig.json
+++ b/test/mocha/unit/rpc/rpcProviderTestProdConfig.json
@@ -30,6 +30,12 @@
     "providerUrls": ["INFURA_11155111", "ALCHEMY_11155111"]
   },
   {
+    "chainId": 137,
+    "useMultiProviderProb": 0.01,
+    "providerInitialWeights": [1, 0, 0],
+    "providerUrls": ["QUICKNODE_137", "INFURA_137", "ALCHEMY_137"]
+  },
+  {
     "chainId": 42161,
     "useMultiProviderProb": 1,
     "providerInitialWeights": [1, 1, 1, 1],


### PR DESCRIPTION
Tested locally:

1. Set chain config to 
```
  {
    "chainId": 42161,
    "useMultiProviderProb": 1,
    "providerInitialWeights": [1, 0, 0, 0],
    "providerUrls": ["INFURA_42161", "QUICKNODE_42161", "NIRVANA_42161", "ALCHEMY_42161"]
  }
```
Then make a bunch of requests. We can see that the major provider is used while others are being shadow called.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/07323031-9bb8-4405-a187-5e01aea3fdb6.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/8cb91a46-d849-4833-bd68-bf90d57a9326.png)

2. Set chain config to 
```
  {
    "chainId": 42161,
    "useMultiProviderProb": 1,
    "providerInitialWeights": [1, 1, 1, 1],
    "providerUrls": ["INFURA_42161", "QUICKNODE_42161", "NIRVANA_42161", "ALCHEMY_42161"]
  }
````
We can see that four providers all served as major providers

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/7362cf68-5af5-4858-9de6-29a5bab917e3.png)

and they shadow called each other

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/d3e2d8fa-79ad-4e45-a5e8-ca4381c75bce.png)

Also there are no errors from any of the providers from what I tested.
