### PR TITLE
fix: activity id to chain id quote injector and lambda handler event

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -65,6 +65,7 @@ import {
   RETRY_OPTIONS,
   SUCCESS_RATE_FAILURE_OVERRIDES,
 } from '../util/onChainQuoteProviderConfigs'
+import { v4 } from 'uuid/index'
 
 export const SUPPORTED_CHAINS: ChainId[] = [
   ChainId.MAINNET,
@@ -120,6 +121,7 @@ export interface ContainerInjected {
   dependencies: {
     [chainId in ChainId]?: ContainerDependencies
   }
+  activityId?: string
 }
 
 export abstract class InjectorSOR<Router, QueryParams> extends Injector<
@@ -129,10 +131,12 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
   QueryParams
 > {
   public async buildContainerInjected(): Promise<ContainerInjected> {
+    const activityId = v4()
     const log: Logger = bunyan.createLogger({
       name: this.injectorName,
       serializers: bunyan.stdSerializers,
       level: bunyan.INFO,
+      activityId: activityId,
     })
     setGlobalLogger(log)
 
@@ -416,6 +420,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
 
       return {
         dependencies: dependenciesByChain,
+        activityId: activityId,
       }
     } catch (err) {
       log.fatal({ err }, `Fatal: Failed to build container`)

--- a/lib/handlers/quote/injector.ts
+++ b/lib/handlers/quote/injector.ts
@@ -29,6 +29,8 @@ export class QuoteHandlerInjector extends InjectorSOR<
     log: Logger,
     metricsLogger: MetricsLogger
   ): Promise<RequestInjected<IRouter<AlphaRouterConfig | LegacyRoutingConfig>>> {
+    const { dependencies, activityId } = containerInjected
+
     const requestId = context.awsRequestId
     const quoteId = requestId.substring(0, 5)
     // Sample 10% of all requests at the INFO log level for debugging purposes.
@@ -62,6 +64,7 @@ export class QuoteHandlerInjector extends InjectorSOR<
       type,
       algorithm,
       gasToken,
+      activityId: activityId,
     })
     setGlobalLogger(log)
 
@@ -73,8 +76,6 @@ export class QuoteHandlerInjector extends InjectorSOR<
     // Today API is restricted such that both tokens must be on the same chain.
     const chainId = tokenInChainId
     const chainIdEnum = ID_TO_CHAIN_ID(chainId)
-
-    const { dependencies } = containerInjected
 
     if (!dependencies[chainIdEnum]) {
       // Request validation should prevent reject unsupported chains with 4xx already, so this should not be possible.


### PR DESCRIPTION
During container injector, we instantiate a new global logger with [injector-sor](https://github.com/Uniswap/routing-api/blob/main/lib/handlers/injector-sor.ts#L132-L137), without request id, or any identifier that can identifier which request it's part of:

```
    const log: Logger = bunyan.createLogger({
      name: this.injectorName,
      serializers: bunyan.stdSerializers,
      level: bunyan.INFO,
    })
    setGlobalLogger(log)
```

The reason for this is because, [buildContainerInjected()](https://github.com/Uniswap/routing-api/blob/main/lib/handlers/injector-sor.ts#L131C16-L131C38) is called as part of  [QuoteHandlerInjector('quoteInjector').build()](https://github.com/Uniswap/routing-api/blob/main/lib/handlers/index.ts#L13), but we only start to get the request id from the lambda event within [new QuoteHandler('quote', quoteInjectorPromise)
](https://github.com/Uniswap/routing-api/blob/main/lib/handlers/index.ts#L14C18-L15C1), within [injector](https://github.com/Uniswap/routing-api/blob/e9d62b4bc4b2886fd9eccbe4cc6f94a4a494dfe8/lib/handlers/quote/injector.ts#L32):

```
  public async getRequestInjected(
    containerInjected: ContainerInjected,
    _requestBody: void,
    requestQueryParams: QuoteQueryParams,
    _event: APIGatewayProxyEvent,
    context: Context,
    log: Logger,
    metricsLogger: MetricsLogger
  ): Promise<RequestInjected<IRouter<AlphaRouterConfig | LegacyRoutingConfig>>> {
    const requestId = context.awsRequestId
  ...

log = log.child({
      serializers: bunyan.stdSerializers,
      level: logLevel,
      requestId,
      quoteId,
      tokenInAddress,
      chainId: tokenInChainId,
      tokenOutAddress,
      amount,
      type,
      algorithm,
      gasToken,
    })
    setGlobalLogger(log)
}
```

So this means we need to manually generate a new random identifier within injector-sor `activityId`, and pass into injector, so that we have the way to identify which request is this container injection from. In addition, because not every request needs the container injection, the activity id has to be optional. I verified in my local and can now see activityId popping up and tieing up the loggings within the same request:

![Screenshot 2024-04-22 at 4 55 27 PM](https://github.com/Uniswap/routing-api/assets/91580504/5ea781c3-3ff0-4be1-a82d-44ab8415a5b8)
![Screenshot 2024-04-22 at 4 55 35 PM](https://github.com/Uniswap/routing-api/assets/91580504/518893cc-ed67-4513-a025-a52d8b0c87f4)

I also tested non-cold start scenario, and can see there's no activity id, only request id:

![Screenshot 2024-04-22 at 5.04.40 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/eccd9a1d-d0c3-4e62-b4e7-48a1701bf5f3.png)

