### PR TITLE
[RPC Gateway] Deploy to 10% Arbitrum

### DIFF
--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -37,7 +37,7 @@
   },
   {
     "chainId": 42161,
-    "useMultiProviderProb": 0.01,
+    "useMultiProviderProb": 0.1,
     "providerInitialWeights": [1, 0, 0, 0],
     "providerUrls": ["INFURA_42161", "QUICKNODE_42161", "NIRVANA_42161", "ALCHEMY_42161"]
   }


### PR DESCRIPTION
We launch to 1% of Arbitrum https://github.com/Uniswap/routing-api/pull/570  
Deployment finished around 16:00

Latency looks fine

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/cef1c901-96f8-4027-92d9-bab402286bfc.png)

No errors after deployment

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/3c334582-c5a7-421f-8599-1abbc5aaa3a4.png)

No 5xx error for requests using RPC gateway

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/bc43d2fb-6f1f-4493-995d-102eaaeb34c0.png)

