### PR TITLE
fix: both null quote comparison

### DIFF
--- a/lib/handlers/quote/provider-migration/v3/traffic-switch-on-chain-quote-provider.ts
+++ b/lib/handlers/quote/provider-migration/v3/traffic-switch-on-chain-quote-provider.ts
@@ -288,7 +288,7 @@ export class TrafficSwitchOnChainQuoteProvider implements IOnChainQuoteProvider 
         const currentQuote = currentQuotes[j]
         const targetQuote = targetQuotes[j]
 
-        if (!currentQuote.quote?.eq(targetQuote.quote ?? BigNumber.from(0))) {
+        if (!(currentQuote.quote ?? BigNumber.from(0)).eq(targetQuote.quote ?? BigNumber.from(0))) {
           log.error(
             {
               currentQuote: currentQuote.quote,


### PR DESCRIPTION
In quote comparison, I noticed that we can log the quotes from current quoter and view-only quoter to be mismatch, even if both return null:

![Screenshot 2024-04-15 at 3 18 50 PM](https://github.com/Uniswap/routing-api/assets/91580504/4b36e901-8915-49ac-85f8-13225315cc17)

This is because in quote [provider](https://github.com/Uniswap/routing-api/blob/main/lib/handlers/quote/provider-migration/v3/traffic-switch-on-chain-quote-provider.ts#L291), we only use null coalesce on the right side but not left side. Fix is to have null coalesce on the left side as well.