### PR TITLE
feat: live switch bnb quote for 1 percent

### DIFF
--- a/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
+++ b/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
@@ -78,9 +78,9 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
     case ChainId.BNB:
       // BNB RPC eth_call traffic is about 1/10 of mainnet, so we can shadow sample 1% of traffic
       return {
-        switchExactInPercentage: 0.0,
+        switchExactInPercentage: 1,
         samplingExactInPercentage: 1,
-        switchExactOutPercentage: 0.0,
+        switchExactOutPercentage: 1,
         samplingExactOutPercentage: 1,
       }
     case ChainId.CELO:


### PR DESCRIPTION
We check the following metrics before we decide to live switch on BNB:

- Is the success rate on the BNB endpoint and on each BNB RPC call consistent?
BNB endpoint shows the consistently high success rate:
<img width="708" alt="Screenshot 2024-04-22 at 2 57 52 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/8cb67699-3aac-468e-a017-f2585a1fd530">

- Is the latency on the BNB endpoint consistent?
BNB latency does not change after the quote shadow sampling:
<img width="704" alt="Screenshot 2024-04-22 at 2 58 53 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/a0186939-e6a1-4a69-8455-0d106c74662d">

- Is the RPC call volume only slightly up after quote shadow sampling on BNB?
[BNB RPC call volume](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~'Uniswap~'ChainId_42220_V3QuoterQuoteLatency~'Service~'RoutingAPI~(visible~false))~(~'.~'ChainId_42220_ShadowV3QuoterQuoteLatency~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_42220_INFURA_call_SUCCESS~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_42220_QUIKNODE_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_42220_QUIKNODE_call_SUCCESS~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_42220_INFURA_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_43114_QUIKNODE_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_43114_INFURA_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_43114_NIRVANA_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_43114_NIRVANA_call_SUCCESS~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_43114_INFURA_call_SUCCESS~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_43114_QUIKNODE_call_SUCCESS~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_56_QUIKNODE_call_FAILED~'.~'.)~(~'.~'RPC_GATEWAY_56_QUIKNODE_call_SUCCESS~'.~'.))~view~'timeSeries~stacked~false~region~'us-east-2~start~'-PT168H~end~'P0D~period~900~stat~'Sum)&query=~'*7bUniswap*2cService*7d*20RPC*20CALL*2056) only shows minimum increase, which is important because when we live switch, we don't expect to see any further more RPC calls due to our optimized implementations:
<img width="1229" alt="Screenshot 2024-04-22 at 3 00 01 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/427befef-9760-4ab2-abb9-b51eb911edb2">

Is the Shadow quoter faster than the current quoter on BNB?
V3 shadow quoter shows consistently better [latency]() then the current v3 quoter on BNB:
<img width="1211" alt="Screenshot 2024-04-22 at 3 01 12 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/29fdc108-4ab3-4e27-8cdd-87f3b9a6e8e7">

Is the quote accuracy always 100% between new v3 quoter and current v3 quoter?
The [accuracy comparison](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~(expression~'*28m7*2bm8*29*2f*28m7*2bm8*2bm9*2bm10*29*2a100~label~'Expression1~id~'e1~period~60))~(~'Uniswap~'ChainId_42220_V3QuoterQuoteLatency~'Service~'RoutingAPI~(visible~false~id~'m1))~(~'.~'ChainId_42220_ShadowV3QuoterQuoteLatency~'.~'.~(visible~false~id~'m2))~(~'.~'RPC_GATEWAY_42220_INFURA_call_SUCCESS~'.~'.~(visible~false~id~'m3))~(~'.~'RPC_GATEWAY_42220_QUIKNODE_call_FAILED~'.~'.~(visible~false~id~'m4))~(~'.~'RPC_GATEWAY_42220_QUIKNODE_call_SUCCESS~'.~'.~(visible~false~id~'m5))~(~'.~'RPC_GATEWAY_42220_INFURA_call_FAILED~'.~'.~(visible~false~id~'m6))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MISMATCH_CHAIN_ID_56~'.~'.~(id~'m9~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MISMATCH_CHAIN_ID_56~'.~'.~(id~'m10~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MATCH_CHAIN_ID_56~'.~'.~(id~'m7~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MATCH_CHAIN_ID_56~'.~'.~(id~'m8~visible~false)))~view~'timeSeries~stacked~false~region~'us-east-2~start~'-PT1H~end~'P0D~period~60~stat~'Sum)&query=~'*7bUniswap*2cService*7d*20MATCH*2056) shows it's always at 100%:
<img width="1288" alt="Screenshot 2024-04-22 at 3 02 50 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/ca107a1b-584a-4ce0-bee2-427414c73950">
