### PR TITLE
[RPC Gateway] Enable auto fallback and recovery on Sepolia

### DIFF
--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -26,8 +26,9 @@
   {
     "chainId": 11155111,
     "useMultiProviderProb": 1,
-    "providerInitialWeights": [1, 1],
-    "providerUrls": ["INFURA_11155111", "ALCHEMY_11155111"]
+    "providerInitialWeights": [1, -1],
+    "providerUrls": ["ALCHEMY_11155111", "INFURA_11155111"],
+    "enableDbSync": true
   },
   {
     "chainId": 137,


### PR DESCRIPTION
After the deployment of https://github.com/Uniswap/routing-api/pull/583 and https://github.com/Uniswap/routing-api/pull/629, we are ready to test auto fallback and recover in production.

The first chain we want to test is Sepolia because it's a testnet with small but meaningful amount of traffic. Even if we bring it down, the cost is still acceptable.

According to the prod alarm data, if we enable it for Sepolia, this is the only alarm that will possibly trigger: The latency alarm for Alchemy-Sepolia pair (Showing data from the last 24h, [link]([url](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~(id~'expr_1~expression~'p50Latency))~(~'Uniswap~'RPC_GATEWAY_11155111_ALCHEMY_evaluated_latency_getBlockNumber~'Service~'RoutingAPI~(stat~'p50~id~'p50Latency~visible~false~unit~'None)))~view~'timeSeries~stacked~false~start~'-PT24H~end~'P0D~period~300~region~'us-east-2~title~'RoutingAPI-RpcGateway-LatencyAlarm-ChainId-11155111-Provider-ALCHEMY~annotations~(horizontal~(~(label~'expr_1*20*3e*3d*20150*20for*201*20datapoints*20within*205*20minutes~value~150)))))))

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/n7CRFgTfi6wAndDXekPd/ba8f63ff-ad22-4dac-8fbb-696b491263cc.png)

So this flip of alarm should make the provider switch between Alchemy (primary provider) and Infura (backup). We should be able to observe it from the "Provider selection for sepolia" graph in [dashboard]([url](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#dashboards/dashboard/RpcGatewayDashboard?start=PT1H&end=null))

There is a small concern that Alchemy couldn't handle the doubled traffic caused by this PR (50% => 100%, because of it becoming primary). However since the quote traffic on Sepolia is indeed very small, we don't really expect an issue there. 