### PR TITLE
fix: update base view-only quoter address

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@uniswap/permit2-sdk": "^1.2.0",
         "@uniswap/router-sdk": "^1.9.0",
         "@uniswap/sdk-core": "^4.2.0",
-        "@uniswap/smart-order-router": "3.28.3",
+        "@uniswap/smart-order-router": "3.28.4",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^1.8.1",
         "@uniswap/v2-sdk": "^4.3.0",
@@ -4745,9 +4745,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.28.3",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.28.3.tgz",
-      "integrity": "sha512-BEJ0JmdcmElt9UUu/wQeNSNEd3BPB0pi48BQp7ueSorUwcCZpawxesPB9M/K8MtI4bX7PbQw5nvs56EQNK9NYQ==",
+      "version": "3.28.4",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.28.4.tgz",
+      "integrity": "sha512-HsoXfLmG1nwyr9i48jaCyk5RyUbkLEHCvdOD1l9dMNyxRmCnpSOdtRGgh6MqcSWrSHn5gfme6gWKwz+/ajbVyg==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -28379,9 +28379,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.28.3",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.28.3.tgz",
-      "integrity": "sha512-BEJ0JmdcmElt9UUu/wQeNSNEd3BPB0pi48BQp7ueSorUwcCZpawxesPB9M/K8MtI4bX7PbQw5nvs56EQNK9NYQ==",
+      "version": "3.28.4",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.28.4.tgz",
+      "integrity": "sha512-HsoXfLmG1nwyr9i48jaCyk5RyUbkLEHCvdOD1l9dMNyxRmCnpSOdtRGgh6MqcSWrSHn5gfme6gWKwz+/ajbVyg==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@uniswap/router-sdk": "^1.9.0",
     "@uniswap/sdk-core": "^4.2.0",
     "@types/semver": "^7.5.8",
-    "@uniswap/smart-order-router": "3.28.3",
+    "@uniswap/smart-order-router": "3.28.4",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^1.8.1",
     "@uniswap/v2-sdk": "^4.3.0",


### PR DESCRIPTION
Release https://github.com/Uniswap/smart-order-router/pull/542. 

I already tested on my local routing-api, and can see quote matches on Base:
![Screenshot 2024-04-19 at 7 29 46 AM](https://github.com/Uniswap/routing-api/assets/91580504/ae4132d1-9bfc-4bb8-ae9b-e10ddf1c56ce)
