### PR TITLE
feat: live switch optimism quote for 1 percent

### DIFF
--- a/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
+++ b/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
@@ -63,17 +63,17 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
       // Optimism RPC eth_call traffic is about 1/10 of mainnet, so we can shadow sample 1% of traffic
       return {
         switchExactInPercentage: 1,
-        samplingExactInPercentage: 1,
+        samplingExactInPercentage: 0,
         switchExactOutPercentage: 1,
-        samplingExactOutPercentage: 1,
+        samplingExactOutPercentage: 0,
       } as QuoteProviderTrafficSwitchConfiguration
     case ChainId.BLAST:
       // Blast RPC eth_call traffic is about 1/10 of mainnet, so we can shadow sample 1% of traffic
       return {
         switchExactInPercentage: 1,
-        samplingExactInPercentage: 1,
+        samplingExactInPercentage: 0,
         switchExactOutPercentage: 1,
-        samplingExactOutPercentage: 1,
+        samplingExactOutPercentage: 0,
       } as QuoteProviderTrafficSwitchConfiguration
     case ChainId.BNB:
       // BNB RPC eth_call traffic is about 1/10 of mainnet, so we can shadow sample 1% of traffic

--- a/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
+++ b/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
@@ -62,9 +62,9 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
     case ChainId.OPTIMISM:
       // Optimism RPC eth_call traffic is about 1/10 of mainnet, so we can shadow sample 1% of traffic
       return {
-        switchExactInPercentage: 0.0,
+        switchExactInPercentage: 1,
         samplingExactInPercentage: 1,
-        switchExactOutPercentage: 0.0,
+        switchExactOutPercentage: 1,
         samplingExactOutPercentage: 1,
       } as QuoteProviderTrafficSwitchConfiguration
     case ChainId.BLAST:


### PR DESCRIPTION
We check the following metrics before we decide to live switch on Optimism:

- Is the success rate on the Optimism endpoint consistent?
Optimism endpoint shows the consistently high success rate:
<img width="642" alt="Screenshot 2024-04-24 at 10 03 31 AM" src="https://github.com/Uniswap/routing-api/assets/91580504/c3714467-0a93-4261-950c-75075219eeac">

- Is the latency on the Optimism endpoint consistent?
Optimism latency does not change after the quote shadow sampling:
<img width="638" alt="Screenshot 2024-04-24 at 10 05 15 AM" src="https://github.com/Uniswap/routing-api/assets/91580504/f5f67067-f26c-42c4-aea3-7a0535533188">

- Is the RPC call volume only slightly up after quote shadow sampling on Optimism?
[Optimism RPC call volume](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~'Uniswap~'ChainId_10_V3QuoterQuoteLatency~'Service~'RoutingAPI~(visible~false))~(~'.~'ChainId_10_ShadowV3QuoterQuoteLatency~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_10_INFURA_call_SUCCESS~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_10_QUIKNODE_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_10_QUIKNODE_call_SUCCESS~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_10_INFURA_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_10_QUIKNODE_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_10_INFURA_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_10_NIRVANA_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_10_NIRVANA_call_SUCCESS~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_10_INFURA_call_SUCCESS~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_10_QUIKNODE_call_SUCCESS~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_10_QUIKNODE_call_FAILED~'.~'.)~(~'.~'RPC_GATEWAY_10_QUIKNODE_call_SUCCESS~'.~'.))~view~'timeSeries~stacked~false~region~'us-east-2~start~'-PT168H~end~'P0D~period~900~stat~'Sum)&query=~'*7bUniswap*2cService*7d*20RPC*20CALL*2056) only shows minimum increase, which is important because when we live switch, we don't expect to see any further more RPC calls due to our optimized implementations:
<img width="1267" alt="Screenshot 2024-04-24 at 10 06 31 AM" src="https://github.com/Uniswap/routing-api/assets/91580504/6d86df71-3617-44f9-8ecd-ab5b67ff18b9">

- Is the Shadow quoter faster than the current quoter on Optimism?
V3 shadow quoter shows consistently better [latency](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~'Uniswap~'ChainId_10_V3QuoterQuoteLatency~'Service~'RoutingAPI)~(~'.~'ChainId_10_ShadowV3QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_42220_QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_10_Shadow_QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_43114_QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_10_Shadow_QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_43114_V3QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_10_ShadowV3QuoterQuoteLatency~'.~'.))~view~'timeSeries~stacked~false~region~'us-east-2~start~'-PT24H~end~'P0D~period~60~stat~'Maximum)&query=~'*7bUniswap*2cService*7d*20Quoter*20Latency*2043114) then the current v3 quoter on Optimism:
<img width="1282" alt="Screenshot 2024-04-24 at 10 07 55 AM" src="https://github.com/Uniswap/routing-api/assets/91580504/5361065c-123a-4f01-ac61-7908f83d8cfa">

- Is the quote accuracy always 100% between new v3 quoter and current v3 quoter?
The [accuracy comparison](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~(expression~'*28m7*2bm8*29*2f*28m7*2bm8*2bm9*2bm10*29*2a100~label~'Expression1~id~'e1~period~60))~(~'Uniswap~'ChainId_10_V3QuoterQuoteLatency~'Service~'RoutingAPI~(visible~false~id~'m1))~(~'.~'ChainId_10_ShadowV3QuoterQuoteLatency~'.~'.~(visible~false~id~'m2))~(~'.~'RPC_GATEWAY_10_INFURA_call_SUCCESS~'.~'.~(visible~false~id~'m3))~(~'.~'RPC_GATEWAY_10_QUIKNODE_call_FAILED~'.~'.~(visible~false~id~'m4))~(~'.~'RPC_GATEWAY_10_QUIKNODE_call_SUCCESS~'.~'.~(visible~false~id~'m5))~(~'.~'RPC_GATEWAY_10_INFURA_call_FAILED~'.~'.~(visible~false~id~'m6))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MISMATCH_CHAIN_ID_10~'.~'.~(id~'m9~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MISMATCH_CHAIN_ID_10~'.~'.~(id~'m10~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MATCH_CHAIN_ID_10~'.~'.~(id~'m7~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MATCH_CHAIN_ID_10~'.~'.~(id~'m8~visible~false)))~view~'timeSeries~stacked~false~region~'us-east-2~start~'-PT72H~end~'P0D~period~60~stat~'Sum)&query=~'*7bUniswap*2cService*7d*2043114*20MATCH) shows it's always at 100%:
<img width="1293" alt="Screenshot 2024-04-24 at 10 09 06 AM" src="https://github.com/Uniswap/routing-api/assets/91580504/155c424e-eac7-4343-b27f-7a35f2cc49ed">

