### PR TITLE
feat: live switch mainnet quote for 1 percent

### DIFF
--- a/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
+++ b/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
@@ -38,10 +38,10 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
     case ChainId.MAINNET:
       // Total RPM for 'QuoteTotalCallsToProvider' is around 20k-30k (across all chains), so 0.1% means 20-30 RPM shadow sampling
       return {
-        switchExactInPercentage: 0.0,
-        samplingExactInPercentage: 0.1,
-        switchExactOutPercentage: 0.0,
-        samplingExactOutPercentage: 0.1,
+        switchExactInPercentage: 1,
+        samplingExactInPercentage: 0,
+        switchExactOutPercentage: 1,
+        samplingExactOutPercentage: 0,
       } as QuoteProviderTrafficSwitchConfiguration
     case ChainId.ARBITRUM_ONE:
       // Arbitrum RPC eth_call traffic is about half of mainnet, so we can shadow sample 0.2% of traffic


### PR DESCRIPTION
We check the following metrics before we decide to live switch on Mainnet:

- Is the success rate on the Mainnet endpoint consistent?
Mainnet endpoint shows the consistently high success rate:
![Screenshot 2024-04-24 at 4.31.37 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/88e25b9f-97f3-4ba4-a1da-c23f1e9a3c8e.png)

- Is the latency on the Mainnet endpoint consistent?
Mainnet latency does not change after the quote shadow sampling:
![Screenshot 2024-04-24 at 4.32.24 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/b896f3f8-d577-46f2-9b3d-0acf1a20158f.png)

- Is the RPC call volume only slightly up after quote shadow sampling on Mainnet?
[Mainnet RPC call volume]([https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~'Uniswap~'ChainId_1_V3QuoterQuoteLatency~'Service~'RoutingAPI~(visible~false))~(~'.~'ChainId_1_ShadowV3QuoterQuoteLatency~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_1_INFURA_call_SUCCESS~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_1_QUIKNODE_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_1_QUIKNODE_call_SUCCESS~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_1_INFURA_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_1_QUIKNODE_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_1_INFURA_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_1_NIRVANA_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_1_NIRVANA_call_SUCCESS~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_1_INFURA_call_SUCCESS~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_1_QUIKNODE_call_SUCCESS~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_1_QUIKNODE_call_FAILED~'.~'.)~(~'.~'RPC_GATEWAY_1_QUIKNODE_call_SUCCESS~'.~'.))~view~'timeSeries~stacked~false~region~'us-east-2~start~'-PT168H~end~'P0D~period~900~stat~'Sum)&query=~'*7bUniswap*2cService*7d*20RPC*20CALL*2056](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~'Uniswap~'ChainId_1_V3QuoterQuoteLatency~'Service~'RoutingAPI~(visible~false))~(~'.~'ChainId_1_ShadowV3QuoterQuoteLatency~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_1_INFURA_call_SUCCESS~'.~'.)~(~'.~'RPC_GATEWAY_1_QUIKNODE_call_FAILED~'.~'.)~(~'.~'RPC_GATEWAY_1_QUIKNODE_call_SUCCESS~'.~'.)~(~'.~'RPC_GATEWAY_1_INFURA_call_FAILED~'.~'.)~(~'.~'RPC_GATEWAY_1_QUIKNODE_call_FAILED~'.~'.)~(~'.~'RPC_GATEWAY_1_INFURA_call_FAILED~'.~'.)~(~'.~'RPC_GATEWAY_1_NIRVANA_call_FAILED~'.~'.)~(~'.~'RPC_GATEWAY_1_NIRVANA_call_SUCCESS~'.~'.)~(~'.~'RPC_GATEWAY_1_INFURA_call_SUCCESS~'.~'.)~(~'.~'RPC_GATEWAY_1_QUIKNODE_call_SUCCESS~'.~'.)~(~'.~'RPC_GATEWAY_1_QUIKNODE_call_FAILED~'.~'.)~(~'.~'RPC_GATEWAY_1_QUIKNODE_call_SUCCESS~'.~'.))~view~'timeSeries~stacked~false~region~'us-east-2~start~'-PT168H~end~'P0D~period~900~stat~'Sum)&query=~'*7bUniswap*2cService*7d*20RPC*20CALL*2056)) only shows minimum increase, which is important because when we live switch, we don't expect to see any further more RPC calls due to our optimized implementations:
![Screenshot 2024-04-24 at 4.33.59 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/375d31e0-686a-4726-985d-95fe008e2b35.png)

- Is the Shadow quoter faster than the current quoter on Mainnet?
V3 shadow quoter shows consistently better [latency](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~'Uniswap~'ChainId_1_V3QuoterQuoteLatency~'Service~'RoutingAPI)~(~'.~'ChainId_1_ShadowV3QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_1_QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_1_Shadow_QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_1_QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_1_Shadow_QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_1_V3QuoterQuoteLatency~'.~'.)~(~'.~'ChainId_1_ShadowV3QuoterQuoteLatency~'.~'.))~view~'timeSeries~stacked~false~region~'us-east-2~start~'-PT24H~end~'P0D~period~60~stat~'Maximum)&query=~'*7bUniswap*2cService*7d*20Quoter*20Latency*2043114) then the current v3 quoter on Mainnet:
![Screenshot 2024-04-24 at 4.35.05 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/2abe4667-956e-425a-8e3d-4f2ae3c4adc3.png)

- Is the quote accuracy always 100% between new v3 quoter and current v3 quoter?
The [accuracy comparison](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~(expression~'*28m7*2bm8*29*2f*28m7*2bm8*2bm9*2bm10*29*2a100~label~'Expression1~id~'e1~period~60))~(~'Uniswap~'ChainId_1_V3QuoterQuoteLatency~'Service~'RoutingAPI~(visible~false~id~'m1))~(~'.~'ChainId_1_ShadowV3QuoterQuoteLatency~'.~'.~(visible~false~id~'m2))~(~'.~'RPC_GATEWAY_1_INFURA_call_SUCCESS~'.~'.~(visible~false~id~'m3))~(~'.~'RPC_GATEWAY_1_QUIKNODE_call_FAILED~'.~'.~(visible~false~id~'m4))~(~'.~'RPC_GATEWAY_1_QUIKNODE_call_SUCCESS~'.~'.~(visible~false~id~'m5))~(~'.~'RPC_GATEWAY_1_INFURA_call_FAILED~'.~'.~(visible~false~id~'m6))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MISMATCH_CHAIN_ID_1~'.~'.~(id~'m9~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MISMATCH_CHAIN_ID_1~'.~'.~(id~'m10~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MATCH_CHAIN_ID_1~'.~'.~(id~'m7~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MATCH_CHAIN_ID_1~'.~'.~(id~'m8~visible~false)))~view~'timeSeries~stacked~false~region~'us-east-2~start~'-PT1H~end~'P0D~period~60~stat~'Sum)&query=~'*7bUniswap*2cService*7d*2043114*20MATCH) shows it's always at 100%:
![Screenshot 2024-04-24 at 4.36.31 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/259f98c8-a915-4d48-9d4a-47dc474e53ba.png)

