### PR TITLE
feat: live switch polygon quote for 1 percent

### DIFF
--- a/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
+++ b/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
@@ -54,10 +54,10 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
     case ChainId.POLYGON:
       // Total RPM for 'QuoteTotalCallsToProvider' is around 20k-30k (across all chains), so 0.1% means 20-30 RPM shadow sampling
       return {
-        switchExactInPercentage: 0.0,
-        samplingExactInPercentage: 0.5,
-        switchExactOutPercentage: 0.0,
-        samplingExactOutPercentage: 0.5,
+        switchExactInPercentage: 1,
+        samplingExactInPercentage: 0,
+        switchExactOutPercentage: 1,
+        samplingExactOutPercentage: 0,
       } as QuoteProviderTrafficSwitchConfiguration
     case ChainId.OPTIMISM:
       // Optimism RPC eth_call traffic is about 1/10 of mainnet, so we can shadow sample 1% of traffic


### PR DESCRIPTION
We check the following metrics before we decide to live switch on Polygon:

- Is the success rate on the Polygon endpoint consistent?
Polygon endpoint shows the consistently high success rate:
![Screenshot 2024-04-24 at 2.12.46 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/a8e6e572-893b-4097-9968-6632205e7e0f.png)
I checked the errors, and those were due to division by zero error, so it's related to the tokenIn/tokenOut.

- Is the latency on the Polygon endpoint consistent?
Polygon latency does not change after the quote shadow sampling:
![Screenshot 2024-04-24 at 2.13.46 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/c71b5b17-99fa-452e-9d9d-ee35d6c73cd2.png)

- Is the RPC call volume only slightly up after quote shadow sampling on Polygon?
[Polygon RPC call volume](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~'Uniswap~'ChainId_137_V3QuoterQuoteLatency~'Service~'RoutingAPI~(visible~false))~(~'.~'ChainId_137_ShadowV3QuoterQuoteLatency~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_137_INFURA_call_SUCCESS~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_137_QUIKNODE_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_137_QUIKNODE_call_SUCCESS~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_137_INFURA_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_137_QUIKNODE_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_137_INFURA_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_137_NIRVANA_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_137_NIRVANA_call_SUCCESS~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_137_INFURA_call_SUCCESS~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_137_QUIKNODE_call_SUCCESS~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_137_QUIKNODE_call_FAILED~'.~'.)~(~'.~'RPC_GATEWAY_137_QUIKNODE_call_SUCCESS~'.~'.))~view~'timeSeries~stacked~false~region~'us-east-2~start~'-PT168H~end~'P0D~period~900~stat~'Sum)&query=~'*7bUniswap*2cService*7d*20RPC*20CALL*2056) only shows minimum increase, which is important because when we live switch, we don't expect to see any further more RPC calls due to our optimized implementations:

![Screenshot 2024-04-24 at 2.15.51 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/4dafd72b-a291-46b5-aed6-81612a9b7967.png)

- Is the Shadow quoter faster than the current quoter on Polygon?
V3 shadow quoter shows consistently better [latency](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~'Uniswap~'ChainId_137_V3QuoterQuoteLatency~'Service~'RoutingAPI)~(~'.~'ChainId_137_ShadowV3QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_137_QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_137_Shadow_QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_137_QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_137_Shadow_QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_137_V3QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_137_ShadowV3QuoterQuoteLatency~'.~'.))~view~'timeSeries~stacked~false~region~'us-east-2~start~'-PT24H~end~'P0D~period~60~stat~'Maximum)&query=~'*7bUniswap*2cService*7d*20Quoter*20Latency*2043114) then the current v3 quoter on Polygon:
![Screenshot 2024-04-24 at 2.17.20 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/399a71a1-4fb5-4773-9d52-68e175c437d4.png)

- Is the quote accuracy always 100% between new v3 quoter and current v3 quoter?
The [accuracy comparison](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~(expression~'*28m7*2bm8*29*2f*28m7*2bm8*2bm9*2bm10*29*2a100~label~'Expression1~id~'e1~period~60))~(~'Uniswap~'ChainId_137_V3QuoterQuoteLatency~'Service~'RoutingAPI~(visible~false~id~'m1))~(~'.~'ChainId_137_ShadowV3QuoterQuoteLatency~'.~'.~(visible~false~id~'m2))~(~'.~'RPC_GATEWAY_10_INFURA_call_SUCCESS~'.~'.~(visible~false~id~'m3))~(~'.~'RPC_GATEWAY_10_QUIKNODE_call_FAILED~'.~'.~(visible~false~id~'m4))~(~'.~'RPC_GATEWAY_10_QUIKNODE_call_SUCCESS~'.~'.~(visible~false~id~'m5))~(~'.~'RPC_GATEWAY_10_INFURA_call_FAILED~'.~'.~(visible~false~id~'m6))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MISMATCH_CHAIN_ID_10~'.~'.~(id~'m9~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MISMATCH_CHAIN_ID_10~'.~'.~(id~'m10~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MATCH_CHAIN_ID_10~'.~'.~(id~'m7~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MATCH_CHAIN_ID_10~'.~'.~(id~'m8~visible~false)))~view~'timeSeries~stacked~false~region~'us-east-2~start~'-PT72H~end~'P0D~period~60~stat~'Sum)&query=~'*7bUniswap*2cService*7d*2043114*20MATCH) shows it's always at 100%:
![Screenshot 2024-04-24 at 2.18.48 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/c59c9f0a-f150-4200-96b0-fb6c3b0ade6e.png)

