### PR TITLE
chore: log pool parsing latency metrics

### DIFF
--- a/lib/handlers/router-entities/aws-subgraph-provider.ts
+++ b/lib/handlers/router-entities/aws-subgraph-provider.ts
@@ -76,7 +76,11 @@ export const cachePoolsFromS3 = async <TSubgraphPool>(
 
   const pools = JSON.parse(poolsBuffer.toString('utf-8')) as TSubgraphPool[]
 
+  const before = Date.now()
   log.info({ bucket, key }, `Got subgraph pools from S3 for protocol ${protocol} on ${chainId}. Num: ${pools.length}`)
+  const after = Date.now()
+
+  metric.putMetric(`S3GetObjectParseLatency_key_${key}`, after - before, MetricLoggerUnit.Milliseconds)
 
   POOL_CACHE.set<TSubgraphPool[]>(LOCAL_POOL_CACHE_KEY(chainId, protocol), pools)
 

--- a/lib/handlers/router-entities/aws-subgraph-provider.ts
+++ b/lib/handlers/router-entities/aws-subgraph-provider.ts
@@ -63,6 +63,7 @@ export const cachePoolsFromS3 = async <TSubgraphPool>(
     // Since we don't set the s3 request timeout, it's possible that the lambda timeout, because we even see latency metrics getting logged
     // In case of increased lambda timeout due to cold start, we expect to see the sampling count of this latency metric to decrease
     metric.putMetric(`S3GetObjectLatency_key_${key}`, after - before, MetricLoggerUnit.Milliseconds)
+    log.info({ bucket, key }, `Downloaded s3 object for ${protocol} on ${chainId} with latency ${after - before} milliseconds.`)
   } catch (err) {
     log.error({ bucket, key, err }, `Failed to get pools from S3 for ${protocol} on chain ${chainId}`)
     throw new Error(`Failed to get pools from S3 for ${protocol} on chain ${chainId}`)
@@ -74,11 +75,11 @@ export const cachePoolsFromS3 = async <TSubgraphPool>(
     throw new Error(`Could not get subgraph pool cache from S3 for protocol ${protocol} on chain ${chainId}`)
   }
 
-  const pools = JSON.parse(poolsBuffer.toString('utf-8')) as TSubgraphPool[]
-
   const before = Date.now()
-  log.info({ bucket, key }, `Got subgraph pools from S3 for protocol ${protocol} on ${chainId}. Num: ${pools.length}`)
+  const pools = JSON.parse(poolsBuffer.toString('utf-8')) as TSubgraphPool[]
   const after = Date.now()
+
+  log.info({ bucket, key }, `Got subgraph pools from S3 for protocol ${protocol} on ${chainId}. Num: ${pools.length} with latency ${after - before} milliseconds.`)
 
   metric.putMetric(`S3GetObjectParseLatency_key_${key}`, after - before, MetricLoggerUnit.Milliseconds)
 

--- a/lib/handlers/router-entities/aws-subgraph-provider.ts
+++ b/lib/handlers/router-entities/aws-subgraph-provider.ts
@@ -63,7 +63,10 @@ export const cachePoolsFromS3 = async <TSubgraphPool>(
     // Since we don't set the s3 request timeout, it's possible that the lambda timeout, because we even see latency metrics getting logged
     // In case of increased lambda timeout due to cold start, we expect to see the sampling count of this latency metric to decrease
     metric.putMetric(`S3GetObjectLatency_key_${key}`, after - before, MetricLoggerUnit.Milliseconds)
-    log.info({ bucket, key }, `Downloaded s3 object for ${protocol} on ${chainId} with latency ${after - before} milliseconds.`)
+    log.info(
+      { bucket, key },
+      `Downloaded s3 object for ${protocol} on ${chainId} with latency ${after - before} milliseconds.`
+    )
   } catch (err) {
     log.error({ bucket, key, err }, `Failed to get pools from S3 for ${protocol} on chain ${chainId}`)
     throw new Error(`Failed to get pools from S3 for ${protocol} on chain ${chainId}`)
@@ -79,7 +82,12 @@ export const cachePoolsFromS3 = async <TSubgraphPool>(
   const pools = JSON.parse(poolsBuffer.toString('utf-8')) as TSubgraphPool[]
   const after = Date.now()
 
-  log.info({ bucket, key }, `Got subgraph pools from S3 for protocol ${protocol} on ${chainId}. Num: ${pools.length} with latency ${after - before} milliseconds.`)
+  log.info(
+    { bucket, key },
+    `Got subgraph pools from S3 for protocol ${protocol} on ${chainId}. Num: ${pools.length} with latency ${
+      after - before
+    } milliseconds.`
+  )
 
   metric.putMetric(`S3GetObjectParseLatency_key_${key}`, after - before, MetricLoggerUnit.Milliseconds)
 


### PR DESCRIPTION
I want to make sure that the pool parsing in memory is not taking long, so logging that. And for each s3 object download and parsing, I also log the latency as part of the logging info, so that when we debug by activity id, we can see each s3 object download latency.