### PR TITLE
Upgrade aws-cdk-lib to 2.137

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@uniswap/v3-periphery": "^1.4.4",
         "@uniswap/v3-sdk": "^3.11.0",
         "async-retry": "^1.3.1",
-        "aws-cdk-lib": "^2.85.0",
+        "aws-cdk-lib": "^2.137.0",
         "aws-embedded-metrics": "^2.0.6",
         "aws-sdk": "^2.927.0",
         "aws-xray-sdk": "^3.3.3",
@@ -123,19 +123,19 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.198",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.198.tgz",
-      "integrity": "sha512-RfOMXFMyZ5Ca8ytB3/vs6srFH5HVV4M2JS9Wsb/uXPEpSblEmuf31iGVfN6Q+xRoNPm8icsquCRQ79JBqH4yjA=="
+      "version": "2.2.202",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.202.tgz",
+      "integrity": "sha512-JqlF0D4+EVugnG5dAsNZMqhu3HW7ehOXm5SDMxMbXNDMdsF0pxtQKNHRl52z1U9igsHmaFpUgSGjbhAJ+0JONg=="
     },
     "node_modules/@aws-cdk/asset-kubectl-v20": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.2.tgz",
       "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg=="
     },
-    "node_modules/@aws-cdk/asset-node-proxy-agent-v5": {
-      "version": "2.0.165",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.165.tgz",
-      "integrity": "sha512-bsyLQD/vqXQcc9RDmlM1XqiFNO/yewgVFXmkMcQkndJbmE/jgYkzewwYGrBlfL725hGLQipXq19+jwWwdsXQqg=="
+    "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.3.tgz",
+      "integrity": "sha512-twhuEG+JPOYCYPx/xy5uH2+VUsIEhPTzDY0F1KuB+ocjWWB/KEDiOVL19nHvbPCB6fhWnkykXEMJ4HHcKvjtvg=="
     },
     "node_modules/@aws-sdk/service-error-classification": {
       "version": "3.186.0",
@@ -5269,7 +5269,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -5323,9 +5322,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.85.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.85.0.tgz",
-      "integrity": "sha512-u+ypK8XEMRH3tGRMSmcbPYxLet7xBdGIztUkMcPtlNJGhS/vxqh12yYkem3g3zzmHwdX8OPLSnlZ2sIuiIqp/g==",
+      "version": "2.137.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.137.0.tgz",
+      "integrity": "sha512-pD3AGdKBa8q1+vVWRabiDHuecVMlP8ERGPHc9Pb0dVlpbC/ODC6XXC1S0TAMsr0JI5Lh6pk4vL5cC+spsMeotw==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -5336,21 +5335,23 @@
         "punycode",
         "semver",
         "table",
-        "yaml"
+        "yaml",
+        "mime-types"
       ],
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.177",
-        "@aws-cdk/asset-kubectl-v20": "^2.1.1",
-        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.148",
+        "@aws-cdk/asset-awscli-v1": "^2.2.202",
+        "@aws-cdk/asset-kubectl-v20": "^2.1.2",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.0.1",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.1.1",
-        "ignore": "^5.2.4",
+        "fs-extra": "^11.2.0",
+        "ignore": "^5.3.1",
         "jsonschema": "^1.4.1",
+        "mime-types": "^2.1.35",
         "minimatch": "^3.1.2",
-        "punycode": "^2.3.0",
-        "semver": "^7.5.1",
-        "table": "^6.8.1",
+        "punycode": "^2.3.1",
+        "semver": "^7.6.0",
+        "table": "^6.8.2",
         "yaml": "1.10.2"
       },
       "engines": {
@@ -5464,7 +5465,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.1.1",
+      "version": "11.2.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5482,7 +5483,7 @@
       "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/ignore": {
-      "version": "5.2.4",
+      "version": "5.3.1",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5537,6 +5538,25 @@
         "node": ">=10"
       }
     },
+    "node_modules/aws-cdk-lib/node_modules/mime-db": {
+      "version": "1.52.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/mime-types": {
+      "version": "2.1.35",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/aws-cdk-lib/node_modules/minimatch": {
       "version": "3.1.2",
       "inBundle": true,
@@ -5549,7 +5569,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/punycode": {
-      "version": "2.3.0",
+      "version": "2.3.1",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5565,7 +5585,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.5.2",
+      "version": "7.6.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5619,7 +5639,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/table": {
-      "version": "6.8.1",
+      "version": "6.8.2",
       "inBundle": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -5634,7 +5654,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/universalify": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -18435,7 +18455,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
       "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
-      "dev": true,
       "engines": {
         "node": ">= 4"
       }
@@ -20182,8 +20201,7 @@
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
-      "dev": true
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw=="
     },
     "node_modules/log-symbols": {
       "version": "4.0.0",
@@ -23287,7 +23305,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
       "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "astral-regex": "^2.0.0",
@@ -23710,7 +23727,6 @@
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
       "integrity": "sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==",
-      "dev": true,
       "dependencies": {
         "ajv": "^8.0.1",
         "lodash.truncate": "^4.4.2",
@@ -24865,19 +24881,19 @@
       }
     },
     "@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.198",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.198.tgz",
-      "integrity": "sha512-RfOMXFMyZ5Ca8ytB3/vs6srFH5HVV4M2JS9Wsb/uXPEpSblEmuf31iGVfN6Q+xRoNPm8icsquCRQ79JBqH4yjA=="
+      "version": "2.2.202",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.202.tgz",
+      "integrity": "sha512-JqlF0D4+EVugnG5dAsNZMqhu3HW7ehOXm5SDMxMbXNDMdsF0pxtQKNHRl52z1U9igsHmaFpUgSGjbhAJ+0JONg=="
     },
     "@aws-cdk/asset-kubectl-v20": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.2.tgz",
       "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg=="
     },
