### PR TITLE
feat: live switch blast quote for 100 percent

### DIFF
--- a/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
+++ b/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
@@ -70,9 +70,9 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
     case ChainId.BLAST:
       // Blast RPC eth_call traffic is about 1/10 of mainnet, so we can shadow sample 1% of traffic
       return {
-        switchExactInPercentage: 1,
+        switchExactInPercentage: 100,
         samplingExactInPercentage: 0,
-        switchExactOutPercentage: 1,
+        switchExactOutPercentage: 100,
         samplingExactOutPercentage: 0,
       } as QuoteProviderTrafficSwitchConfiguration
     case ChainId.BNB:


### PR DESCRIPTION
We check the following metrics before we decide to increase traffic switch on Blast:

- Is Blast live traffic switched at 1%?
Based on the [metrics](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~(expression~'*28m1*2bm2*29*2f*28m1*2bm2*2bm3*2bm4*29*2a100~label~'BLAST*20sampling*20percent~id~'e1~period~900))~(~(expression~'*28m5*2bm6*29*2f*28m5*2bm6*2bm7*2bm8*29*2a100~label~'BLAST*20traffic*20switch*20percent~id~'e2~period~900))~(~'Uniswap~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_SAMPLING_CHAIN_ID_81457~'Service~'RoutingAPI~(id~'m1~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_SAMPLING_CHAIN_ID_81457~'.~'.~(id~'m2~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_TOTAL_CHAIN_ID_81457~'.~'.~(id~'m3~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_TOTAL_CHAIN_ID_81457~'.~'.~(id~'m4~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_CHAIN_ID_81457~'.~'.~(id~'m7~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_CURRENT_CHAIN_ID_81457~'.~'.~(id~'m8~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_TARGET_CHAIN_ID_81457~'.~'.~(id~'m5~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_TARGET_CHAIN_ID_81457~'.~'.~(id~'m6~visible~false)))~view~'timeSeries~stacked~false~region~'us-east-2~period~900~stat~'Sum~start~'-PT24H~end~'P0D)&query=~'*7bUniswap*2cService*7d*20_TRAFFIC_TARGET_CHAIN_ID_), this appears to be the same:
![Screenshot 2024-04-25 at 10.00.51 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/10db80f8-0b76-46fd-b54d-edb8f35ff9d2.png)

- Is the success rate on the Blast endpoint and on each Blast RPC call consistent?
Blast endpoint shows the consistently high success rate:
![Screenshot 2024-04-25 at 10.02.27 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/a7cd73c1-c8bb-4ebb-b404-d8e28abfaa7b.png)

- Is the latency on the Blast endpoint consistent?
Blast latency does not change after live switch:
![Screenshot 2024-04-25 at 10.03.31 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/0c5dd82e-e3ef-4afa-a842-fb62f58e2717.png)

- Is the RPC call volume only slightly up after quote shadow sampling on Blast?
[Blast RPC call volume](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~'Uniswap~'ChainId_81457_V3QuoterQuoteLatency~'Service~'RoutingAPI~(visible~false))~(~'.~'ChainId_81457_ShadowV3QuoterQuoteLatency~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_81457_INFURA_call_SUCCESS~'.~'.)~(~'.~'RPC_GATEWAY_81457_QUIKNODE_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_81457_QUIKNODE_call_SUCCESS~'.~'.)~(~'.~'RPC_GATEWAY_81457_INFURA_call_FAILED~'.~'.~(visible~false)))~view~'timeSeries~stacked~false~region~'us-east-2~start~'-PT12H~end~'P0D~period~60~stat~'Sum)&query=~'*7bUniswap*2cService*7d*2042220*20RPC*20CALL) only shows minimum increase, which is important because when we live switch, we don't expect to see any further more RPC calls due to our optimized implementations:
![Screenshot 2024-04-25 at 10.04.45 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/2a2d18e7-d601-4c51-84dd-5a7ea05f2323.png)

