### PR TITLE
fix: when protocols is undefined throw error, otherwise query empty array

### DIFF
--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -240,7 +240,7 @@ export class QuoteHandler extends APIGLambdaHandler<
       forceCrossProtocol
     )
 
-    if (protocols.length === 0) {
+    if (protocols === undefined) {
       return {
         statusCode: 400,
         errorCode: 'INVALID_PROTOCOL',
@@ -630,7 +630,7 @@ export class QuoteHandler extends APIGLambdaHandler<
     requestSource: string,
     appVersion: string | undefined,
     forceCrossProtocol: boolean | undefined
-  ): Protocol[] {
+  ): Protocol[] | undefined {
     const isMobileRequest = ['uniswap-ios', 'uniswap-android'].includes(requestSource)
     // We will exclude V2 if isMobile and the appVersion is not present or is lower than 1.24
     const semverAppVersion = semver.coerce(appVersion)
@@ -656,7 +656,7 @@ export class QuoteHandler extends APIGLambdaHandler<
             }
             break
           default:
-            return []
+            return undefined;
         }
       }
 

--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -656,7 +656,7 @@ export class QuoteHandler extends APIGLambdaHandler<
             }
             break
           default:
-            return undefined;
+            return undefined
         }
       }
 

--- a/test/jest/unit/handlers/quote.test.ts
+++ b/test/jest/unit/handlers/quote.test.ts
@@ -43,7 +43,7 @@ describe('QuoteHandler', () => {
     it('returns undefined when a requested protocol is invalid', () => {
       expect(
         QuoteHandler.protocolsFromRequest(ChainId.BASE, ['v2', 'v3', 'mixed', 'miguel'], '', undefined, undefined)
-      ).toBeUndefined();
+      ).toBeUndefined()
     })
 
     describe('for mobile request', () => {

--- a/test/jest/unit/handlers/quote.test.ts
+++ b/test/jest/unit/handlers/quote.test.ts
@@ -40,10 +40,10 @@ describe('QuoteHandler', () => {
       ])
     })
 
-    it('returns empty when a requested protocol is invalid', () => {
+    it('returns undefined when a requested protocol is invalid', () => {
       expect(
         QuoteHandler.protocolsFromRequest(ChainId.BASE, ['v2', 'v3', 'mixed', 'miguel'], '', undefined, undefined)
-      ).toEqual([])
+      ).toBeUndefined();
     })
 
     describe('for mobile request', () => {


### PR DESCRIPTION
ForceCrossProtocol flag would keep an empty array of protocols, and it would query alpha router using that empty array. SOR will then determine the protocol that it must request.

I accidentally tarted throwing 400s on this case since I wrongly assumed that an empty array of protocols was a failure case