### PR TITLE
[RPC Gateway] Launch to 10% Base

### DIFF
--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -43,7 +43,7 @@
   },
   {
     "chainId": 8453,
-    "useMultiProviderProb": 0.01,
+    "useMultiProviderProb": 0.1,
     "providerInitialWeights": [1, 0, 0],
     "providerUrls": ["QUICKNODE_8453", "ALCHEMY_8453", "NIRVANA_8453"]
   },


### PR DESCRIPTION
We deployed to 1% of Base https://github.com/Uniswap/routing-api/pull/574. Deployment finished at 10:47

Latency stays the same

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/10e60981-4ba7-4ada-9f4d-6c171f0580fd.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/bb07ab0d-d31f-435d-908a-1706262babf7.png)

Success rates and error rate not affected

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/be39ae0c-326e-4263-88ea-f8d001f52909.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/9a682a1b-ab26-4e17-8992-4fd79130a311.png)

We don’t see 5xx errors using RPC gateway code path.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/360ad2d2-4a41-457a-8b99-fb81dac5cf0b.png)

