### PR TITLE
[RPC Gateway] Launch to 10% of Blast

### DIFF
--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -55,7 +55,7 @@
   },
   {
     "chainId": 81457,
-    "useMultiProviderProb": 0.01,
+    "useMultiProviderProb": 0.1,
     "providerInitialWeights": [1, 0],
     "providerUrls": ["QUICKNODE_81457", "INFURA_81457"]
   }


### PR DESCRIPTION
Previously we deployed 1% to Blast https://github.com/Uniswap/routing-api/pull/578. Deployment finished around 14:30.

P99.9 latency looks the same as before

![Screenshot 2024-04-11 at 3.45.31 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/70bce41b-9bc6-482c-ae22-87d13e7cb14e.png)

Success rate has not changed

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/7802055b-38e2-49f1-8bda-6eca01d6e3c2.png)

No 5xx errors on RPC gateway code path

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/0a7f4012-4c00-4680-802b-cb2d8446f21d.png)

