### PR TITLE
feat: live switch base quote for 1 percent

### DIFF
--- a/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
+++ b/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
@@ -30,10 +30,10 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
     case ChainId.BASE:
       // Base RPC eth_call traffic is about double mainnet, so we can shadow sample 0.05% of traffic
       return {
-        switchExactInPercentage: 0.0,
-        samplingExactInPercentage: 0.05,
-        switchExactOutPercentage: 0.0,
-        samplingExactOutPercentage: 0.05,
+        switchExactInPercentage: 1,
+        samplingExactInPercentage: 0,
+        switchExactOutPercentage: 1,
+        samplingExactOutPercentage: 0,
       } as QuoteProviderTrafficSwitchConfiguration
     case ChainId.MAINNET:
       // Total RPM for 'QuoteTotalCallsToProvider' is around 20k-30k (across all chains), so 0.1% means 20-30 RPM shadow sampling


### PR DESCRIPTION
We check the following metrics before we decide to live switch on Base:

- Is the success rate on the Base endpoint consistent?
Base endpoint shows the consistently high success rate:
![Screenshot 2024-04-24 at 4.03.57 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/11a21434-fd45-4439-b248-3c3a864a93cb.png)

- Is the latency on the Base endpoint consistent?
Base latency does not change after the quote shadow sampling:
![Screenshot 2024-04-24 at 4.05.07 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/2b4027c8-555d-481b-a410-e75c053a79d8.png)

- Is the RPC call volume only slightly up after quote shadow sampling on Base?
[Base RPC call volume](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~'Uniswap~'ChainId_42161_V3QuoterQuoteLatency~'Service~'RoutingAPI~(visible~false))~(~'.~'ChainId_*208453_ShadowV3QuoterQuoteLatency~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_8453_INFURA_call_SUCCESS~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_8453_QUIKNODE_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_8453_QUIKNODE_call_SUCCESS~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_8453_INFURA_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_8453_QUIKNODE_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_8453_INFURA_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_8453_NIRVANA_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_8453_NIRVANA_call_SUCCESS~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_8453_INFURA_call_SUCCESS~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_8453_QUIKNODE_call_SUCCESS~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_8453_QUIKNODE_call_FAILED~'.~'.)~(~'.~'RPC_GATEWAY_8453_QUIKNODE_call_SUCCESS~'.~'.))~view~'timeSeries~stacked~false~region~'us-east-2~start~'-PT168H~end~'P0D~period~900~stat~'Sum)&query=~'*7bUniswap*2cService*7d*20RPC*20CALL*2056) only shows minimum increase, which is important because when we live switch, we don't expect to see any further more RPC calls due to our optimized implementations:
![Screenshot 2024-04-24 at 4.13.06 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/bfea59d0-aa62-47f6-bd4e-2948a28eea98.png)

- Is the Shadow quoter faster than the current quoter on Base?
V3 shadow quoter shows consistently better [latency](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~'Uniswap~'ChainId_8453_V3QuoterQuoteLatency~'Service~'RoutingAPI)~(~'.~'ChainId_8453_ShadowV3QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_8453_QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_8453_Shadow_QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_8453_QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_8453_Shadow_QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_8453_V3QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_8453_ShadowV3QuoterQuoteLatency~'.~'.))~view~'timeSeries~stacked~false~region~'us-east-2~start~'-PT24H~end~'P0D~period~60~stat~'Maximum)&query=~'*7bUniswap*2cService*7d*20Quoter*20Latency*2043114) then the current v3 quoter on Base:
![Screenshot 2024-04-24 at 4.15.26 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/26e5bdfb-7e5a-4857-909d-a8a54baab1b4.png)

- Is the quote accuracy always 100% between new v3 quoter and current v3 quoter?
The [accuracy comparison](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~(expression~'*28m7*2bm8*29*2f*28m7*2bm8*2bm9*2bm10*29*2a100~label~'Expression1~id~'e1~period~60))~(~'Uniswap~'ChainId_8453_V3QuoterQuoteLatency~'Service~'RoutingAPI~(visible~false~id~'m1))~(~'.~'ChainId_8453_ShadowV3QuoterQuoteLatency~'.~'.~(visible~false~id~'m2))~(~'.~'RPC_GATEWAY_8453_INFURA_call_SUCCESS~'.~'.~(visible~false~id~'m3))~(~'.~'RPC_GATEWAY_8453_QUIKNODE_call_FAILED~'.~'.~(visible~false~id~'m4))~(~'.~'RPC_GATEWAY_8453_QUIKNODE_call_SUCCESS~'.~'.~(visible~false~id~'m5))~(~'.~'RPC_GATEWAY_8453_INFURA_call_FAILED~'.~'.~(visible~false~id~'m6))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MISMATCH_CHAIN_ID_8453~'.~'.~(id~'m9~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MISMATCH_CHAIN_ID_8453~'.~'.~(id~'m10~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MATCH_CHAIN_ID_8453~'.~'.~(id~'m7~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MATCH_CHAIN_ID_8453~'.~'.~(id~'m8~visible~false)))~view~'timeSeries~stacked~false~region~'us-east-2~start~'-PT72H~end~'P0D~period~60~stat~'Sum)&query=~'*7bUniswap*2cService*7d*2043114*20MATCH) shows it's always at 100%:
![Screenshot 2024-04-24 at 4.16.51 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/3d5d28f8-ffa5-4091-917d-c46f5cf5bbd4.png)

