### PR TITLE
feat: live switch celo quote for 100 percent

### DIFF
--- a/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
+++ b/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
@@ -86,9 +86,9 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
     case ChainId.CELO:
       // Celo RPC eth_call traffic is about 1/100 of mainnet, so we can shadow sample 10% of traffic
       return {
-        switchExactInPercentage: 1,
+        switchExactInPercentage: 100,
         samplingExactInPercentage: 10,
-        switchExactOutPercentage: 1,
+        switchExactOutPercentage: 100,
         samplingExactOutPercentage: 10,
       } as QuoteProviderTrafficSwitchConfiguration
     case ChainId.AVALANCHE:

--- a/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
+++ b/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
@@ -87,9 +87,9 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
       // Celo RPC eth_call traffic is about 1/100 of mainnet, so we can shadow sample 10% of traffic
       return {
         switchExactInPercentage: 100,
-        samplingExactInPercentage: 10,
+        samplingExactInPercentage: 0,
         switchExactOutPercentage: 100,
-        samplingExactOutPercentage: 10,
+        samplingExactOutPercentage: 0,
       } as QuoteProviderTrafficSwitchConfiguration
     case ChainId.AVALANCHE:
       // Avalanche RPC eth_call traffic is about 1/100 of mainnet, so we can shadow sample 10% of traffic


### PR DESCRIPTION
We check the following metrics before we decide to increase traffic switch on CELO:

- Is CELO still sampling at 10%, meanwhile live traffic switched at 1%?
Based on the [metrics](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~(expression~'*28m1*2bm2*29*2f*28m1*2bm2*2bm3*2bm4*29*2a100~label~'CELO*20sampling*20percent~id~'e1))~(~(expression~'*28m5*2bm6*29*2f*28m5*2bm6*2bm7*2bm8*29*2a100~label~'CELO*20traffic*20switch*20percent~id~'e2))~(~'Uniswap~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_SAMPLING_CHAIN_ID_42220~'Service~'RoutingAPI~(id~'m1~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_SAMPLING_CHAIN_ID_42220~'.~'.~(id~'m2~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_TOTAL_CHAIN_ID_42220~'.~'.~(id~'m3~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_TOTAL_CHAIN_ID_42220~'.~'.~(id~'m4~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_CHAIN_ID_42220~'.~'.~(id~'m7~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_CURRENT_CHAIN_ID_42220~'.~'.~(id~'m8~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_TARGET_CHAIN_ID_42220~'.~'.~(id~'m5~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_TARGET_CHAIN_ID_42220~'.~'.~(id~'m6~visible~false)))~view~'timeSeries~stacked~false~region~'us-east-2~period~60~stat~'Sum~start~'-PT12H~end~'P0D)&query=~'*7bUniswap*2cService*7d*20_TRAFFIC_TARGET_CHAIN_ID_), this appears to be the same:
<img width="1274" alt="Screenshot 2024-04-22 at 3 36 46 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/80644c18-b5f8-4c18-b6e9-f52dc9064d74">

- Is the success rate on the CELO endpoint and on each CELO RPC call consistent?
CELO endpoint shows the consistently high success rate:
<img width="719" alt="Screenshot 2024-04-22 at 3 39 03 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/65571137-9d83-4e59-942b-647668f899a9">

- Is the latency on the CELO endpoint consistent?
CELO latency does not change after live switch:
<img width="718" alt="Screenshot 2024-04-22 at 3 40 17 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/25112a4a-88a5-4732-b099-e8eec1f1b59e">

- Is the RPC call volume only slightly up after quote shadow sampling on CELO?
[CELO RPC call volume](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~'Uniswap~'ChainId_42220_V3QuoterQuoteLatency~'Service~'RoutingAPI~(visible~false))~(~'.~'ChainId_42220_ShadowV3QuoterQuoteLatency~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_42220_INFURA_call_SUCCESS~'.~'.)~(~'.~'RPC_GATEWAY_42220_QUIKNODE_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_42220_QUIKNODE_call_SUCCESS~'.~'.)~(~'.~'RPC_GATEWAY_42220_INFURA_call_FAILED~'.~'.~(visible~false)))~view~'timeSeries~stacked~false~region~'us-east-2~start~'-PT12H~end~'P0D~period~60~stat~'Sum)&query=~'*7bUniswap*2cService*7d*2042220*20RPC*20CALL) only shows minimum increase, which is important because when we live switch, we don't expect to see any further more RPC calls due to our optimized implementations:
<img width="1454" alt="Screenshot 2024-04-22 at 3 40 57 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/ee7f7dc8-d636-4a02-badf-46816bd0bd21">

- Is the Shadow quoter faster than the current quoter on CELO?
V3 shadow quoter shows consistently better [latency](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~'Uniswap~'ChainId_42220_V3QuoterQuoteLatency~'Service~'RoutingAPI)~(~'.~'ChainId_42220_ShadowV3QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_42220_QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_42220_Shadow_QuoterQuoteLatency~'.~'.))~view~'timeSeries~stacked~false~region~'us-east-2~start~'-PT3H~end~'P0D~period~60~stat~'Maximum)&query=~'*7bUniswap*2cService*7d*20Quoter*2042220*20Latency) then the current v3 quoter on CELO:
<img width="1454" alt="Screenshot 2024-04-22 at 3 42 48 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/c60b0b7f-2688-417b-bcf9-e4f6e369e899">

Is the quote accuracy always 100% between new v3 quoter and current v3 quoter?
The [accuracy comparison](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~(expression~'*28m7*2bm8*29*2f*28m7*2bm8*2bm9*2bm10*29*2a100~label~'Expression1~id~'e1~period~60))~(~'Uniswap~'ChainId_42220_V3QuoterQuoteLatency~'Service~'RoutingAPI~(visible~false~id~'m1))~(~'.~'ChainId_42220_ShadowV3QuoterQuoteLatency~'.~'.~(visible~false~id~'m2))~(~'.~'RPC_GATEWAY_42220_INFURA_call_SUCCESS~'.~'.~(visible~false~id~'m3))~(~'.~'RPC_GATEWAY_42220_QUIKNODE_call_FAILED~'.~'.~(visible~false~id~'m4))~(~'.~'RPC_GATEWAY_42220_QUIKNODE_call_SUCCESS~'.~'.~(visible~false~id~'m5))~(~'.~'RPC_GATEWAY_42220_INFURA_call_FAILED~'.~'.~(visible~false~id~'m6))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MATCH_CHAIN_ID_42220~'.~'.~(id~'m7~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MATCH_CHAIN_ID_42220~'.~'.~(id~'m8~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MISMATCH_CHAIN_ID_42220~'.~'.~(id~'m9~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MISMATCH_CHAIN_ID_42220~'.~'.~(id~'m10~visible~false)))~view~'timeSeries~stacked~false~region~'us-east-2~start~'-PT3H~end~'P0D~period~60~stat~'Sum)&query=~'*7bUniswap*2cService*7d*2042220) shows it's always at 100%:
<img width="1451" alt="Screenshot 2024-04-22 at 3 44 00 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/ef64a982-ca87-4e4f-b518-ea6aaf2ccc49">
