### PR TITLE
feat: shadow sampling view-only quoter on blast

### DIFF
--- a/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
+++ b/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
@@ -67,6 +67,14 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
         switchExactOutPercentage: 0.0,
         samplingExactOutPercentage: 1,
       } as QuoteProviderTrafficSwitchConfiguration
+    case ChainId.BLAST:
+      // Blast RPC eth_call traffic is about 1/10 of mainnet, so we can shadow sample 1% of traffic
+      return {
+        switchExactInPercentage: 0.0,
+        samplingExactInPercentage: 1,
+        switchExactOutPercentage: 0.0,
+        samplingExactOutPercentage: 1,
+      } as QuoteProviderTrafficSwitchConfiguration
     case ChainId.BNB:
       // BNB RPC eth_call traffic is about 1/10 of mainnet, so we can shadow sample 1% of traffic
       return {

--- a/lib/util/onChainQuoteProviderConfigs.ts
+++ b/lib/util/onChainQuoteProviderConfigs.ts
@@ -36,6 +36,11 @@ export const RETRY_OPTIONS: { [chainId: number]: AsyncRetry.Options | undefined 
     minTimeout: 100,
     maxTimeout: 1000,
   },
+  [ChainId.BLAST]: {
+    retries: 2,
+    minTimeout: 100,
+    maxTimeout: 1000,
+  },
 }
 
 export const BATCH_PARAMS: { [chainId: number]: BatchParams } = {
@@ -60,6 +65,11 @@ export const BATCH_PARAMS: { [chainId: number]: BatchParams } = {
     gasLimitPerCall: 5_000_000,
     quoteMinSuccessRate: 0.1,
   },
+  [ChainId.BLAST]: {
+    multicallChunk: 80,
+    gasLimitPerCall: 1_200_000,
+    quoteMinSuccessRate: 0.1,
+  },
 }
 
 export const GAS_ERROR_FAILURE_OVERRIDES: { [chainId: number]: FailureOverrides } = {
@@ -80,6 +90,10 @@ export const GAS_ERROR_FAILURE_OVERRIDES: { [chainId: number]: FailureOverrides 
     gasLimitOverride: 5_000_000,
     multicallChunk: 5,
   },
+  [ChainId.BLAST]: {
+    gasLimitOverride: 3_000_000,
+    multicallChunk: 45,
+  },
 }
 
 export const SUCCESS_RATE_FAILURE_OVERRIDES: { [chainId: number]: FailureOverrides } = {
@@ -99,6 +113,10 @@ export const SUCCESS_RATE_FAILURE_OVERRIDES: { [chainId: number]: FailureOverrid
   [ChainId.CELO]: {
     gasLimitOverride: 6_250_000,
     multicallChunk: 4,
+  },
+  [ChainId.BLAST]: {
+    gasLimitOverride: 3_000_000,
+    multicallChunk: 45,
   },
 }
 
@@ -128,6 +146,14 @@ export const BLOCK_NUMBER_CONFIGS: { [chainId: number]: BlockNumberConfig } = {
       rollbackBlockOffset: -20,
     },
   },
+  [ChainId.BLAST]: {
+    baseBlockOffset: -10,
+    rollback: {
+      enabled: true,
+      attemptsBeforeRollback: 1,
+      rollbackBlockOffset: -10,
+    },
+  },
 }
 
 // block -1 means it's never deployed
@@ -155,7 +181,7 @@ export const NEW_QUOTER_DEPLOY_BLOCK: { [chainId in ChainId]: number } = {
   [ChainId.ZORA]: -1,
   [ChainId.ZORA_SEPOLIA]: -1,
   [ChainId.ROOTSTOCK]: -1,
-  [ChainId.BLAST]: -1,
+  [ChainId.BLAST]: 2370179,
 }
 
 // 0 threshold means it's not deployed yet
@@ -182,5 +208,5 @@ export const LIKELY_OUT_OF_GAS_THRESHOLD: { [chainId in ChainId]: number } = {
   [ChainId.ZORA]: 0,
   [ChainId.ZORA_SEPOLIA]: 0,
   [ChainId.ROOTSTOCK]: 0,
-  [ChainId.BLAST]: 0,
+  [ChainId.BLAST]: 17540 * 2, // 17540 is the single tick.cross cost on blast. We multiply by 2 to be safe
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@uniswap/permit2-sdk": "^1.2.0",
         "@uniswap/router-sdk": "^1.9.0",
         "@uniswap/sdk-core": "^4.2.0",
-        "@uniswap/smart-order-router": "3.28.4",
+        "@uniswap/smart-order-router": "3.28.5",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^1.8.1",
         "@uniswap/v2-sdk": "^4.3.0",
@@ -4745,9 +4745,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.28.4",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.28.4.tgz",
-      "integrity": "sha512-HsoXfLmG1nwyr9i48jaCyk5RyUbkLEHCvdOD1l9dMNyxRmCnpSOdtRGgh6MqcSWrSHn5gfme6gWKwz+/ajbVyg==",
+      "version": "3.28.5",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.28.5.tgz",
+      "integrity": "sha512-FhlZLXY0N4Oye9GtFrGTiZG3h8FQjqQ5cUB1kX0N4c5bcNJay64YgITbAACNJ/jqugzsG43KMjKN+GaQtpCSFw==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -28379,9 +28379,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.28.4",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.28.4.tgz",
-      "integrity": "sha512-HsoXfLmG1nwyr9i48jaCyk5RyUbkLEHCvdOD1l9dMNyxRmCnpSOdtRGgh6MqcSWrSHn5gfme6gWKwz+/ajbVyg==",
+      "version": "3.28.5",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.28.5.tgz",
+      "integrity": "sha512-FhlZLXY0N4Oye9GtFrGTiZG3h8FQjqQ5cUB1kX0N4c5bcNJay64YgITbAACNJ/jqugzsG43KMjKN+GaQtpCSFw==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@uniswap/router-sdk": "^1.9.0",
     "@uniswap/sdk-core": "^4.2.0",
     "@types/semver": "^7.5.8",
-    "@uniswap/smart-order-router": "3.28.4",
+    "@uniswap/smart-order-router": "3.28.5",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^1.8.1",
     "@uniswap/v2-sdk": "^4.3.0",


### PR DESCRIPTION
Blast RPC call is about 1/10th of mainnet, so we sample at 1% on Blast:
![Screenshot 2024-04-19 at 12 31 14 PM](https://github.com/Uniswap/routing-api/assets/91580504/af8f6b95-71ed-4039-bf09-370467048b80)

New view-only [quoter](https://blastscan.io/address/0x9d0f15f2cf58655fddcd1ee6129c547fdaed01b1#code) was just deployed on Blast.

I verified Avax quote accuracy sampled an hour ago at 100%:
![Screenshot 2024-04-19 at 12 32 56 PM](https://github.com/Uniswap/routing-api/assets/91580504/eb7075c4-9a25-448c-bcc8-5b011fa71fc3)

So we should move forward with BLAST.

(Note: We have to bump SOR version, explained in https://github.com/Uniswap/smart-order-router/pull/545)