### PR TITLE
fix: stop sampling on polygon mumbai

### DIFF
--- a/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
+++ b/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
@@ -11,8 +11,15 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
   chainId: ChainId
 ): QuoteProviderTrafficSwitchConfiguration => {
   switch (chainId) {
-    // Mumbai and Sepolia together have well below 50 RPM, so we can shadow sample 100% of traffic
+    // Mumbai was deprecated on April 13th. Do not sample at all
     case ChainId.POLYGON_MUMBAI:
+      return {
+        switchExactInPercentage: 0.0,
+        samplingExactInPercentage: 0,
+        switchExactOutPercentage: 0.0,
+        samplingExactOutPercentage: 0,
+      } as QuoteProviderTrafficSwitchConfiguration
+    // Sepolia together have well below 50 RPM, so we can shadow sample 100% of traffic
     case ChainId.SEPOLIA:
       return {
         switchExactInPercentage: 0.0,


### PR DESCRIPTION
Polygon mumbai stopped on April 13th https://polygon.technology/blog/polygon-pos-is-cooking-the-napoli-upgrade-means-better-ux-the-mumbai-testnet-takes-a-bow. We should no longer sample in Polygon Mumbai.

We might need to remove mumbai from the `SUPPORTED_CHAINS` all together.