### PR TITLE
feat: shadow sampling view-only quoter on polygon

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -284,6 +284,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
             case ChainId.SEPOLIA:
             case ChainId.POLYGON_MUMBAI:
             case ChainId.MAINNET:
+            case ChainId.POLYGON:
               const currentQuoteProvider = new OnChainQuoteProvider(
                 chainId,
                 provider,

--- a/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
+++ b/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
@@ -28,6 +28,15 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
         switchExactOutPercentage: 0.0,
         samplingExactOutPercentage: 0.1,
       } as QuoteProviderTrafficSwitchConfiguration
+    case ChainId.POLYGON:
+      // Total RPM for 'QuoteTotalCallsToProvider' is around 20k-30k (across all chains), so 0.1% means 20-30 RPM shadow sampling
+      return {
+        switchExactInPercentage: 0.0,
+        samplingExactInPercentage: 0.5,
+        switchExactOutPercentage: 0.0,
+        samplingExactOutPercentage: 0.5,
+      } as QuoteProviderTrafficSwitchConfiguration
+
     // If we accidentally switch a traffic, we have the protection to shadow sample only 0.1% of traffic
     default:
       return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@uniswap/permit2-sdk": "^1.2.0",
         "@uniswap/router-sdk": "^1.9.0",
         "@uniswap/sdk-core": "^4.2.0",
-        "@uniswap/smart-order-router": "3.28.1",
+        "@uniswap/smart-order-router": "3.28.2",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^1.8.1",
         "@uniswap/v2-sdk": "^4.3.0",
@@ -4738,9 +4738,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.28.1",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.28.1.tgz",
-      "integrity": "sha512-LOluuaYIR9zBzoJd0H8mHuuq7CBvSpXkji6L8nUCTevQyK9q8QqPcUP+pwsgQIf3WkwyNU1d+WvUgI3l6fWTsQ==",
+      "version": "3.28.2",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.28.2.tgz",
+      "integrity": "sha512-8qRNIZ05/g+sdhBIAoejFvb16wVr9m24pSWPjPrDjIcADefMbjS1yMKumTiSJ4FFyy2TwSd/dT1QhIwwgQXuvA==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -28367,9 +28367,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.28.1",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.28.1.tgz",
-      "integrity": "sha512-LOluuaYIR9zBzoJd0H8mHuuq7CBvSpXkji6L8nUCTevQyK9q8QqPcUP+pwsgQIf3WkwyNU1d+WvUgI3l6fWTsQ==",
+      "version": "3.28.2",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.28.2.tgz",
+      "integrity": "sha512-8qRNIZ05/g+sdhBIAoejFvb16wVr9m24pSWPjPrDjIcADefMbjS1yMKumTiSJ4FFyy2TwSd/dT1QhIwwgQXuvA==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@uniswap/permit2-sdk": "^1.2.0",
     "@uniswap/router-sdk": "^1.9.0",
     "@uniswap/sdk-core": "^4.2.0",
-    "@uniswap/smart-order-router": "3.28.1",
+    "@uniswap/smart-order-router": "3.28.2",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^1.8.1",
     "@uniswap/v2-sdk": "^4.3.0",


### PR DESCRIPTION
New view-only [quoter](https://polygonscan.com/address/0x5e55c9e631fae526cd4b0526c4818d6e0a9ef0e3#code) was just deployed on polygon. We are ready to shadow sample the new view-only quoter after the bug fix.

Sampling rate is 0.5%, because the total RPC call volume between mainnet and polygon is about 5:1:
<img width="1417" alt="Screenshot 2024-04-17 at 1 12 15 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/410c9c18-96a5-4ba0-b232-a35c484106a6">
