### PR TITLE
feat: live switch arbitrum quote for 100 percent

### DIFF
--- a/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
+++ b/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
@@ -46,9 +46,9 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
     case ChainId.ARBITRUM_ONE:
       // Arbitrum RPC eth_call traffic is about half of mainnet, so we can shadow sample 0.2% of traffic
       return {
-        switchExactInPercentage: 1,
+        switchExactInPercentage: 100,
         samplingExactInPercentage: 0,
-        switchExactOutPercentage: 1,
+        switchExactOutPercentage: 100,
         samplingExactOutPercentage: 0,
       } as QuoteProviderTrafficSwitchConfiguration
     case ChainId.POLYGON:


### PR DESCRIPTION
We check the following metrics before we decide to increase traffic switch on Arbitrum:

- Is Arbitrum live traffic switched at 1%?
Based on the [metrics](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~(expression~'*28m1*2bm2*29*2f*28m1*2bm2*2bm3*2bm4*29*2a100~label~'Arbitrum*20sampling*20percent~id~'e1~period~60))~(~(expression~'*28m5*2bm6*29*2f*28m5*2bm6*2bm7*2bm8*29*2a100~label~'Arbitrum*20traffic*20switch*20percent~id~'e2~period~60))~(~'Uniswap~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_SAMPLING_CHAIN_ID_42161~'Service~'RoutingAPI~(id~'m1~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_SAMPLING_CHAIN_ID_42161~'.~'.~(id~'m2~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_TOTAL_CHAIN_ID_42161~'.~'.~(id~'m3~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_TOTAL_CHAIN_ID_42161~'.~'.~(id~'m4~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_CHAIN_ID_42161~'.~'.~(id~'m7~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_CURRENT_CHAIN_ID_42161~'.~'.~(id~'m8~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_TARGET_CHAIN_ID_42161~'.~'.~(id~'m5~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_TARGET_CHAIN_ID_42161~'.~'.~(id~'m6~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MATCH_CHAIN_ID_42161~'.~'.~(id~'m9~visible~false))~(~'.~'ChainId_42161_Shadow_QuoterQuoteBatchSize_arbitrum-mainnet~'.~'.~(id~'m10~visible~false))~(~'.~'ChainId_42161_Shadow_QuoterQuoteExpectedCallsToProvider~'.~'.~(id~'m11~visible~false))~(~'.~'ChainId_42161_Shadow_QuoterQuoteLatency~'.~'.~(id~'m12~visible~false))~(~'.~'ChainId_42161_Shadow_QuoterQuoteBatchSize~'.~'.~(id~'m13~visible~false))~(~'.~'ChainId_42161_Shadow_QuoterQuoteNumRetryLoops~'.~'.~(id~'m14~visible~false))~(~'.~'ChainId_42161_Shadow_QuoterQuoteApproxGasUsedPerSuccessfulCall~'.~'.~(id~'m15~visible~false))~(~'.~'ChainId_42161_Shadow_QuoterQuoteTotalCallsToProvider~'.~'.~(id~'m16~visible~false))~(~'.~'ChainId_42161_Shadow_QuoterQuoteNumRetriedCalls~'.~'.~(id~'m17~visible~false))~(~'.~'ChainId_42161_V3QuoterQuoteBatchSize_arbitrum-mainnet~'.~'.~(id~'m19~visible~false))~(~'.~'ChainId_42161_V3QuoterQuoteTotalCallsToProvider~'.~'.~(id~'m21~visible~false))~(~'.~'ChainId_42161_V3QuoterQuoteNumRetriedCalls~'.~'.~(id~'m22~visible~false))~(~'.~'ChainId_42161_V3QuoterQuoteBatchSize~'.~'.~(id~'m23~visible~false))~(~'.~'ChainId_42161_V3QuoterQuoteExpectedCallsToProvider~'.~'.~(id~'m24~visible~false))~(~'.~'ChainId_42161_V3QuoterQuoteNumRetryLoops~'.~'.~(id~'m25~visible~false)))~view~'timeSeries~stacked~false~region~'us-east-2~period~60~stat~'Sum~start~'-PT24H~end~'P0D)&query=~'*7bUniswap*2cService*7d*2042161*20Quoter*20Quote*20V3), this appears to be the same:
![Screenshot 2024-04-25 at 2.42.05 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/9afb47c9-92ee-4e8f-950b-c004dfa3ebeb.png)

- Is the success rate on the Arbitrum endpoint?
Arbitrum endpoint shows the consistently high success rate:
![Screenshot 2024-04-25 at 2.43.04 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/2abac991-ba29-43c5-8da7-905fe2fc1548.png)

- Is the latency on the Arbitrum endpoint consistent?
Arbitrum latency is consistent:
![Screenshot 2024-04-25 at 2.43.57 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/1fe965b6-4cb6-472f-a15c-f8353f3bc5c4.png)

- Is the RPC call volume only slightly up after quote shadow sampling on Arbitrum?
[Arbitrum RPC call volume](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~'Uniswap~'ChainId_42161_V3QuoterQuoteLatency~'Service~'RoutingAPI~(visible~false))~(~'.~'ChainId_42161_ShadowV3QuoterQuoteLatency~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_42161_INFURA_call_SUCCESS~'.~'.)~(~'.~'RPC_GATEWAY_42161_QUIKNODE_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_42161_QUIKNODE_call_SUCCESS~'.~'.)~(~'.~'RPC_GATEWAY_42161_INFURA_call_FAILED~'.~'.~(visible~false)))~view~'timeSeries~stacked~false~region~'us-east-2~start~'-PT12H~end~'P0D~period~60~stat~'Sum)&query=~'*7bUniswap*2cService*7d*2042220*20RPC*20CALL) only shows minimum increase, which is important because when we live switch, we don't expect to see any further more RPC calls due to our optimized implementations:
![Screenshot 2024-04-25 at 2.44.59 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/d6144955-3d2b-424c-ae05-c4a0fc781eb3.png)

