### PR TITLE
feat: live switch blast quote for 1 percent

### DIFF
--- a/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
+++ b/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
@@ -70,9 +70,9 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
     case ChainId.BLAST:
       // Blast RPC eth_call traffic is about 1/10 of mainnet, so we can shadow sample 1% of traffic
       return {
-        switchExactInPercentage: 0.0,
+        switchExactInPercentage: 1,
         samplingExactInPercentage: 1,
-        switchExactOutPercentage: 0.0,
+        switchExactOutPercentage: 1,
         samplingExactOutPercentage: 1,
       } as QuoteProviderTrafficSwitchConfiguration
     case ChainId.BNB:


### PR DESCRIPTION
We check the following metrics before we decide to live switch on Blast:

- Is the success rate on the Blast endpoint consistent?
Blast endpoint shows the consistently high success rate:
<img width="642" alt="Screenshot 2024-04-24 at 9 40 04 AM" src="https://github.com/Uniswap/routing-api/assets/91580504/f27bfddb-ccb9-43c7-a273-beae16306390">

- Is the latency on the Blast endpoint consistent?
Blast latency does not change after the quote shadow sampling:
<img width="640" alt="Screenshot 2024-04-24 at 9 41 15 AM" src="https://github.com/Uniswap/routing-api/assets/91580504/339b3c31-e9ae-4bae-b225-166f5ffa9d3c">

- Is the RPC call volume only slightly up after quote shadow sampling on BNB?
[Blast RPC call volume](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~'Uniswap~'ChainId_81457_V3QuoterQuoteLatency~'Service~'RoutingAPI~(visible~false))~(~'.~'ChainId_81457_ShadowV3QuoterQuoteLatency~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_81457_INFURA_call_SUCCESS~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_81457_QUIKNODE_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_81457_QUIKNODE_call_SUCCESS~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_81457_INFURA_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_81457_QUIKNODE_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_81457_INFURA_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_81457_NIRVANA_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_81457_NIRVANA_call_SUCCESS~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_81457_INFURA_call_SUCCESS~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_81457_QUIKNODE_call_SUCCESS~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_81457_QUIKNODE_call_FAILED~'.~'.)~(~'.~'RPC_GATEWAY_81457_QUIKNODE_call_SUCCESS~'.~'.))~view~'timeSeries~stacked~false~region~'us-east-2~start~'-PT168H~end~'P0D~period~900~stat~'Sum)&query=~'*7bUniswap*2cService*7d*20RPC*20CALL*2056) only shows minimum increase, which is important because when we live switch, we don't expect to see any further more RPC calls due to our optimized implementations:
<img width="1300" alt="Screenshot 2024-04-24 at 9 42 55 AM" src="https://github.com/Uniswap/routing-api/assets/91580504/011d1084-b903-4b10-be84-543cf6cc437e">

Is the Shadow quoter faster than the current quoter on Blast?
V3 shadow quoter shows consistently better [latency](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~'Uniswap~'ChainId_81457_V3QuoterQuoteLatency~'Service~'RoutingAPI)~(~'.~'ChainId_81457_ShadowV3QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_42220_QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_81457_Shadow_QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_43114_QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_81457_Shadow_QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_43114_V3QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_81457_ShadowV3QuoterQuoteLatency~'.~'.))~view~'timeSeries~stacked~false~region~'us-east-2~start~'-PT24H~end~'P0D~period~3600~stat~'Maximum)&query=~'*7bUniswap*2cService*7d*20Quoter*20Latency*2043114) then the current v3 quoter on Blast:
<img width="1281" alt="Screenshot 2024-04-24 at 9 44 35 AM" src="https://github.com/Uniswap/routing-api/assets/91580504/76b34b83-be25-4538-89fc-f527057037c5">

Is the quote accuracy always 100% between new v3 quoter and current v3 quoter?
The [accuracy comparison](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~(expression~'*28m7*2bm8*29*2f*28m7*2bm8*2bm9*2bm10*29*2a100~label~'Expression1~id~'e1~period~60))~(~'Uniswap~'ChainId_81457_V3QuoterQuoteLatency~'Service~'RoutingAPI~(visible~false~id~'m1))~(~'.~'ChainId_81457_ShadowV3QuoterQuoteLatency~'.~'.~(visible~false~id~'m2))~(~'.~'RPC_GATEWAY_81457_INFURA_call_SUCCESS~'.~'.~(visible~false~id~'m3))~(~'.~'RPC_GATEWAY_81457_QUIKNODE_call_FAILED~'.~'.~(visible~false~id~'m4))~(~'.~'RPC_GATEWAY_81457_QUIKNODE_call_SUCCESS~'.~'.~(visible~false~id~'m5))~(~'.~'RPC_GATEWAY_81457_INFURA_call_FAILED~'.~'.~(visible~false~id~'m6))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MISMATCH_CHAIN_ID_81457~'.~'.~(id~'m9~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MISMATCH_CHAIN_ID_81457~'.~'.~(id~'m10~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MATCH_CHAIN_ID_81457~'.~'.~(id~'m7~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MATCH_CHAIN_ID_81457~'.~'.~(id~'m8~visible~false)))~view~'timeSeries~stacked~false~region~'us-east-2~start~'-PT72H~end~'P0D~period~60~stat~'Sum)&query=~'*7bUniswap*2cService*7d*2043114*20MATCH) shows it's always at 100%:
<img width="1283" alt="Screenshot 2024-04-24 at 9 46 01 AM" src="https://github.com/Uniswap/routing-api/assets/91580504/d0bba43e-e070-4b5c-9e8c-32dff15d5d98">
