### PR TITLE
feat: live switch bnb quote for 100 percent

### DIFF
--- a/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
+++ b/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
@@ -78,10 +78,10 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
     case ChainId.BNB:
       // BNB RPC eth_call traffic is about 1/10 of mainnet, so we can shadow sample 1% of traffic
       return {
-        switchExactInPercentage: 1,
-        samplingExactInPercentage: 1,
-        switchExactOutPercentage: 1,
-        samplingExactOutPercentage: 1,
+        switchExactInPercentage: 100,
+        samplingExactInPercentage: 0,
+        switchExactOutPercentage: 100,
+        samplingExactOutPercentage: 0,
       }
     case ChainId.CELO:
       // Celo RPC eth_call traffic is about 1/100 of mainnet, so we can shadow sample 10% of traffic


### PR DESCRIPTION
We check the following metrics before we decide to increase traffic switch on BNB:

- Is BNB still sampling at 1%, meanwhile live traffic switched at 1%?
Based on the [metrics](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~(expression~'*28m1*2bm2*29*2f*28m1*2bm2*2bm3*2bm4*29*2a100~label~'BNB*20sampling*20percent~id~'e1~period~900))~(~(expression~'*28m5*2bm6*29*2f*28m5*2bm6*2bm7*2bm8*29*2a100~label~'BNB*20traffic*20switch*20percent~id~'e2~period~900))~(~'Uniswap~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_SAMPLING_CHAIN_ID_56~'Service~'RoutingAPI~(id~'m1~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_SAMPLING_CHAIN_ID_56~'.~'.~(id~'m2~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_TOTAL_CHAIN_ID_56~'.~'.~(id~'m3~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_TOTAL_CHAIN_ID_56~'.~'.~(id~'m4~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_CHAIN_ID_56~'.~'.~(id~'m7~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_CURRENT_CHAIN_ID_56~'.~'.~(id~'m8~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_TARGET_CHAIN_ID_56~'.~'.~(id~'m5~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_TARGET_CHAIN_ID_56~'.~'.~(id~'m6~visible~false)))~view~'timeSeries~stacked~false~region~'us-east-2~period~900~stat~'Sum~start~'-PT24H~end~'P0D)&query=~'*7bUniswap*2cService*7d*20_TRAFFIC_TARGET_CHAIN_ID_), this appears to be the same:
<img width="1278" alt="Screenshot 2024-04-23 at 1 46 16 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/cfc28fcb-7a86-48a8-b8f6-a58eacf4333a">

- Is the success rate on the BNB endpoint and on each BNB RPC call consistent?
BNB endpoint shows the consistently high success rate:
<img width="645" alt="Screenshot 2024-04-23 at 1 47 10 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/cc2fb8a5-0362-4e44-98dd-2950d4c160be">

- Is the latency on the BNB endpoint consistent?
BNB latency does not change after live switch:
<img width="643" alt="Screenshot 2024-04-23 at 1 51 03 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/e127b367-d475-4ce7-ae48-b6bd11dc2aa6">

- Is the RPC call volume only slightly up after quote shadow sampling on BNB?
[BNB RPC call volume](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~'Uniswap~'ChainId_56_V3QuoterQuoteLatency~'Service~'RoutingAPI~(visible~false))~(~'.~'ChainId_43114_ShadowV3QuoterQuoteLatency~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_56_INFURA_call_SUCCESS~'.~'.)~(~'.~'RPC_GATEWAY_56_QUIKNODE_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_56_QUIKNODE_call_SUCCESS~'.~'.)~(~'.~'RPC_GATEWAY_56_INFURA_call_FAILED~'.~'.~(visible~false)))~view~'timeSeries~stacked~false~region~'us-east-2~start~'-PT12H~end~'P0D~period~60~stat~'Sum)&query=~'*7bUniswap*2cService*7d*2042220*20RPC*20CALL) only shows minimum increase, which is important because when we live switch, we don't expect to see any further more RPC calls due to our optimized implementations:
<img width="1289" alt="Screenshot 2024-04-23 at 1 48 47 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/080faa05-6bdc-43d3-a46c-3fb960465dc5">

- Is the quote accuracy always 100% between new v3 quoter and current v3 quoter?
The [accuracy comparison](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~(expression~'*28m7*2bm8*29*2f*28m7*2bm8*2bm9*2bm10*29*2a100~label~'Expression1~id~'e1~period~60))~(~'Uniswap~'ChainId_56_V3QuoterQuoteLatency~'Service~'RoutingAPI~(visible~false~id~'m1))~(~'.~'ChainId_56_ShadowV3QuoterQuoteLatency~'.~'.~(visible~false~id~'m2))~(~'.~'RPC_GATEWAY_56_INFURA_call_SUCCESS~'.~'.~(visible~false~id~'m3))~(~'.~'RPC_GATEWAY_56_QUIKNODE_call_FAILED~'.~'.~(visible~false~id~'m4))~(~'.~'RPC_GATEWAY_56_QUIKNODE_call_SUCCESS~'.~'.~(visible~false~id~'m5))~(~'.~'RPC_GATEWAY_56_INFURA_call_FAILED~'.~'.~(visible~false~id~'m6))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MATCH_CHAIN_ID_56~'.~'.~(id~'m7~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MATCH_CHAIN_ID_56~'.~'.~(id~'m8~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MISMATCH_CHAIN_ID_56~'.~'.~(id~'m9~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MISMATCH_CHAIN_ID_56~'.~'.~(id~'m10~visible~false)))~view~'timeSeries~stacked~false~region~'us-east-2~start~'-PT3H~end~'P0D~period~60~stat~'Sum)&query=~'*7bUniswap*2cService*7d*2042220) shows it's always at 100%:
<img width="1280" alt="Screenshot 2024-04-23 at 1 50 13 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/373b3e37-015b-460b-aa54-9021e964147e">
