### PR TITLE
fix: improve quote provider logging

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -312,7 +312,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
                 SUCCESS_RATE_FAILURE_OVERRIDES[chainId],
                 BLOCK_NUMBER_CONFIGS[chainId],
                 (useMixedRouteQuoter: boolean) =>
-                  useMixedRouteQuoter ? MIXED_ROUTE_QUOTER_V1_ADDRESSES[chainId]! : NEW_QUOTER_V2_ADDRESSES[chainId]!,
+                  useMixedRouteQuoter ? MIXED_ROUTE_QUOTER_V1_ADDRESSES[chainId] : NEW_QUOTER_V2_ADDRESSES[chainId],
                 (chainId: ChainId, useMixedRouteQuoter: boolean) =>
                   useMixedRouteQuoter ? `ChainId_${chainId}_ShadowMixedQuoter` : `ChainId_${chainId}_ShadowV3Quoter`
               )

--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -35,8 +35,8 @@ import {
   TokenValidatorProvider,
   ITokenPropertiesProvider,
   IOnChainQuoteProvider,
+  MIXED_ROUTE_QUOTER_V1_ADDRESSES,
   NEW_QUOTER_V2_ADDRESSES,
-  QUOTER_V2_ADDRESSES,
 } from '@uniswap/smart-order-router'
 import { TokenList } from '@uniswap/token-lists'
 import { default as bunyan, default as Logger } from 'bunyan'
@@ -300,9 +300,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
                 BATCH_PARAMS[chainId],
                 GAS_ERROR_FAILURE_OVERRIDES[chainId],
                 SUCCESS_RATE_FAILURE_OVERRIDES[chainId],
-                BLOCK_NUMBER_CONFIGS[chainId],
-                QUOTER_V2_ADDRESSES[chainId],
-                `ChainId_${chainId}_Quoter`
+                BLOCK_NUMBER_CONFIGS[chainId]
               )
               const targetQuoteProvider = new OnChainQuoteProvider(
                 chainId,
@@ -313,8 +311,10 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
                 GAS_ERROR_FAILURE_OVERRIDES[chainId],
                 SUCCESS_RATE_FAILURE_OVERRIDES[chainId],
                 BLOCK_NUMBER_CONFIGS[chainId],
-                NEW_QUOTER_V2_ADDRESSES[chainId],
-                `ChainId_${chainId}_Shadow_Quoter`
+                (useMixedRouteQuoter: boolean) =>
+                  useMixedRouteQuoter ? MIXED_ROUTE_QUOTER_V1_ADDRESSES[chainId]! : NEW_QUOTER_V2_ADDRESSES[chainId]!,
+                (chainId: ChainId, useMixedRouteQuoter: boolean) =>
+                  useMixedRouteQuoter ? `ChainId_${chainId}_ShadowMixedQuoter` : `ChainId_${chainId}_ShadowV3Quoter`
               )
               quoteProvider = new TrafficSwitchOnChainQuoteProvider({
                 currentQuoteProvider: currentQuoteProvider,

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@uniswap/permit2-sdk": "^1.2.0",
         "@uniswap/router-sdk": "^1.9.0",
         "@uniswap/sdk-core": "^4.2.0",
-        "@uniswap/smart-order-router": "3.28.5",
+        "@uniswap/smart-order-router": "3.28.6",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^1.8.1",
         "@uniswap/v2-sdk": "^4.3.0",
@@ -4745,9 +4745,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.28.5",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.28.5.tgz",
-      "integrity": "sha512-FhlZLXY0N4Oye9GtFrGTiZG3h8FQjqQ5cUB1kX0N4c5bcNJay64YgITbAACNJ/jqugzsG43KMjKN+GaQtpCSFw==",
+      "version": "3.28.6",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.28.6.tgz",
+      "integrity": "sha512-VD8g+7pd4rnYcROgemZqYHZaIYSIqOaoyK75ZMgQjPO+cmQ8P0DYPC/+jX+ZYIAb4INr8JWH8T7tmoe4OaqpAQ==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -28379,9 +28379,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.28.5",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.28.5.tgz",
-      "integrity": "sha512-FhlZLXY0N4Oye9GtFrGTiZG3h8FQjqQ5cUB1kX0N4c5bcNJay64YgITbAACNJ/jqugzsG43KMjKN+GaQtpCSFw==",
+      "version": "3.28.6",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.28.6.tgz",
+      "integrity": "sha512-VD8g+7pd4rnYcROgemZqYHZaIYSIqOaoyK75ZMgQjPO+cmQ8P0DYPC/+jX+ZYIAb4INr8JWH8T7tmoe4OaqpAQ==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@uniswap/router-sdk": "^1.9.0",
     "@uniswap/sdk-core": "^4.2.0",
     "@types/semver": "^7.5.8",
-    "@uniswap/smart-order-router": "3.28.5",
+    "@uniswap/smart-order-router": "3.28.6",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^1.8.1",
     "@uniswap/v2-sdk": "^4.3.0",


### PR DESCRIPTION
We want to be able to different the quoter protocol version by explicitly adding the `Mixed` vs `V3` metrics wording. This is done primary through SOR https://github.com/Uniswap/smart-order-router/pull/547