### PR TITLE
fix: current quoter out-of-gas quote comparison

### DIFF
--- a/lib/handlers/quote/provider-migration/v3/traffic-switch-on-chain-quote-provider.ts
+++ b/lib/handlers/quote/provider-migration/v3/traffic-switch-on-chain-quote-provider.ts
@@ -304,7 +304,7 @@ export class TrafficSwitchOnChainQuoteProvider implements IOnChainQuoteProvider 
               currentQuote: currentQuote,
               targetQuote: targetQuote,
             },
-            'Current and target quote providers returned different quotes'
+            `Current and target quote providers returned different quotes at block ${targetRoutesWithQuotes.blockNumber}`
           )
           metric.putMetric(
             `ON_CHAIN_QUOTE_PROVIDER_${tradeTypeMetric}_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MISMATCH_CHAIN_ID_${this.chainId}`,

--- a/lib/handlers/quote/provider-migration/v3/traffic-switch-on-chain-quote-provider.ts
+++ b/lib/handlers/quote/provider-migration/v3/traffic-switch-on-chain-quote-provider.ts
@@ -287,6 +287,9 @@ export class TrafficSwitchOnChainQuoteProvider implements IOnChainQuoteProvider 
         const targetQuote = targetQuotes[j]
 
         if (!(currentQuote.quote ?? BigNumber.from(0)).eq(targetQuote.quote ?? BigNumber.from(0))) {
+          // This is to deal with the case, where some quotes from the quoter multicalls failed,
+          // but still above the success rate threshold (https://github.com/Uniswap/smart-order-router/blob/main/src/providers/on-chain-quote-provider.ts#L496)
+          // so that the current quote failed, but the view-only quoter is more gas-efficient, and can return the quote.
           if (!currentQuote.quote && targetQuote.quote) {
             const gasEstimate = currentQuote.gasEstimate?.toNumber() ?? 0
             const gasLimit = currentQuote.gasLimit?.toNumber() ?? 0

--- a/lib/handlers/quote/provider-migration/v3/traffic-switch-on-chain-quote-provider.ts
+++ b/lib/handlers/quote/provider-migration/v3/traffic-switch-on-chain-quote-provider.ts
@@ -304,8 +304,6 @@ export class TrafficSwitchOnChainQuoteProvider implements IOnChainQuoteProvider 
             }
           }
 
-          if (currentQuote.gasEstimate?.toNumber() )
-
           log.error(
             {
               currentQuote: currentQuote.quote,

--- a/lib/handlers/quote/provider-migration/v3/traffic-switch-on-chain-quote-provider.ts
+++ b/lib/handlers/quote/provider-migration/v3/traffic-switch-on-chain-quote-provider.ts
@@ -295,7 +295,7 @@ export class TrafficSwitchOnChainQuoteProvider implements IOnChainQuoteProvider 
             const gasLimit = currentQuote.gasLimit?.toNumber() ?? 0
 
             if (gasLimit - gasEstimate <= LIKELY_OUT_OF_GAS_THRESHOLD[this.chainId]) {
-              continue;
+              continue
             }
           }
 

--- a/lib/handlers/quote/provider-migration/v3/traffic-switch-on-chain-quote-provider.ts
+++ b/lib/handlers/quote/provider-migration/v3/traffic-switch-on-chain-quote-provider.ts
@@ -292,22 +292,14 @@ export class TrafficSwitchOnChainQuoteProvider implements IOnChainQuoteProvider 
             const gasLimit = currentQuote.gasLimit?.toNumber() ?? 0
 
             if (gasLimit - gasEstimate <= LIKELY_OUT_OF_GAS_THRESHOLD[this.chainId]) {
-              log.error(
-                {
-                  currentQuote: currentQuote,
-                  targetQuote: targetQuote,
-                },
-                'Current quote provider did not return a quote, but target quote provider did. ' +
-                'This is likely due to current quote provider hitting gas limit for some multicalls but still above the success rate threshold.'
-              )
               continue;
             }
           }
 
           log.error(
             {
-              currentQuote: currentQuote.quote,
-              targetQuote: targetQuote.quote,
+              currentQuote: currentQuote,
+              targetQuote: targetQuote,
             },
             'Current and target quote providers returned different quotes'
           )

--- a/lib/util/onChainQuoteProviderConfigs.ts
+++ b/lib/util/onChainQuoteProviderConfigs.ts
@@ -35,3 +35,7 @@ export const BLOCK_NUMBER_CONFIGS = {
 export const NEW_QUOTER_DEPLOY_BLOCK: { [chainId: number]: number } = {
   [ChainId.MAINNET]: 19662663,
 }
+
+export const LIKELY_OUT_OF_GAS_THRESHOLD: { [chainId: number]: number } = {
+  [ChainId.MAINNET]: 17540 * 2, // 17540 is the single tick.cross cost on mainnet. We multiply by 2 to be safe.
+}

--- a/lib/util/onChainQuoteProviderConfigs.ts
+++ b/lib/util/onChainQuoteProviderConfigs.ts
@@ -32,10 +32,56 @@ export const BLOCK_NUMBER_CONFIGS = {
   ...constructSameBlockNumberConfigsMap(DEFAULT_BLOCK_NUMBER_CONFIGS),
 }
 
-export const NEW_QUOTER_DEPLOY_BLOCK: { [chainId: number]: number } = {
+// block -1 means it's never deployed
+export const NEW_QUOTER_DEPLOY_BLOCK: { [chainId in ChainId]: number } = {
   [ChainId.MAINNET]: 19662663,
+  [ChainId.GOERLI]: -1,
+  [ChainId.SEPOLIA]: 5677582,
+  [ChainId.OPTIMISM]: -1,
+  [ChainId.OPTIMISM_GOERLI]: -1,
+  [ChainId.OPTIMISM_SEPOLIA]: -1,
+  [ChainId.ARBITRUM_ONE]: -1,
+  [ChainId.ARBITRUM_GOERLI]: -1,
+  [ChainId.ARBITRUM_SEPOLIA]: -1,
+  [ChainId.POLYGON]: -1,
+  [ChainId.POLYGON_MUMBAI]: 48054046,
+  [ChainId.CELO]: -1,
+  [ChainId.CELO_ALFAJORES]: -1,
+  [ChainId.GNOSIS]: -1,
+  [ChainId.MOONBEAM]: -1,
+  [ChainId.BNB]: -1,
+  [ChainId.AVALANCHE]: -1,
+  [ChainId.BASE]: -1,
+  [ChainId.BASE_GOERLI]: -1,
+  [ChainId.ZORA]: -1,
+  [ChainId.ZORA_SEPOLIA]: -1,
+  [ChainId.ROOTSTOCK]: -1,
+  [ChainId.BLAST]: -1,
 }
 
-export const LIKELY_OUT_OF_GAS_THRESHOLD: { [chainId: number]: number } = {
+// 0 threshold means it's not deployed yet
+export const LIKELY_OUT_OF_GAS_THRESHOLD: { [chainId in ChainId]: number } = {
   [ChainId.MAINNET]: 17540 * 2, // 17540 is the single tick.cross cost on mainnet. We multiply by 2 to be safe.
+  [ChainId.GOERLI]: 0,
+  [ChainId.SEPOLIA]: 17540 * 2, // 17540 is the single tick.cross cost on mainnet. We multiply by 2 to be safe.
+  [ChainId.OPTIMISM]: 0,
+  [ChainId.OPTIMISM_GOERLI]: 0,
+  [ChainId.OPTIMISM_SEPOLIA]: 0,
+  [ChainId.ARBITRUM_ONE]: 0,
+  [ChainId.ARBITRUM_GOERLI]: 0,
+  [ChainId.ARBITRUM_SEPOLIA]: 0,
+  [ChainId.POLYGON]: 0,
+  [ChainId.POLYGON_MUMBAI]: 17540 * 2, // 17540 is the single tick.cross cost on mainnet. We multiply by 2 to be safe.
+  [ChainId.CELO]: 0,
+  [ChainId.CELO_ALFAJORES]: 0,
+  [ChainId.GNOSIS]: 0,
+  [ChainId.MOONBEAM]: 0,
+  [ChainId.BNB]: 0,
+  [ChainId.AVALANCHE]: 0,
+  [ChainId.BASE]: 0,
+  [ChainId.BASE_GOERLI]: 0,
+  [ChainId.ZORA]: 0,
+  [ChainId.ZORA_SEPOLIA]: 0,
+  [ChainId.ROOTSTOCK]: 0,
+  [ChainId.BLAST]: 0,
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@uniswap/permit2-sdk": "^1.2.0",
         "@uniswap/router-sdk": "^1.9.0",
         "@uniswap/sdk-core": "^4.2.0",
-        "@uniswap/smart-order-router": "3.28.0",
+        "@uniswap/smart-order-router": "3.28.1",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^1.8.1",
         "@uniswap/v2-sdk": "^4.3.0",
@@ -4738,9 +4738,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.28.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.28.0.tgz",
-      "integrity": "sha512-k/PGYZQjko/JTD0Q2MuM6HabAz//EPF9lFopcV5p8cBxXhH3VS0lGrULxomnLp5LxnxOMu0Ci9NIsY2goiBSAA==",
+      "version": "3.28.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.28.1.tgz",
+      "integrity": "sha512-LOluuaYIR9zBzoJd0H8mHuuq7CBvSpXkji6L8nUCTevQyK9q8QqPcUP+pwsgQIf3WkwyNU1d+WvUgI3l6fWTsQ==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -28367,9 +28367,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.28.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.28.0.tgz",
-      "integrity": "sha512-k/PGYZQjko/JTD0Q2MuM6HabAz//EPF9lFopcV5p8cBxXhH3VS0lGrULxomnLp5LxnxOMu0Ci9NIsY2goiBSAA==",
+      "version": "3.28.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.28.1.tgz",
+      "integrity": "sha512-LOluuaYIR9zBzoJd0H8mHuuq7CBvSpXkji6L8nUCTevQyK9q8QqPcUP+pwsgQIf3WkwyNU1d+WvUgI3l6fWTsQ==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@uniswap/permit2-sdk": "^1.2.0",
     "@uniswap/router-sdk": "^1.9.0",
     "@uniswap/sdk-core": "^4.2.0",
-    "@uniswap/smart-order-router": "3.28.0",
+    "@uniswap/smart-order-router": "3.28.1",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^1.8.1",
     "@uniswap/v2-sdk": "^4.3.0",

--- a/test/mocha/integ/handlers/quote/provider-migration/traffic-switch-quote-provider.test.ts
+++ b/test/mocha/integ/handlers/quote/provider-migration/traffic-switch-quote-provider.test.ts
@@ -1,12 +1,14 @@
 import sinon, { SinonSpy } from 'sinon'
 import { metric } from '@uniswap/smart-order-router/build/main/util/metric'
-import { MetricLoggerUnit, USDC_MAINNET, WRAPPED_NATIVE_CURRENCY } from '@uniswap/smart-order-router'
+import { MetricLoggerUnit, RouteWithQuotes, USDC_MAINNET, WRAPPED_NATIVE_CURRENCY } from '@uniswap/smart-order-router'
 import { TrafficSwitchOnChainQuoteProvider } from '../../../../../../lib/handlers/quote/provider-migration/v3/traffic-switch-on-chain-quote-provider'
 import { ChainId, CurrencyAmount } from '@uniswap/sdk-core'
 import { V3Route } from '@uniswap/smart-order-router/build/main/routers'
 import { USDC_WETH_LOW } from '../../../../../test-utils/mocked-data'
 import { getMockedOnChainQuoteProvider } from '../../../../../test-utils/mocked-dependencies'
 import { ProviderConfig } from '@uniswap/smart-order-router/build/main/providers/provider'
+import { AmountQuote } from '@uniswap/smart-order-router/build/main/providers/on-chain-quote-provider'
+import { BigNumber } from 'ethers'
 
 describe('TrafficSwitchOnChainQuoteProvider', () => {
   const amountIns = [CurrencyAmount.fromRawAmount(WRAPPED_NATIVE_CURRENCY[ChainId.MAINNET], '1000000000000000000')]
@@ -199,5 +201,63 @@ describe('TrafficSwitchOnChainQuoteProvider', () => {
     // This is the case we will have to invoke currentQuoteProvider.getQuotesManyExactIn twice, because of the runtime error during sampling
     sinon.assert.calledTwice(currentQuoteProvider.getQuotesManyExactOut)
     sinon.assert.threw(targetQuoteProvider.getQuotesManyExactOut)
+  })
+
+  it('sample exact in quotes and current quoter out of gas for the quote', async () => {
+    spy.withArgs(
+      `ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MATCH_CHAIN_ID_${ChainId.MAINNET}`,
+      1,
+      MetricLoggerUnit.None
+    )
+    spy.withArgs(
+      `ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MISMATCH_CHAIN_ID_${ChainId.MAINNET}`,
+      1,
+      MetricLoggerUnit.None
+    )
+
+    const currentQuoteProvider = getMockedOnChainQuoteProvider()
+    const targetQuoteProvider = getMockedOnChainQuoteProvider()
+    const quotes: AmountQuote[] = [
+      {
+        amount: CurrencyAmount.fromRawAmount(WRAPPED_NATIVE_CURRENCY[ChainId.MAINNET], '1000000000000000000'),
+        quote: BigNumber.from('1000000000000000000'),
+        sqrtPriceX96AfterList: [BigNumber.from(100)],
+        initializedTicksCrossedList: [1, 1, 1],
+        gasEstimate: BigNumber.from(999999),
+        gasLimit: BigNumber.from(1000000),
+      },
+    ]
+    const routesWithQuotes: RouteWithQuotes<V3Route>[] = [[new V3Route([USDC_WETH_LOW], WRAPPED_NATIVE_CURRENCY[ChainId.MAINNET], USDC_MAINNET), quotes]]
+
+    currentQuoteProvider.getQuotesManyExactIn.resolves(
+      {
+        routesWithQuotes: routesWithQuotes,
+        blockNumber: BigNumber.from(0),
+      }
+    )
+
+    const trafficSwitchProvider =
+      new (class SwitchTrafficSwitchOnChainQuoteProvider extends TrafficSwitchOnChainQuoteProvider {
+        override readonly SHOULD_SAMPLE_EXACT_IN_TRAFFIC = (_: ChainId) => true
+      })({
+        currentQuoteProvider: currentQuoteProvider,
+        targetQuoteProvider: targetQuoteProvider,
+        chainId: ChainId.MAINNET,
+      })
+
+    await trafficSwitchProvider.getQuotesManyExactIn(amountIns, routes, providerConfig)
+
+    // We will check neither match nor mismatch metric was logged
+    sinon.assert.neverCalledWith(
+      spy,
+      `ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MATCH_CHAIN_ID_${ChainId.MAINNET}`,
+      1,
+      MetricLoggerUnit.None)
+    sinon.assert.neverCalledWith(
+      spy,
+      `ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MISMATCH_CHAIN_ID_${ChainId.MAINNET}`,
+      1,
+      MetricLoggerUnit.None)
+    sinon.assert.calledOnce(currentQuoteProvider.getQuotesManyExactIn)
   })
 })

--- a/test/mocha/integ/handlers/quote/provider-migration/traffic-switch-quote-provider.test.ts
+++ b/test/mocha/integ/handlers/quote/provider-migration/traffic-switch-quote-provider.test.ts
@@ -227,14 +227,14 @@ describe('TrafficSwitchOnChainQuoteProvider', () => {
         gasLimit: BigNumber.from(1000000),
       },
     ]
-    const routesWithQuotes: RouteWithQuotes<V3Route>[] = [[new V3Route([USDC_WETH_LOW], WRAPPED_NATIVE_CURRENCY[ChainId.MAINNET], USDC_MAINNET), quotes]]
+    const routesWithQuotes: RouteWithQuotes<V3Route>[] = [
+      [new V3Route([USDC_WETH_LOW], WRAPPED_NATIVE_CURRENCY[ChainId.MAINNET], USDC_MAINNET), quotes],
+    ]
 
-    currentQuoteProvider.getQuotesManyExactIn.resolves(
-      {
-        routesWithQuotes: routesWithQuotes,
-        blockNumber: BigNumber.from(0),
-      }
-    )
+    currentQuoteProvider.getQuotesManyExactIn.resolves({
+      routesWithQuotes: routesWithQuotes,
+      blockNumber: BigNumber.from(0),
+    })
 
     const trafficSwitchProvider =
       new (class SwitchTrafficSwitchOnChainQuoteProvider extends TrafficSwitchOnChainQuoteProvider {
@@ -252,12 +252,14 @@ describe('TrafficSwitchOnChainQuoteProvider', () => {
       spy,
       `ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MATCH_CHAIN_ID_${ChainId.MAINNET}`,
       1,
-      MetricLoggerUnit.None)
+      MetricLoggerUnit.None
+    )
     sinon.assert.neverCalledWith(
       spy,
       `ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MISMATCH_CHAIN_ID_${ChainId.MAINNET}`,
       1,
-      MetricLoggerUnit.None)
+      MetricLoggerUnit.None
+    )
     sinon.assert.calledOnce(currentQuoteProvider.getQuotesManyExactIn)
   })
 })

--- a/test/test-utils/mocked-dependencies.ts
+++ b/test/test-utils/mocked-dependencies.ts
@@ -44,7 +44,8 @@ export function getMockedOnChainQuoteProvider(): sinon.SinonStubbedInstance<OnCh
       quote: BigNumber.from('1000000000000000000'),
       sqrtPriceX96AfterList: [BigNumber.from(100)],
       initializedTicksCrossedList: [1, 1, 1],
-      gasEstimate: BigNumber.from(100),
+      gasEstimate: BigNumber.from(10000),
+      gasLimit: BigNumber.from(1000000),
     },
   ]
   const routesWithQuotes: RouteWithQuotes<V3Route>[] = [[route, quotes]]


### PR DESCRIPTION
Once SOR returns per-quote-call gasUsed and gasLimit (https://github.com/Uniswap/smart-order-router/pull/534), then routing-api can calculate per-quote call failure is due to likely out-of-gas error. 

I was deciding between using gasUsed and gasLimit vs the encoded error from the return data, but the [simulation](https://www.tdly.co/shared/simulation/39de04bb-d794-43b0-aed2-8ea31957ca77) shows me that the encoded error from the return data might not be accurate. For this simulation, the error indicates [SLP](https://docs.uniswap.org/contracts/v3/reference/error-codes), which is not true:

 ```
cast 4byte-decode 0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000353504c0000000000000000000000000000000000000000000000000000000000
1) "Error(string)"
"SPL"
```

Now testing coverage added.