### PR TITLE
feat: live switch avax quote for 1 percent

### DIFF
--- a/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
+++ b/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
@@ -94,9 +94,9 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
     case ChainId.AVALANCHE:
       // Avalanche RPC eth_call traffic is about 1/100 of mainnet, so we can shadow sample 10% of traffic
       return {
-        switchExactInPercentage: 0.0,
+        switchExactInPercentage: 1,
         samplingExactInPercentage: 10,
-        switchExactOutPercentage: 0.0,
+        switchExactOutPercentage: 1,
         samplingExactOutPercentage: 10,
       } as QuoteProviderTrafficSwitchConfiguration
     // If we accidentally switch a traffic, we have the protection to shadow sample only 0.1% of traffic


### PR DESCRIPTION
We check the following metrics before we decide to live switch on AVAX:

- Is the success rate on the AVAX endpoint and on each AVAX RPC call consistent?
AVAX endpoint shows the consistently high success rate:
![Screenshot 2024-04-22 at 1 07 36 PM](https://github.com/Uniswap/routing-api/assets/91580504/3edcd06f-d5e8-46dd-b003-4823f50d2580)

- Is the latency on the AVAX endpoint consistent?
AVAX latency does not change after the quote shadow sampling:
![Screenshot 2024-04-22 at 1 06 36 PM](https://github.com/Uniswap/routing-api/assets/91580504/73e9b499-af0c-4c93-87d6-d584069dac10)

- Is the RPC call volume only slightly up after quote shadow sampling on AVAX?
[AVAX RPC call volume](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~'Uniswap~'ChainId_42220_V3QuoterQuoteLatency~'Service~'RoutingAPI~(visible~false))~(~'.~'ChainId_42220_ShadowV3QuoterQuoteLatency~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_42220_INFURA_call_SUCCESS~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_42220_QUIKNODE_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_42220_QUIKNODE_call_SUCCESS~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_42220_INFURA_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_43114_QUIKNODE_call_FAILED~'.~'.)~(~'.~'RPC_GATEWAY_43114_INFURA_call_FAILED~'.~'.)~(~'.~'RPC_GATEWAY_43114_NIRVANA_call_FAILED~'.~'.)~(~'.~'RPC_GATEWAY_43114_NIRVANA_call_SUCCESS~'.~'.)~(~'.~'RPC_GATEWAY_43114_INFURA_call_SUCCESS~'.~'.)~(~'.~'RPC_GATEWAY_43114_QUIKNODE_call_SUCCESS~'.~'.))~view~'timeSeries~stacked~false~region~'us-east-2~start~'-PT168H~end~'P0D~period~900~stat~'Sum)&query=~'*7bUniswap*2cService*7d*20RPC*20CALL*2043114) only shows minimum increase, which is important because when we live switch, we don't expect to see any further more RPC calls due to our optimized implementations:
![Screenshot 2024-04-22 at 1 09 21 PM](https://github.com/Uniswap/routing-api/assets/91580504/2ea8377b-6394-4c7a-81e1-c2f133921492)

- Is the Shadow quoter faster than the current quoter on AVAX?
V3 shadow quoter shows consistently better [latency](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~'Uniswap~'ChainId_42220_V3QuoterQuoteLatency~'Service~'RoutingAPI)~(~'.~'ChainId_42220_ShadowV3QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_42220_QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_42220_Shadow_QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_43114_QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_43114_Shadow_QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_43114_V3QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_43114_ShadowV3QuoterQuoteLatency~'.~'.))~view~'timeSeries~stacked~false~region~'us-east-2~start~'-PT1H~end~'P0D~period~60~stat~'Maximum)&query=~'*7bUniswap*2cService*7d*20Quoter*20Latency*2043114) then the current v3 quoter on AVAX:
![Screenshot 2024-04-22 at 1 10 36 PM](https://github.com/Uniswap/routing-api/assets/91580504/9015b72b-4045-4e80-be6d-9b71d507913e)

- Is the quote accuracy always 100% between new v3 quoter and current v3 quoter?
The [accuracy comparison](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~(expression~'*28m7*2bm8*29*2f*28m7*2bm8*2bm9*2bm10*29*2a100~label~'Expression1~id~'e1~period~60))~(~'Uniswap~'ChainId_42220_V3QuoterQuoteLatency~'Service~'RoutingAPI~(visible~false~id~'m1))~(~'.~'ChainId_42220_ShadowV3QuoterQuoteLatency~'.~'.~(visible~false~id~'m2))~(~'.~'RPC_GATEWAY_42220_INFURA_call_SUCCESS~'.~'.~(visible~false~id~'m3))~(~'.~'RPC_GATEWAY_42220_QUIKNODE_call_FAILED~'.~'.~(visible~false~id~'m4))~(~'.~'RPC_GATEWAY_42220_QUIKNODE_call_SUCCESS~'.~'.~(visible~false~id~'m5))~(~'.~'RPC_GATEWAY_42220_INFURA_call_FAILED~'.~'.~(visible~false~id~'m6))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MISMATCH_CHAIN_ID_43114~'.~'.~(id~'m9~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MISMATCH_CHAIN_ID_43114~'.~'.~(id~'m10~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MATCH_CHAIN_ID_43114~'.~'.~(id~'m7~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MATCH_CHAIN_ID_43114~'.~'.~(id~'m8~visible~false)))~view~'timeSeries~stacked~false~region~'us-east-2~start~'-PT1H~end~'P0D~period~60~stat~'Sum)&query=~'*7bUniswap*2cService*7d*2043114*20MATCH) shows it's always at 100%:
![Screenshot 2024-04-22 at 1 13 25 PM](https://github.com/Uniswap/routing-api/assets/91580504/62804b65-c36c-4938-baff-5cc0237cac73)

