### PR TITLE
[RPC Gateway] Launch to 1% Ethereum

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -201,6 +201,11 @@ export class RoutingAPIPipeline extends Stack {
       'QUICKNODE_42161',
       'NIRVANA_42161',
       'ALCHEMY_42161',
+      // Ethereum
+      'INFURA_1',
+      'QUICKNODE_1',
+      'NIRVANA_1',
+      'ALCHEMY_1',
     ]
     for (const provider of RPC_GATEWAY_PROVIDERS) {
       jsonRpcProviders[provider] = jsonRpcProvidersSecret.secretValueFromJson(provider).toString()
@@ -350,6 +355,11 @@ const jsonRpcProviders = {
   QUICKNODE_42161: process.env.QUICKNODE_42161!,
   NIRVANA_42161: process.env.NIRVANA_42161!,
   ALCHEMY_42161: process.env.ALCHEMY_42161!,
+  // Ethereum
+  INFURA_1: process.env.INFURA_1!,
+  QUICKNODE_1: process.env.QUICKNODE_1!,
+  NIRVANA_1: process.env.NIRVANA_1!,
+  ALCHEMY_1: process.env.ALCHEMY_1!,
 }
 
 // Local dev stack

--- a/bin/stacks/routing-lambda-stack.ts
+++ b/bin/stacks/routing-lambda-stack.ts
@@ -100,7 +100,7 @@ export class RoutingLambdaStack extends cdk.NestedStack {
       // 11/8/23: URA currently calls the Routing API with a timeout of 10 seconds.
       // Set this lambda's timeout to be slightly lower to give them time to
       // log the response in the event of a failure on our end.
-      timeout: cdk.Duration.seconds(19),
+      timeout: cdk.Duration.seconds(9),
       memorySize: 2560,
       deadLetterQueueEnabled: true,
       bundling: {

--- a/bin/stacks/routing-lambda-stack.ts
+++ b/bin/stacks/routing-lambda-stack.ts
@@ -100,7 +100,7 @@ export class RoutingLambdaStack extends cdk.NestedStack {
       // 11/8/23: URA currently calls the Routing API with a timeout of 10 seconds.
       // Set this lambda's timeout to be slightly lower to give them time to
       // log the response in the event of a failure on our end.
-      timeout: cdk.Duration.seconds(9),
+      timeout: cdk.Duration.seconds(19),
       memorySize: 2560,
       deadLetterQueueEnabled: true,
       bundling: {

--- a/bin/stacks/rpc-gateway-dashboard.ts
+++ b/bin/stacks/rpc-gateway-dashboard.ts
@@ -15,7 +15,7 @@ const providerNameForChain: Map<ChainId, string[]> = new Map([
   [ChainId.CELO, ['INFURA', 'QUIKNODE']],
   [ChainId.BNB, ['QUIKNODE']],
   [ChainId.POLYGON, ['INFURA', 'QUIKNODE', 'ALCHEMY']],
-  [ChainId.BASE, ['QUIKNODE', 'INFURA', 'ALCHEMY', 'NIRVANA']],
+  [ChainId.BASE, ['QUIKNODE', 'ALCHEMY', 'NIRVANA']],
   [ChainId.SEPOLIA, ['INFURA', 'ALCHEMY']],
   [ChainId.ARBITRUM_ONE, ['INFURA', 'QUIKNODE', 'ALCHEMY', 'NIRVANA']],
   [ChainId.MAINNET, ['INFURA', 'QUIKNODE', 'NIRVANA', 'ALCHEMY']],

--- a/bin/stacks/rpc-gateway-dashboard.ts
+++ b/bin/stacks/rpc-gateway-dashboard.ts
@@ -18,6 +18,7 @@ const providerNameForChain: Map<ChainId, string[]> = new Map([
   [ChainId.BASE, ['QUIKNODE', 'INFURA', 'ALCHEMY', 'NIRVANA']],
   [ChainId.SEPOLIA, ['INFURA', 'ALCHEMY']],
   [ChainId.ARBITRUM_ONE, ['INFURA', 'QUIKNODE', 'ALCHEMY', 'NIRVANA']],
+  [ChainId.MAINNET, ['INFURA', 'QUIKNODE', 'NIRVANA', 'ALCHEMY']],
 ])
 
 function getProviderNameForChain(chainId: ChainId): string[] {

--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -49,8 +49,8 @@
   },
   {
     "chainId": 1,
-    "useMultiProviderProb": 1,
-    "providerInitialWeights": [1, 1, 1, 1],
+    "useMultiProviderProb": 0.01,
+    "providerInitialWeights": [1, 0, 0, 0],
     "providerUrls": ["INFURA_1", "QUICKNODE_1", "NIRVANA_1", "ALCHEMY_1"]
   }
 ]

--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -46,5 +46,11 @@
     "useMultiProviderProb": 0.01,
     "providerInitialWeights": [1, 0, 0],
     "providerUrls": ["QUICKNODE_8453", "ALCHEMY_8453", "NIRVANA_8453"]
+  },
+  {
+    "chainId": 1,
+    "useMultiProviderProb": 1,
+    "providerInitialWeights": [1, 1, 1, 1],
+    "providerUrls": ["INFURA_1", "QUICKNODE_1", "NIRVANA_1", "ALCHEMY_1"]
   }
 ]

--- a/lib/rpc/utils.ts
+++ b/lib/rpc/utils.ts
@@ -27,9 +27,6 @@ export function generateProviderUrl(key: string, value: string): string {
   const tokens = value.split(',')
   switch (key) {
     // Infura
-    case 'INFURA_1': {
-      return `https://mainnet.infura.io/v3/${tokens[0]}`
-    }
     case 'INFURA_43114': {
       return `https://avalanche-mainnet.infura.io/v3/${tokens[0]}`
     }
@@ -51,6 +48,9 @@ export function generateProviderUrl(key: string, value: string): string {
     case 'INFURA_42161': {
       return `https://arbitrum-mainnet.infura.io/v3/${tokens[0]}`
     }
+    case 'INFURA_1': {
+      return `https://mainnet.infura.io/v3/${tokens[0]}`
+    }
     // Nirvana
     case 'NIRVANA_43114': {
       return `https://avax.nirvanalabs.xyz/${tokens[0]}/ext/bc/C/rpc?apikey=${tokens[1]}`
@@ -63,6 +63,9 @@ export function generateProviderUrl(key: string, value: string): string {
     }
     case 'NIRVANA_42161': {
       return `https://arb.nirvanalabs.xyz/${tokens[0]}?apikey=${tokens[1]}`
+    }
+    case 'NIRVANA_1': {
+      return `https://ethereum.nirvanalabs.xyz/${tokens[0]}?apikey=${tokens[1]}`
     }
     // Quicknode
     case 'QUICKNODE_43114': {
@@ -86,6 +89,9 @@ export function generateProviderUrl(key: string, value: string): string {
     case 'QUICKNODE_42161': {
       return `https://${tokens[0]}.arbitrum-mainnet.quiknode.pro/${tokens[1]}`
     }
+    case 'QUICKNODE_1': {
+      return `https://${tokens[0]}.quiknode.pro/${tokens[1]}`
+    }
     // Alchemy
     case 'ALCHEMY_10': {
       return `https://opt-mainnet.g.alchemy.com/v2/${tokens[0]}`
@@ -101,6 +107,9 @@ export function generateProviderUrl(key: string, value: string): string {
     }
     case 'ALCHEMY_42161': {
       return `https://arb-mainnet.g.alchemy.com/v2/${tokens[0]}`
+    }
+    case 'ALCHEMY_1': {
+      return `https://eth-mainnet.g.alchemy.com/v2/${tokens[0]}`
     }
   }
   throw new Error(`Unknown provider-chainId pair: ${key}`)

--- a/test/mocha/unit/rpc/GlobalRpcProviders.test.ts
+++ b/test/mocha/unit/rpc/GlobalRpcProviders.test.ts
@@ -267,6 +267,10 @@ describe('GlobalRpcProviders', () => {
       QUICKNODE_42161: 'host19,key19',
       NIRVANA_42161: 'host20,key20',
       ALCHEMY_42161: 'key21',
+      INFURA_1: 'key22',
+      QUICKNODE_1: 'host23,key23',
+      NIRVANA_1: 'host24,key24',
+      ALCHEMY_1: 'key25',
     }
 
     const randStub = sandbox.stub(Math, 'random')
@@ -311,6 +315,17 @@ describe('GlobalRpcProviders', () => {
     expect(baseRpcProvider['providers'][1].url).equal('https://base-mainnet.infura.io/v3/key12')
     expect(baseRpcProvider['providers'][2].url).equal('https://base-mainnet.g.alchemy.com/v2/key14')
     expect(baseRpcProvider['providers'][3].url).equal('https://base.nirvanalabs.xyz/host15?apikey=key15')
+
+    const ethRpcProvider = GlobalRpcProviders.getGlobalUniRpcProviders(
+      log,
+      UNI_PROVIDER_TEST_CONFIG,
+      SINGLE_PROVIDER_TEST_CONFIG,
+      TEST_PROD_CONFIG
+    ).get(ChainId.MAINNET)!!
+    expect(ethRpcProvider['providers'][0].url).equal('https://mainnet.infura.io/v3/key22')
+    expect(ethRpcProvider['providers'][1].url).equal('https://host23.quiknode.pro/key23')
+    expect(ethRpcProvider['providers'][2].url).equal('https://ethereum.nirvanalabs.xyz/host24?apikey=key24')
+    expect(ethRpcProvider['providers'][3].url).equal('https://eth-mainnet.g.alchemy.com/v2/key25')
 
     cleanUp()
   })

--- a/test/mocha/unit/rpc/rpcProviderTestProdConfig.json
+++ b/test/mocha/unit/rpc/rpcProviderTestProdConfig.json
@@ -46,5 +46,11 @@
     "useMultiProviderProb": 1,
     "providerInitialWeights": [1, 0, 0, 0],
     "providerUrls": ["QUICKNODE_8453", "INFURA_8453", "ALCHEMY_8453", "NIRVANA_8453"]
+  },
+  {
+    "chainId": 1,
+    "useMultiProviderProb": 1,
+    "providerInitialWeights": [1, 0, 0, 0],
+    "providerUrls": ["INFURA_1", "QUICKNODE_1", "NIRVANA_1", "ALCHEMY_1"]
   }
 ]


### PR DESCRIPTION
Locally tested with config 
```json
  {
    "chainId": 1,
    "useMultiProviderProb": 1,
    "providerInitialWeights": [1, 1, 1, 1],
    "providerUrls": ["INFURA_1", "QUICKNODE_1", "NIRVANA_1", "ALCHEMY_1"]
  }
```
and made sure quote request, regardless of the provider selection, has no error returned.