### PR TITLE
feat: shadow sampling view-only quoter on bsc

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -288,6 +288,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
             case ChainId.BASE:
             case ChainId.ARBITRUM_ONE:
             case ChainId.OPTIMISM:
+            case ChainId.BNB:
               const currentQuoteProvider = new OnChainQuoteProvider(
                 chainId,
                 provider,

--- a/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
+++ b/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
@@ -67,6 +67,14 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
         switchExactOutPercentage: 0.0,
         samplingExactOutPercentage: 1,
       } as QuoteProviderTrafficSwitchConfiguration
+    case ChainId.BNB:
+      // BNB RPC eth_call traffic is about 1/10 of mainnet, so we can shadow sample 1% of traffic
+      return {
+        switchExactInPercentage: 0.0,
+        samplingExactInPercentage: 1,
+        switchExactOutPercentage: 0.0,
+        samplingExactOutPercentage: 1,
+      } as QuoteProviderTrafficSwitchConfiguration
     // If we accidentally switch a traffic, we have the protection to shadow sample only 0.1% of traffic
     default:
       return {

--- a/lib/util/onChainQuoteProviderConfigs.ts
+++ b/lib/util/onChainQuoteProviderConfigs.ts
@@ -130,7 +130,7 @@ export const NEW_QUOTER_DEPLOY_BLOCK: { [chainId in ChainId]: number } = {
   [ChainId.CELO_ALFAJORES]: -1,
   [ChainId.GNOSIS]: -1,
   [ChainId.MOONBEAM]: -1,
-  [ChainId.BNB]: -1,
+  [ChainId.BNB]: 37990148,
   [ChainId.AVALANCHE]: -1,
   [ChainId.BASE]: 13311537,
   [ChainId.BASE_GOERLI]: -1,
@@ -157,7 +157,7 @@ export const LIKELY_OUT_OF_GAS_THRESHOLD: { [chainId in ChainId]: number } = {
   [ChainId.CELO_ALFAJORES]: 0,
   [ChainId.GNOSIS]: 0,
   [ChainId.MOONBEAM]: 0,
-  [ChainId.BNB]: 0,
+  [ChainId.BNB]: 17540 * 2, // 17540 is the single tick.cross cost on polygon. We multiply by 2 to be safe
   [ChainId.AVALANCHE]: 0,
   [ChainId.BASE]: 17540 * 2, // 17540 is the single tick.cross cost on polygon. We multiply by 2 to be safe
   [ChainId.BASE_GOERLI]: 0,


### PR DESCRIPTION
BSC RPC call is about 1/10th of mainnet, so we sample at 1% on BSC:
![Screenshot 2024-04-19 at 12 36 31 AM](https://github.com/Uniswap/routing-api/assets/91580504/a6963885-89cd-476c-b459-4e5804cb1637)

New view-only [quoter](https://bscscan.com/address/0x5e55c9e631fae526cd4b0526c4818d6e0a9ef0e3#code) was just deployed on BSC.

I already verified on local routing-api, and can see quote matches:
![Screenshot 2024-04-19 at 12 45 49 AM](https://github.com/Uniswap/routing-api/assets/91580504/aee2e40e-fb0b-45de-9f02-5ca478e845e5)
