### PR TITLE
feat: live switch arbitrum quote for 1 percent

### DIFF
--- a/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
+++ b/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
@@ -46,10 +46,10 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
     case ChainId.ARBITRUM_ONE:
       // Arbitrum RPC eth_call traffic is about half of mainnet, so we can shadow sample 0.2% of traffic
       return {
-        switchExactInPercentage: 0.0,
-        samplingExactInPercentage: 0.2,
-        switchExactOutPercentage: 0.0,
-        samplingExactOutPercentage: 0.2,
+        switchExactInPercentage: 1,
+        samplingExactInPercentage: 0,
+        switchExactOutPercentage: 1,
+        samplingExactOutPercentage: 0,
       } as QuoteProviderTrafficSwitchConfiguration
     case ChainId.POLYGON:
       // Total RPM for 'QuoteTotalCallsToProvider' is around 20k-30k (across all chains), so 0.1% means 20-30 RPM shadow sampling


### PR DESCRIPTION
We check the following metrics before we decide to live switch on Arbitrum:

- Is the success rate on the Arbitrum endpoint consistent?
Arbitrum endpoint shows the consistently high success rate:
![Screenshot 2024-04-24 at 2.42.28 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/46c6f6b5-51ce-4021-9fe8-8cdca5aefe27.png)

- Is the latency on the Arbitrum endpoint consistent?
Arbitrum latency does not change after the quote shadow sampling:
![Screenshot 2024-04-24 at 2.45.55 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/191ffef6-c8ef-4e84-b69c-9af389083d47.png)

- Is the RPC call volume only slightly up after quote shadow sampling on Arbitrum?
[Arbitrum RPC call volume](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~'Uniswap~'ChainId_42161_V3QuoterQuoteLatency~'Service~'RoutingAPI~(visible~false))~(~'.~'ChainId_42161_ShadowV3QuoterQuoteLatency~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_42161_INFURA_call_SUCCESS~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_42161_QUIKNODE_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_42161_QUIKNODE_call_SUCCESS~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_42161_INFURA_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_42161_QUIKNODE_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_42161_INFURA_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_42161_NIRVANA_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_42161_NIRVANA_call_SUCCESS~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_42161_INFURA_call_SUCCESS~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_42161_QUIKNODE_call_SUCCESS~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_42161_QUIKNODE_call_FAILED~'.~'.)~(~'.~'RPC_GATEWAY_42161_QUIKNODE_call_SUCCESS~'.~'.))~view~'timeSeries~stacked~false~region~'us-east-2~start~'-PT168H~end~'P0D~period~900~stat~'Sum)&query=~'*7bUniswap*2cService*7d*20RPC*20CALL*2056) only shows minimum increase, which is important because when we live switch, we don't expect to see any further more RPC calls due to our optimized implementations:
![Screenshot 2024-04-24 at 2.47.48 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/df185a6d-5cf1-4375-bf4e-e8845e1557a7.png)

- Is the Shadow quoter faster than the current quoter on Arbitrum?
V3 shadow quoter shows consistently better [latency](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~'Uniswap~'ChainId_42161_V3QuoterQuoteLatency~'Service~'RoutingAPI)~(~'.~'ChainId_42161_ShadowV3QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_42161_QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_42161_Shadow_QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_42161_QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_42161_Shadow_QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_42161_V3QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_42161_ShadowV3QuoterQuoteLatency~'.~'.))~view~'timeSeries~stacked~false~region~'us-east-2~start~'-PT24H~end~'P0D~period~60~stat~'Maximum)&query=~'*7bUniswap*2cService*7d*20Quoter*20Latency*2043114) then the current v3 quoter on Arbitrum:
![Screenshot 2024-04-24 at 2.49.09 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/ceecd482-ef23-4788-ac8c-3d25b4a7cf2e.png)

- Is the quote accuracy always 100% between new v3 quoter and current v3 quoter?
The [accuracy comparison](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~(expression~'*28m7*2bm8*29*2f*28m7*2bm8*2bm9*2bm10*29*2a100~label~'Expression1~id~'e1~period~60))~(~'Uniswap~'ChainId_42161_V3QuoterQuoteLatency~'Service~'RoutingAPI~(visible~false~id~'m1))~(~'.~'ChainId_42161_ShadowV3QuoterQuoteLatency~'.~'.~(visible~false~id~'m2))~(~'.~'RPC_GATEWAY_42161_INFURA_call_SUCCESS~'.~'.~(visible~false~id~'m3))~(~'.~'RPC_GATEWAY_42161_QUIKNODE_call_FAILED~'.~'.~(visible~false~id~'m4))~(~'.~'RPC_GATEWAY_42161_QUIKNODE_call_SUCCESS~'.~'.~(visible~false~id~'m5))~(~'.~'RPC_GATEWAY_42161_INFURA_call_FAILED~'.~'.~(visible~false~id~'m6))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MISMATCH_CHAIN_ID_10~'.~'.~(id~'m9~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MISMATCH_CHAIN_ID_42161~'.~'.~(id~'m10~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MATCH_CHAIN_ID_42161~'.~'.~(id~'m7~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MATCH_CHAIN_ID_42161~'.~'.~(id~'m8~visible~false)))~view~'timeSeries~stacked~false~region~'us-east-2~start~'-PT72H~end~'P0D~period~60~stat~'Sum)&query=~'*7bUniswap*2cService*7d*2043114*20MATCH) shows it's always at 100%:
![Screenshot 2024-04-24 at 2.50.48 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/68d527c8-b073-49c6-a152-2128f6ee8781.png)

