### PR TITLE
feat: live switch polygon quote for 100 percent

### DIFF
--- a/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
+++ b/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
@@ -54,9 +54,9 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
     case ChainId.POLYGON:
       // Total RPM for 'QuoteTotalCallsToProvider' is around 20k-30k (across all chains), so 0.1% means 20-30 RPM shadow sampling
       return {
-        switchExactInPercentage: 1,
+        switchExactInPercentage: 100,
         samplingExactInPercentage: 0,
-        switchExactOutPercentage: 1,
+        switchExactOutPercentage: 100,
         samplingExactOutPercentage: 0,
       } as QuoteProviderTrafficSwitchConfiguration
     case ChainId.OPTIMISM:


### PR DESCRIPTION
We check the following metrics before we decide to increase traffic switch on Polygon:

- Is Polygon live traffic switched at 1%?
Based on the [metrics](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~(expression~'*28m1*2bm2*29*2f*28m1*2bm2*2bm3*2bm4*29*2a100~label~'Polygon*20sampling*20percent~id~'e1~period~900))~(~(expression~'*28m5*2bm6*29*2f*28m5*2bm6*2bm7*2bm8*29*2a100~label~'Polygon*20traffic*20switch*20percent~id~'e2~period~900))~(~'Uniswap~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_SAMPLING_CHAIN_ID_137~'Service~'RoutingAPI~(id~'m1~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_SAMPLING_CHAIN_ID_137~'.~'.~(id~'m2~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_TOTAL_CHAIN_ID_137~'.~'.~(id~'m3~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_TOTAL_CHAIN_ID_137~'.~'.~(id~'m4~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_CHAIN_ID_137~'.~'.~(id~'m7~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_CURRENT_CHAIN_ID_137~'.~'.~(id~'m8~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_TARGET_CHAIN_ID_137~'.~'.~(id~'m5~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_TARGET_CHAIN_ID_137~'.~'.~(id~'m6~visible~false)))~view~'timeSeries~stacked~false~region~'us-east-2~period~900~stat~'Sum~start~'-PT24H~end~'P0D)&query=~'*7bUniswap*2cService*7d*20_TRAFFIC_TARGET_CHAIN_ID_), this appears to be the same:
![Screenshot 2024-04-25 at 10.39.51 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/ac79a791-4781-41ce-94e2-650902adbcc3.png)

- Is the success rate on the Polygon endpoint?
Polygon endpoint shows the consistently high success rate:
![Screenshot 2024-04-25 at 10.42.31 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/8a28030e-e219-46d1-9235-0b3d03578351.png)

- Is the latency on the Polygon endpoint consistent?
Polygon latency is consistent:
![Screenshot 2024-04-25 at 10.42.31 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/54274a0f-3b1b-4811-a594-f471f2783f53.png)

- Is the RPC call volume only slightly up after quote shadow sampling on Polygon?
[Polygon RPC call volume](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~'Uniswap~'ChainId_137_V3QuoterQuoteLatency~'Service~'RoutingAPI~(visible~false))~(~'.~'ChainId_137_ShadowV3QuoterQuoteLatency~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_137_INFURA_call_SUCCESS~'.~'.)~(~'.~'RPC_GATEWAY_137_QUIKNODE_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_137_QUIKNODE_call_SUCCESS~'.~'.)~(~'.~'RPC_GATEWAY_137_INFURA_call_FAILED~'.~'.~(visible~false)))~view~'timeSeries~stacked~false~region~'us-east-2~start~'-PT12H~end~'P0D~period~60~stat~'Sum)&query=~'*7bUniswap*2cService*7d*2042220*20RPC*20CALL) only shows minimum increase, which is important because when we live switch, we don't expect to see any further more RPC calls due to our optimized implementations:
![Screenshot 2024-04-25 at 10.44.43 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/6bd723c0-e69e-46e6-92b0-88e477791636.png)

