### PR TITLE
feat: shadow sampling view-only quoter on base

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -285,6 +285,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
             case ChainId.POLYGON_MUMBAI:
             case ChainId.MAINNET:
             case ChainId.POLYGON:
+            case ChainId.BASE:
               const currentQuoteProvider = new OnChainQuoteProvider(
                 chainId,
                 provider,
@@ -315,7 +316,6 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
                 chainId: chainId,
               })
               break
-            case ChainId.BASE:
             case ChainId.OPTIMISM:
               quoteProvider = new OnChainQuoteProvider(
                 chainId,

--- a/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
+++ b/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
@@ -28,12 +28,12 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
         samplingExactOutPercentage: 100,
       } as QuoteProviderTrafficSwitchConfiguration
     case ChainId.BASE:
-      // Base traffic can be as high as Mainnet in spikes, so we sample at the same rate as mainnet
+      // Base RPC eth_call traffic is about double mainnet, so we can shadow sample 0.05% of traffic
       return {
         switchExactInPercentage: 0.0,
-        samplingExactInPercentage: 0.1,
+        samplingExactInPercentage: 0.05,
         switchExactOutPercentage: 0.0,
-        samplingExactOutPercentage: 0.1,
+        samplingExactOutPercentage: 0.05,
       } as QuoteProviderTrafficSwitchConfiguration
     case ChainId.MAINNET:
       // Total RPM for 'QuoteTotalCallsToProvider' is around 20k-30k (across all chains), so 0.1% means 20-30 RPM shadow sampling

--- a/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
+++ b/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
@@ -27,6 +27,14 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
         switchExactOutPercentage: 0.0,
         samplingExactOutPercentage: 100,
       } as QuoteProviderTrafficSwitchConfiguration
