### PR TITLE
chore: add s3 latency metrics

### DIFF
--- a/lib/handlers/router-entities/aws-subgraph-provider.ts
+++ b/lib/handlers/router-entities/aws-subgraph-provider.ts
@@ -2,9 +2,9 @@ import { Protocol } from '@uniswap/router-sdk'
 import {
   IV2SubgraphProvider,
   IV3SubgraphProvider,
-  log,
+  log, metric, MetricLoggerUnit,
   V2SubgraphPool,
-  V3SubgraphPool,
+  V3SubgraphPool
 } from '@uniswap/smart-order-router'
 import { S3 } from 'aws-sdk'
 import { ChainId } from '@uniswap/sdk-core'
@@ -54,7 +54,13 @@ export const cachePoolsFromS3 = async <TSubgraphPool>(
 
   let result
   try {
+    const before = Date.now()
     result = await s3.getObject({ Key: key, Bucket: bucket }).promise()
+    const after = Date.now()
+
+    // Since we don't set the s3 request timeout, it's possible that the lambda timeout, because we even see latency metrics getting logged
+    // In case of increased lambda timeout due to cold start, we expect to see the sampling count of this latency metric to decrease
+    metric.putMetric(`S3GetObjectLatency_key_${key}`, after - before, MetricLoggerUnit.Milliseconds)
   } catch (err) {
     log.error({ bucket, key, err }, `Failed to get pools from S3 for ${protocol} on chain ${chainId}`)
     throw new Error(`Failed to get pools from S3 for ${protocol} on chain ${chainId}`)

--- a/lib/handlers/router-entities/aws-subgraph-provider.ts
+++ b/lib/handlers/router-entities/aws-subgraph-provider.ts
@@ -2,9 +2,11 @@ import { Protocol } from '@uniswap/router-sdk'
 import {
   IV2SubgraphProvider,
   IV3SubgraphProvider,
-  log, metric, MetricLoggerUnit,
+  log,
+  metric,
+  MetricLoggerUnit,
   V2SubgraphPool,
-  V3SubgraphPool
+  V3SubgraphPool,
 } from '@uniswap/smart-order-router'
 import { S3 } from 'aws-sdk'
 import { ChainId } from '@uniswap/sdk-core'


### PR DESCRIPTION
We are seeing increased lambda cold start, as well as provisioned concurrency spillovers. We suspect it's due to the S3 slow download due to the large pool file size:
![Screenshot 2024-04-22 at 1 26 12 PM](https://github.com/Uniswap/routing-api/assets/91580504/9867da99-71dd-42a7-8a5f-03dbd8f9bba9)

We are explicitly logging the per s3 bucket key downloading latency. We expect to see either very high latency, or it doesn't get logged due to lambda-level timeout.