### PR TITLE
feat: shadow sampling view-only quoter on avax

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -290,6 +290,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
             case ChainId.OPTIMISM:
             case ChainId.BNB:
             case ChainId.CELO:
+            case ChainId.AVALANCHE:
               const currentQuoteProvider = new OnChainQuoteProvider(
                 chainId,
                 provider,

--- a/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
+++ b/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
@@ -83,6 +83,14 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
         switchExactOutPercentage: 0.0,
         samplingExactOutPercentage: 10,
       } as QuoteProviderTrafficSwitchConfiguration
+    case ChainId.AVALANCHE:
+      // Avalanche RPC eth_call traffic is about 1/100 of mainnet, so we can shadow sample 10% of traffic
+      return {
+        switchExactInPercentage: 0.0,
+        samplingExactInPercentage: 10,
+        switchExactOutPercentage: 0.0,
+        samplingExactOutPercentage: 10,
+      } as QuoteProviderTrafficSwitchConfiguration
     // If we accidentally switch a traffic, we have the protection to shadow sample only 0.1% of traffic
     default:
       return {

--- a/lib/util/onChainQuoteProviderConfigs.ts
+++ b/lib/util/onChainQuoteProviderConfigs.ts
@@ -149,7 +149,7 @@ export const NEW_QUOTER_DEPLOY_BLOCK: { [chainId in ChainId]: number } = {
   [ChainId.GNOSIS]: -1,
   [ChainId.MOONBEAM]: -1,
   [ChainId.BNB]: 37990148,
-  [ChainId.AVALANCHE]: -1,
+  [ChainId.AVALANCHE]: 44406304,
   [ChainId.BASE]: 13311537,
   [ChainId.BASE_GOERLI]: -1,
   [ChainId.ZORA]: -1,
@@ -175,8 +175,8 @@ export const LIKELY_OUT_OF_GAS_THRESHOLD: { [chainId in ChainId]: number } = {
   [ChainId.CELO_ALFAJORES]: 0,
   [ChainId.GNOSIS]: 0,
   [ChainId.MOONBEAM]: 0,
-  [ChainId.BNB]: 17540 * 2, // 17540 is the single tick.cross cost on polygon. We multiply by 2 to be safe
-  [ChainId.AVALANCHE]: 0,
+  [ChainId.BNB]: 17540 * 2, // 17540 is the single tick.cross cost on bnb. We multiply by 2 to be safe
+  [ChainId.AVALANCHE]: 17540 * 2, // 17540 is the single tick.cross cost on avax. We multiply by 2 to be safe
   [ChainId.BASE]: 17540 * 2, // 17540 is the single tick.cross cost on base. We multiply by 2 to be safe
   [ChainId.BASE_GOERLI]: 0,
   [ChainId.ZORA]: 0,


### PR DESCRIPTION
AVAX RPC call is about 1/100th of mainnet, so we sample at 10% on AVAX:
<img width="1217" alt="Screenshot 2024-04-19 at 11 16 44 AM" src="https://github.com/Uniswap/routing-api/assets/91580504/5197e01f-5167-43c2-a382-d9379dfc77a7">

New view-only [quoter](https://snowtrace.io/address/0x5e55C9e631FAE526cd4B0526C4818D6e0a9eF0e3/contract/43114/code) was just deployed on Avax.

I verified CELO and BSC quote accuracy sampled since this morning, and both are at 100%:
<img width="1215" alt="Screenshot 2024-04-19 at 11 15 30 AM" src="https://github.com/Uniswap/routing-api/assets/91580504/2463214c-d3f0-4d82-ac20-7f82f62352c4">

So we should move forward with AVAX.