-    "@aws-cdk/asset-node-proxy-agent-v5": {
-      "version": "2.0.165",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.165.tgz",
-      "integrity": "sha512-bsyLQD/vqXQcc9RDmlM1XqiFNO/yewgVFXmkMcQkndJbmE/jgYkzewwYGrBlfL725hGLQipXq19+jwWwdsXQqg=="
+    "@aws-cdk/asset-node-proxy-agent-v6": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.3.tgz",
+      "integrity": "sha512-twhuEG+JPOYCYPx/xy5uH2+VUsIEhPTzDY0F1KuB+ocjWWB/KEDiOVL19nHvbPCB6fhWnkykXEMJ4HHcKvjtvg=="
     },
     "@aws-sdk/service-error-classification": {
       "version": "3.186.0",
@@ -28749,8 +28765,7 @@
     "astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-      "dev": true
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="
     },
     "async-hook-jl": {
       "version": "1.7.6",
@@ -28789,22 +28804,23 @@
       "integrity": "sha512-gsDXAS6XVc4Jt+7S92MPX6Noq69bdeXUPEaXd8dk3+yVr629LTDLxNt4j1ycBbrU+AStK2PhKIyNIM+xzWMVOQ=="
     },
     "aws-cdk-lib": {
-      "version": "2.85.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.85.0.tgz",
-      "integrity": "sha512-u+ypK8XEMRH3tGRMSmcbPYxLet7xBdGIztUkMcPtlNJGhS/vxqh12yYkem3g3zzmHwdX8OPLSnlZ2sIuiIqp/g==",
+      "version": "2.137.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.137.0.tgz",
+      "integrity": "sha512-pD3AGdKBa8q1+vVWRabiDHuecVMlP8ERGPHc9Pb0dVlpbC/ODC6XXC1S0TAMsr0JI5Lh6pk4vL5cC+spsMeotw==",
       "requires": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.177",
-        "@aws-cdk/asset-kubectl-v20": "^2.1.1",
-        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.148",
+        "@aws-cdk/asset-awscli-v1": "^2.2.202",
+        "@aws-cdk/asset-kubectl-v20": "^2.1.2",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.0.1",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.1.1",
-        "ignore": "^5.2.4",
+        "fs-extra": "^11.2.0",
+        "ignore": "^5.3.1",
         "jsonschema": "^1.4.1",
+        "mime-types": "^2.1.35",
         "minimatch": "^3.1.2",
-        "punycode": "^2.3.0",
-        "semver": "^7.5.1",
-        "table": "^6.8.1",
+        "punycode": "^2.3.1",
+        "semver": "^7.6.0",
+        "table": "^6.8.2",
         "yaml": "1.10.2"
       },
       "dependencies": {
@@ -28877,7 +28893,7 @@
           "bundled": true
         },
         "fs-extra": {
-          "version": "11.1.1",
+          "version": "11.2.0",
           "bundled": true,
           "requires": {
             "graceful-fs": "^4.2.0",
@@ -28890,7 +28906,7 @@
           "bundled": true
         },
         "ignore": {
-          "version": "5.2.4",
+          "version": "5.3.1",
           "bundled": true
         },
         "is-fullwidth-code-point": {
@@ -28924,6 +28940,17 @@
             "yallist": "^4.0.0"
           }
         },
+        "mime-db": {
+          "version": "1.52.0",
+          "bundled": true
+        },
+        "mime-types": {
+          "version": "2.1.35",
+          "bundled": true,
+          "requires": {
+            "mime-db": "1.52.0"
+          }
+        },
         "minimatch": {
           "version": "3.1.2",
           "bundled": true,
@@ -28932,7 +28959,7 @@
           }
         },
         "punycode": {
-          "version": "2.3.0",
+          "version": "2.3.1",
           "bundled": true
         },
         "require-from-string": {
@@ -28940,7 +28967,7 @@
           "bundled": true
         },
         "semver": {
-          "version": "7.5.2",
+          "version": "7.6.0",
           "bundled": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -28972,7 +28999,7 @@
           }
         },
         "table": {
-          "version": "6.8.1",
+          "version": "6.8.2",
           "bundled": true,
           "requires": {
             "ajv": "^8.0.1",
@@ -28983,7 +29010,7 @@
           }
         },
         "universalify": {
-          "version": "2.0.0",
+          "version": "2.0.1",
           "bundled": true
         },
         "uri-js": {
@@ -38810,8 +38837,7 @@
     "ignore": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
-      "dev": true
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ=="
     },
     "immutable": {
       "version": "4.1.0",
@@ -40123,8 +40149,7 @@
     "lodash.truncate": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
-      "dev": true
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw=="
     },
     "log-symbols": {
       "version": "4.0.0",
@@ -42427,7 +42452,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
       "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^4.0.0",
         "astral-regex": "^2.0.0",
@@ -42759,7 +42783,6 @@
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
       "integrity": "sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==",
-      "dev": true,
       "requires": {
         "ajv": "^8.0.1",
         "lodash.truncate": "^4.4.2",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@uniswap/v3-periphery": "^1.4.4",
     "@uniswap/v3-sdk": "^3.11.0",
     "async-retry": "^1.3.1",
-    "aws-cdk-lib": "^2.85.0",
+    "aws-cdk-lib": "^2.137.0",
     "aws-embedded-metrics": "^2.0.6",
     "aws-sdk": "^2.927.0",
     "aws-xray-sdk": "^3.3.3",


### PR DESCRIPTION
Upgrade `aws-cdk-lib` to latest version as we need the use [LambdaAction](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_cloudwatch_actions.LambdaAction.html) for allowing lambda to be directly invoked by Cloudwatch Alarms.