### PR TITLE
fix: blast quote provider traffic switch

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -291,6 +291,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
             case ChainId.BNB:
             case ChainId.CELO:
             case ChainId.AVALANCHE:
+            case ChainId.BLAST:
               const currentQuoteProvider = new OnChainQuoteProvider(
                 chainId,
                 provider,


### PR DESCRIPTION
I forgot to make the change in injector-sor to enable the shadow sampling in blast https://github.com/Uniswap/routing-api/pull/611. As a result, that PR was a no-op to blast traffic. This PR is a quick fix to enable blast shadow sampling quote at 1%.