### PR TITLE
fix: arbitrum deploy block for view-only quoter

### DIFF
--- a/lib/util/onChainQuoteProviderConfigs.ts
+++ b/lib/util/onChainQuoteProviderConfigs.ts
@@ -94,7 +94,8 @@ export const NEW_QUOTER_DEPLOY_BLOCK: { [chainId in ChainId]: number } = {
   [ChainId.OPTIMISM]: -1,
   [ChainId.OPTIMISM_GOERLI]: -1,
   [ChainId.OPTIMISM_SEPOLIA]: -1,
-  [ChainId.ARBITRUM_ONE]: 202182926,
+  // Arbitrum is special, it's using L1-ish block number (see https://docs.arbitrum.io/build-decentralized-apps/arbitrum-vs-ethereum/block-numbers-and-time)
+  [ChainId.ARBITRUM_ONE]: 19680034,
   [ChainId.ARBITRUM_GOERLI]: -1,
   [ChainId.ARBITRUM_SEPOLIA]: -1,
   [ChainId.POLYGON]: 55938282,


### PR DESCRIPTION
After shadow sampling in Arbitrum, I don't see a single match or mismatch quote on Arbitrum:

![Screenshot 2024-04-18 at 4 35 33 PM](https://github.com/Uniswap/routing-api/assets/91580504/21c9a0e1-c0a6-4c9d-97a7-b0e2695d8a4c)

![Screenshot 2024-04-18 at 4 35 40 PM](https://github.com/Uniswap/routing-api/assets/91580504/a0ef3798-2894-4a2d-90b1-ace84c1fcaa5)

But we have sampling traffic to Arbitrum:
![Screenshot 2024-04-18 at 4 35 11 PM](https://github.com/Uniswap/routing-api/assets/91580504/ae6edb2f-3b2c-45ef-87e8-989cdf42bed8)

This tells me the within the [compareQuotes](https://github.com/Uniswap/routing-api/blob/main/lib/handlers/quote/provider-migration/v3/traffic-switch-on-chain-quote-provider.ts#L224), it probably stopped because of the deploy block cutoff. I tried with my local routing-api, and I saw that the multicall returned the block number seemingly from L1, not from Arbitrum L2:

![Screenshot 2024-04-18 at 4 33 23 PM](https://github.com/Uniswap/routing-api/assets/91580504/9140285d-bd8f-409c-afa3-edaf3bec7b4e)

Then I checked Arbitrum [doc](https://docs.arbitrum.io/build-decentralized-apps/arbitrum-vs-ethereum/block-numbers-and-time) to see:

> // some Arbitrum contract:
> block.number // => returns L1 block number ("ish")

This is the case for us, because we get the block number from [multicall](https://github.com/Uniswap/v3-periphery/blob/main/contracts/lens/UniswapInterfaceMulticall.sol#L28).

The fix is to use the L1 block as cutoff time just for Arbitrum.