### PR TITLE
fix: missing quoter v2 contract address

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -35,7 +35,8 @@ import {
   TokenValidatorProvider,
   ITokenPropertiesProvider,
   IOnChainQuoteProvider,
-  NEW_QUOTER_V2_ADDRESSES, QUOTER_V2_ADDRESSES
+  NEW_QUOTER_V2_ADDRESSES,
+  QUOTER_V2_ADDRESSES,
 } from '@uniswap/smart-order-router'
 import { TokenList } from '@uniswap/token-lists'
 import { default as bunyan, default as Logger } from 'bunyan'

--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -35,7 +35,7 @@ import {
   TokenValidatorProvider,
   ITokenPropertiesProvider,
   IOnChainQuoteProvider,
-  NEW_QUOTER_V2_ADDRESSES,
+  NEW_QUOTER_V2_ADDRESSES, QUOTER_V2_ADDRESSES
 } from '@uniswap/smart-order-router'
 import { TokenList } from '@uniswap/token-lists'
 import { default as bunyan, default as Logger } from 'bunyan'
@@ -292,6 +292,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
                 GAS_ERROR_FAILURE_OVERRIDES[chainId],
                 SUCCESS_RATE_FAILURE_OVERRIDES[chainId],
                 BLOCK_NUMBER_CONFIGS[chainId],
+                QUOTER_V2_ADDRESSES[chainId],
                 `ChainId_${chainId}_Quoter`
               )
               const targetQuoteProvider = new OnChainQuoteProvider(


### PR DESCRIPTION
From https://github.com/Uniswap/routing-api/pull/586, when I fixed the metrix prefix for the current quoter, I forgot to explicitly provide the current quoter v2 contract address https://github.com/Uniswap/routing-api/pull/586/files#diff-42941f26ebe3855c458055f7f2269f22a2f85265c24cb1c5ac8dd78d20e0a947R295. It resulted in the current quoter contract call failed, because it was trying to call contract address `ChainId_${chainId}_Quoter`, which is non-existent.

Local tests can pass again https://app.warp.dev/block/tvDpWU7EL4pwPiOC38uxUf