### PR TITLE
[RPC Gateway] Launch to 10% of Polygon

### DIFF
--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -31,7 +31,7 @@
   },
   {
     "chainId": 137,
-    "useMultiProviderProb": 0.01,
+    "useMultiProviderProb": 0.1,
     "providerInitialWeights": [1, 0, 0],
     "providerUrls": ["QUICKNODE_137", "INFURA_137", "ALCHEMY_137"]
   },


### PR DESCRIPTION
We deployed to 1% on Polygon: https://github.com/Uniswap/routing-api/pull/568. Deployment time is at 13:38

Polygon mainnet p99.9 latency stays regular

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/33d6278c-0c7a-40bd-a684-acad5021f73f.png)

Success rate and 5xx error not affected by deployment (the spike is way after the deployment)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/d5b0e4b2-b96f-489c-99e2-d257aa4647fe.png)

P99 latency using RPC gateway on Polygon

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/f9f248de-579e-43f0-a245-ae4446d5df0c.png)

Is similar to the p99 latency overall on Polygon

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/f98a67f5-4f0a-47a9-8913-cfe48a12e97f.png)