+    case ChainId.BASE:
+      // Base traffic can be as high as Mainnet in spikes, so we sample at the same rate as mainnet
+      return {
+        switchExactInPercentage: 0.0,
+        samplingExactInPercentage: 0.1,
+        switchExactOutPercentage: 0.0,
+        samplingExactOutPercentage: 0.1,
+      } as QuoteProviderTrafficSwitchConfiguration
     case ChainId.MAINNET:
       // Total RPM for 'QuoteTotalCallsToProvider' is around 20k-30k (across all chains), so 0.1% means 20-30 RPM shadow sampling
       return {

--- a/lib/util/onChainQuoteProviderConfigs.ts
+++ b/lib/util/onChainQuoteProviderConfigs.ts
@@ -11,25 +11,53 @@ import {
   DEFAULT_SUCCESS_RATE_FAILURE_OVERRIDES,
 } from '@uniswap/smart-order-router/build/main/util/onchainQuoteProviderConfigs'
 import { ChainId } from '@uniswap/sdk-core'
+import AsyncRetry from 'async-retry'
+import { BatchParams, BlockNumberConfig, FailureOverrides } from '@uniswap/smart-order-router'
 
-export const RETRY_OPTIONS = {
+export const RETRY_OPTIONS: { [chainId: number]: AsyncRetry.Options | undefined } = {
   ...constructSameRetryOptionsMap(DEFAULT_RETRY_OPTIONS),
+  [ChainId.BASE]: {
+    retries: 2,
+    minTimeout: 100,
+    maxTimeout: 1000,
+  },
 }
 
-export const BATCH_PARAMS = {
+export const BATCH_PARAMS: { [chainId: number]: BatchParams } = {
   ...constructSameBatchParamsMap(DEFAULT_BATCH_PARAMS),
+  [ChainId.BASE]: {
+    multicallChunk: 110,
+    gasLimitPerCall: 1_200_000,
+    quoteMinSuccessRate: 0.1,
+  },
 }
 
-export const GAS_ERROR_FAILURE_OVERRIDES = {
+export const GAS_ERROR_FAILURE_OVERRIDES: { [chainId: number]: FailureOverrides } = {
   ...constructSameGasErrorFailureOverridesMap(DEFAULT_GAS_ERROR_FAILURE_OVERRIDES),
+  [ChainId.BASE]: {
+    gasLimitOverride: 3_000_000,
+    multicallChunk: 45,
+  },
 }
 
-export const SUCCESS_RATE_FAILURE_OVERRIDES = {
+export const SUCCESS_RATE_FAILURE_OVERRIDES: { [chainId: number]: FailureOverrides } = {
   ...constructSameSuccessRateFailureOverridesMap(DEFAULT_SUCCESS_RATE_FAILURE_OVERRIDES),
+  [ChainId.BASE]: {
+    gasLimitOverride: 3_000_000,
+    multicallChunk: 45,
+  },
 }
 
-export const BLOCK_NUMBER_CONFIGS = {
+export const BLOCK_NUMBER_CONFIGS: { [chainId: number]: BlockNumberConfig } = {
   ...constructSameBlockNumberConfigsMap(DEFAULT_BLOCK_NUMBER_CONFIGS),
+  [ChainId.BASE]: {
+    baseBlockOffset: -25,
+    rollback: {
+      enabled: true,
+      attemptsBeforeRollback: 1,
+      rollbackBlockOffset: -20,
+    },
+  },
 }
 
 // block -1 means it's never deployed
@@ -51,7 +79,7 @@ export const NEW_QUOTER_DEPLOY_BLOCK: { [chainId in ChainId]: number } = {
   [ChainId.MOONBEAM]: -1,
   [ChainId.BNB]: -1,
   [ChainId.AVALANCHE]: -1,
-  [ChainId.BASE]: -1,
+  [ChainId.BASE]: 13311537,
   [ChainId.BASE_GOERLI]: -1,
   [ChainId.ZORA]: -1,
   [ChainId.ZORA_SEPOLIA]: -1,
@@ -78,7 +106,7 @@ export const LIKELY_OUT_OF_GAS_THRESHOLD: { [chainId in ChainId]: number } = {
   [ChainId.MOONBEAM]: 0,
   [ChainId.BNB]: 0,
   [ChainId.AVALANCHE]: 0,
-  [ChainId.BASE]: 0,
+  [ChainId.BASE]: 17540 * 2, // 17540 is the single tick.cross cost on polygon. We multiply by 2 to be safe
   [ChainId.BASE_GOERLI]: 0,
   [ChainId.ZORA]: 0,
   [ChainId.ZORA_SEPOLIA]: 0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@uniswap/permit2-sdk": "^1.2.0",
         "@uniswap/router-sdk": "^1.9.0",
         "@uniswap/sdk-core": "^4.2.0",
-        "@uniswap/smart-order-router": "3.28.2",
+        "@uniswap/smart-order-router": "3.28.3",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^1.8.1",
         "@uniswap/v2-sdk": "^4.3.0",
@@ -4738,9 +4738,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.28.2",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.28.2.tgz",
-      "integrity": "sha512-8qRNIZ05/g+sdhBIAoejFvb16wVr9m24pSWPjPrDjIcADefMbjS1yMKumTiSJ4FFyy2TwSd/dT1QhIwwgQXuvA==",
+      "version": "3.28.3",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.28.3.tgz",
+      "integrity": "sha512-BEJ0JmdcmElt9UUu/wQeNSNEd3BPB0pi48BQp7ueSorUwcCZpawxesPB9M/K8MtI4bX7PbQw5nvs56EQNK9NYQ==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -28367,9 +28367,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.28.2",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.28.2.tgz",
-      "integrity": "sha512-8qRNIZ05/g+sdhBIAoejFvb16wVr9m24pSWPjPrDjIcADefMbjS1yMKumTiSJ4FFyy2TwSd/dT1QhIwwgQXuvA==",
+      "version": "3.28.3",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.28.3.tgz",
+      "integrity": "sha512-BEJ0JmdcmElt9UUu/wQeNSNEd3BPB0pi48BQp7ueSorUwcCZpawxesPB9M/K8MtI4bX7PbQw5nvs56EQNK9NYQ==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@uniswap/permit2-sdk": "^1.2.0",
     "@uniswap/router-sdk": "^1.9.0",
     "@uniswap/sdk-core": "^4.2.0",
-    "@uniswap/smart-order-router": "3.28.2",
+    "@uniswap/smart-order-router": "3.28.3",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^1.8.1",
     "@uniswap/v2-sdk": "^4.3.0",


### PR DESCRIPTION
Sample quote on Mainnet and Polygon shows that the accuracy is at 100%:
![Screenshot 2024-04-18 at 9 43 15 AM](https://github.com/Uniswap/routing-api/assets/91580504/3056bb3e-fa3c-4f2c-bb4a-0ce8923a62ad)

This is positive, and gives us confidence to sample quote more. We can either increase the existing chain traffic or deploy to new chain with small shadow sampling rate. Shadow sampling on new chain makes more sense, because if the new view-only quoter were to have bug, at this point, it's easier to discover the bug on a new chain, rather than keep sampling on the current chains.

New view-only [quoter](https://basescan.org/address/0xf0c802dcb0cf1c4f7b953756b49d940eed190221#code) was just deployed on base. We will sample base at half of the mainnet rate, because eth_call call is doubled at base than mainnet:
![Screenshot 2024-04-18 at 9 46 34 AM](https://github.com/Uniswap/routing-api/assets/91580504/2b95ed56-8143-49c7-9ecc-31843adefc5f)
