### PR TITLE
feat: shadow sampling view-only quoter on mainnet

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -282,6 +282,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
           switch (chainId) {
             case ChainId.SEPOLIA:
             case ChainId.POLYGON_MUMBAI:
+            case ChainId.MAINNET:
               const currentQuoteProvider = new OnChainQuoteProvider(
                 chainId,
                 provider,
@@ -290,7 +291,8 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
                 BATCH_PARAMS[chainId],
                 GAS_ERROR_FAILURE_OVERRIDES[chainId],
                 SUCCESS_RATE_FAILURE_OVERRIDES[chainId],
-                BLOCK_NUMBER_CONFIGS[chainId]
+                BLOCK_NUMBER_CONFIGS[chainId],
+                '' // metric prefix is empty for current provider
               )
               const targetQuoteProvider = new OnChainQuoteProvider(
                 chainId,

--- a/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
+++ b/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
@@ -20,6 +20,14 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
         switchExactOutPercentage: 0.0,
         samplingExactOutPercentage: 100,
       } as QuoteProviderTrafficSwitchConfiguration
+    case ChainId.MAINNET:
+      // Total RPM for 'QuoteTotalCallsToProvider' is around 20k-30k (across all chains), so 0.1% means 20-30 RPM shadow sampling
+      return {
+        switchExactInPercentage: 0.0,
+        samplingExactInPercentage: 0.1,
+        switchExactOutPercentage: 0.0,
+        samplingExactOutPercentage: 0.1,
+      } as QuoteProviderTrafficSwitchConfiguration
     // If we accidentally switch a traffic, we have the protection to shadow sample only 0.1% of traffic
     default:
       return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@uniswap/permit2-sdk": "^1.2.0",
         "@uniswap/router-sdk": "^1.9.0",
         "@uniswap/sdk-core": "^4.2.0",
-        "@uniswap/smart-order-router": "3.27.0",
+        "@uniswap/smart-order-router": "3.27.1",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^1.8.1",
         "@uniswap/v2-sdk": "^4.3.0",
@@ -4738,9 +4738,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.27.0.tgz",
-      "integrity": "sha512-yKkv9HMroGnv8Q22Iyu5ApDfk9diB7AzfD7Z0oV1C67BxdvwRAm3krmdKSVvL0ewVHsaKTn1V7zaRio/N2xZyA==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.27.1.tgz",
+      "integrity": "sha512-sqjpAjRVInlX+pzWe93kYqtIYHprkm5lf/K6DM2mzR4snIsCCdtPc4trKq0s3GwTLNZm9ECfifkt0eh52HIpVg==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -28346,9 +28346,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.27.0.tgz",
-      "integrity": "sha512-yKkv9HMroGnv8Q22Iyu5ApDfk9diB7AzfD7Z0oV1C67BxdvwRAm3krmdKSVvL0ewVHsaKTn1V7zaRio/N2xZyA==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.27.1.tgz",
+      "integrity": "sha512-sqjpAjRVInlX+pzWe93kYqtIYHprkm5lf/K6DM2mzR4snIsCCdtPc4trKq0s3GwTLNZm9ECfifkt0eh52HIpVg==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@uniswap/permit2-sdk": "^1.2.0",
     "@uniswap/router-sdk": "^1.9.0",
     "@uniswap/sdk-core": "^4.2.0",
-    "@uniswap/smart-order-router": "3.27.0",
+    "@uniswap/smart-order-router": "3.27.1",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^1.8.1",
     "@uniswap/v2-sdk": "^4.3.0",


### PR DESCRIPTION
New view-only [quoter](https://etherscan.io/address/0x5e55c9e631fae526cd4b0526c4818d6e0a9ef0e3#code) was just deployed on mainnet. We are ready to shadow sample the new view-only quoter after the bug fix.

Sampling rate is 0.1%, since total quoter call to the RPC providers are between 20-30k/minute:
![Screenshot 2024-04-15 at 12 48 46 PM](https://github.com/Uniswap/routing-api/assets/91580504/5bd6077e-98af-4f5c-b6d7-eacfe117d3c8)

Related, from the screenshot, I noticed that the shadow quoter metrics prefix was evaluated to undefined, i.e. 'undefinedQuoteTotalCallsToProvider'. I will fix by populating metric prefix to empty string for the current quote provider.