### PR TITLE
fix: new quoter comparison not deployed bug

### DIFF
--- a/lib/util/onChainQuoteProviderConfigs.ts
+++ b/lib/util/onChainQuoteProviderConfigs.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_RETRY_OPTIONS,
   DEFAULT_SUCCESS_RATE_FAILURE_OVERRIDES,
 } from '@uniswap/smart-order-router/build/main/util/onchainQuoteProviderConfigs'
+import { ChainId } from '@uniswap/sdk-core'
 
 export const RETRY_OPTIONS = {
   ...constructSameRetryOptionsMap(DEFAULT_RETRY_OPTIONS),
@@ -29,4 +30,8 @@ export const SUCCESS_RATE_FAILURE_OVERRIDES = {
 
 export const BLOCK_NUMBER_CONFIGS = {
   ...constructSameBlockNumberConfigsMap(DEFAULT_BLOCK_NUMBER_CONFIGS),
+}
+
+export const NEW_QUOTER_DEPLOY_BLOCK: { [chainId: number]: number } = {
+  [ChainId.MAINNET]: 19662663,
 }


### PR DESCRIPTION
I was investigating the case, where the current quoter will return the quote, meanwhile the new [view-only quoter](https://github.com/Uniswap/view-quoter-v3) does not:

![Screenshot 2024-04-16 at 4 16 05 PM](https://github.com/Uniswap/routing-api/assets/91580504/51ea307f-93cf-4bdd-8fcf-7d828067b42d)

After the investigation, I found it was due to the historical quote inquiry, i.e.g the quote request includes the block number before the [mainnet quoter](https://etherscan.io/address/0x5e55c9e631fae526cd4b0526c4818d6e0a9ef0e3#code) was deployed.

The fix is to ensure, if we are comparing the quote that's before the new quoter deploy block number, we skip the entire quote comparisons.