### PR TITLE
[RPC Gateway] Launch to 10% Ethereum

### DIFF
--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -49,7 +49,7 @@
   },
   {
     "chainId": 1,
-    "useMultiProviderProb": 0.01,
+    "useMultiProviderProb": 0.1,
     "providerInitialWeights": [1, 0, 0, 0],
     "providerUrls": ["INFURA_1", "QUICKNODE_1", "NIRVANA_1", "ALCHEMY_1"]
   }


### PR DESCRIPTION
We deployed to 1% on Ethereum https://github.com/Uniswap/routing-api/pull/575. Deployment time is 11:32

Latency after deployment

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/9f719d52-faa9-472b-b167-fb7c98d78e33.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/82f87c60-e4de-4448-bd01-129e54149b4a.png)

Success rate and error rate

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/6ccfe147-a13a-4d7d-a7fe-faa032dbe890.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/615b13ea-a135-4f39-bc50-727b00c70f64.png)

Is the drop related to RPC gateway?
There’s a spike on total 5xx quote errors

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/0aed2100-2658-467a-9714-3e90339c6ad4.png)

But RPC gateway code path didn’t contribute much to it (2 out of 79)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/3ea98860-e09f-485c-a762-46a4135e61e5.png)

So we are confident to roll it out further to 10%
