### PR TITLE
feat: live switch celo quote for 1 percent

### DIFF
--- a/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
+++ b/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
@@ -86,9 +86,9 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
     case ChainId.CELO:
       // Celo RPC eth_call traffic is about 1/100 of mainnet, so we can shadow sample 10% of traffic
       return {
-        switchExactInPercentage: 0.0,
+        switchExactInPercentage: 1,
         samplingExactInPercentage: 10,
-        switchExactOutPercentage: 0.0,
+        switchExactOutPercentage: 1,
         samplingExactOutPercentage: 10,
       } as QuoteProviderTrafficSwitchConfiguration
     case ChainId.AVALANCHE:


### PR DESCRIPTION
We are ready to live switch to new view-only quoter. We will do it in the following order:

First batch:
- CELO: 1% -> 100%
- AVAX: 1% -> 100%
- BNB: 1% -> 100%

Second batch:
- Blast: 1% -> 10% -> 100%
- OP: 1% -> 10% -> 100%
- Polygon: 1% -> 10% -> 100%

Third batch:
- Arb: 1% -> 10% -> 100%
- Base: 1% -> 10% -> 100%
- Mainnet: 1% -> 10% -> 100%

We check the following metrics before we decide to live switch on CELO:
- Is the success rate on the CELO endpoint and on each CELO RPC call consistent?
CELO endpoint shows the consistently high success rate:
<img width="707" alt="Screenshot 2024-04-22 at 12 04 12 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/ffc7f9c2-04c4-4d4c-8416-6fe3a4bd65ff">
<img width="706" alt="Screenshot 2024-04-22 at 12 04 32 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/d63bd927-327d-40e4-9ab2-25bef695747c">

- Is the latency on the CELO endpoint consistent?
CELO latency does not change after the quote shadow sampling:
<img width="707" alt="Screenshot 2024-04-22 at 12 04 12 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/786b395a-e5c1-4097-ae1f-8fea5c747efd">

- Is the RPC call volume only slightly up after quote shadow sampling on CELO?
[CELO RPC call volume](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~'Uniswap~'ChainId_42220_V3QuoterQuoteLatency~'Service~'RoutingAPI~(visible~false))~(~'.~'ChainId_42220_ShadowV3QuoterQuoteLatency~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_42220_INFURA_call_SUCCESS~'.~'.)~(~'.~'RPC_GATEWAY_42220_QUIKNODE_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_42220_QUIKNODE_call_SUCCESS~'.~'.)~(~'.~'RPC_GATEWAY_42220_INFURA_call_FAILED~'.~'.~(visible~false)))~view~'timeSeries~stacked~false~region~'us-east-2~start~'-PT168H~end~'P0D~period~60~stat~'Sum)&query=~'*7bUniswap*2cService*7d*2042220*20RPC*20CALL) only shows minimum increase, which is important because when we live switch, we don't expect to see any further more RPC calls due to our optimized implementations:
<img width="1207" alt="Screenshot 2024-04-22 at 12 08 48 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/88da6b63-3c60-4c50-ace3-a7fb57cc3218">

- Is the Shadow quoter faster than the current quoter on CELO?
V3 shadow quoter shows consistently better [latency](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~'Uniswap~'ChainId_42220_V3QuoterQuoteLatency~'Service~'RoutingAPI)~(~'.~'ChainId_42220_ShadowV3QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_42220_QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_42220_Shadow_QuoterQuoteLatency~'.~'.))~view~'timeSeries~stacked~false~region~'us-east-2~start~'-PT168H~end~'P0D~period~60~stat~'Maximum)&query=~'*7bUniswap*2cService*7d*20Quoter*2042220*20Latency) then the current v3 quoter on CELO:
<img width="1218" alt="Screenshot 2024-04-22 at 12 01 16 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/024ffdf1-778a-428f-8370-5139a690102a">

- Is the quote accuracy always 100% between new v3 quoter and current v3 quoter?
The [accuracy comparison](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~(expression~'*28m7*2bm8*29*2f*28m7*2bm8*2bm9*2bm10*29*2a100~label~'Expression1~id~'e1~period~3600))~(~'Uniswap~'ChainId_42220_V3QuoterQuoteLatency~'Service~'RoutingAPI~(visible~false~id~'m1))~(~'.~'ChainId_42220_ShadowV3QuoterQuoteLatency~'.~'.~(visible~false~id~'m2))~(~'.~'RPC_GATEWAY_42220_INFURA_call_SUCCESS~'.~'.~(visible~false~id~'m3))~(~'.~'RPC_GATEWAY_42220_QUIKNODE_call_FAILED~'.~'.~(visible~false~id~'m4))~(~'.~'RPC_GATEWAY_42220_QUIKNODE_call_SUCCESS~'.~'.~(visible~false~id~'m5))~(~'.~'RPC_GATEWAY_42220_INFURA_call_FAILED~'.~'.~(visible~false~id~'m6))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MATCH_CHAIN_ID_42220~'.~'.~(id~'m7~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MATCH_CHAIN_ID_42220~'.~'.~(id~'m8~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MISMATCH_CHAIN_ID_42220~'.~'.~(id~'m9~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MISMATCH_CHAIN_ID_42220~'.~'.~(id~'m10~visible~false)))~view~'timeSeries~stacked~false~region~'us-east-2~start~'-PT168H~end~'P0D~period~3600~stat~'Sum)&query=~'*7bUniswap*2cService*7d*2042220) shows it's always at 100%:
<img width="1231" alt="Screenshot 2024-04-22 at 12 12 13 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/96bc4679-d3d8-4cfb-9f22-d5d30fc61b4a">
