### PR TITLE
feat: live switch base quote for 100 percent

### DIFF
--- a/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
+++ b/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
@@ -30,9 +30,9 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
     case ChainId.BASE:
       // Base RPC eth_call traffic is about double mainnet, so we can shadow sample 0.05% of traffic
       return {
-        switchExactInPercentage: 1,
+        switchExactInPercentage: 100,
         samplingExactInPercentage: 0,
-        switchExactOutPercentage: 1,
+        switchExactOutPercentage: 100,
         samplingExactOutPercentage: 0,
       } as QuoteProviderTrafficSwitchConfiguration
     case ChainId.MAINNET:


### PR DESCRIPTION
We check the following metrics before we decide to increase traffic switch on Base:

- Is Base live traffic switched at 1%?
Based on the [metrics](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~(expression~'*28m1*2bm2*29*2f*28m1*2bm2*2bm3*2bm4*29*2a100~label~'Base*20sampling*20percent~id~'e1~period~900))~(~(expression~'*28m5*2bm6*29*2f*28m5*2bm6*2bm7*2bm8*29*2a100~label~'Base*20traffic*20switch*20percent~id~'e2~period~900))~(~'Uniswap~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_SAMPLING_CHAIN_ID_8453~'Service~'RoutingAPI~(id~'m1~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_SAMPLING_CHAIN_ID_8453~'.~'.~(id~'m2~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_TOTAL_CHAIN_ID_8453~'.~'.~(id~'m3~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_TOTAL_CHAIN_ID_8453~'.~'.~(id~'m4~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_CHAIN_ID_8453~'.~'.~(id~'m7~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_CURRENT_CHAIN_ID_8453~'.~'.~(id~'m8~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_TARGET_CHAIN_ID_8453~'.~'.~(id~'m5~visible~false))~(~'.~'ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_TARGET_CHAIN_ID_8453~'.~'.~(id~'m6~visible~false)))~view~'timeSeries~stacked~false~region~'us-east-2~period~900~stat~'Sum~start~'-PT24H~end~'P0D)&query=~'*7bUniswap*2cService*7d*20_TRAFFIC_TARGET_CHAIN_ID_8453), this appears to be the same:
![Screenshot 2024-04-25 at 3.57.32 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/b4eb0520-b1d3-4d48-97f9-ba2883d21f34.png)

- Is the success rate on the Base endpoint?
Base endpoint shows the consistently high success rate:
![Screenshot 2024-04-25 at 4.10.33 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/e46771b4-f8c3-4aed-bb1d-13f3269b0003.png)

- Is the latency on the Base endpoint consistent?
Base latency is consistent:
![Screenshot 2024-04-25 at 4.05.50 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/5c4de423-37c3-44fd-9f00-925c8877e48c.png)

- Is the RPC call volume only slightly up after quote shadow sampling on Base?
[Base RPC call volume](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~'Uniswap~'ChainId_8453_V3QuoterQuoteLatency~'Service~'RoutingAPI~(visible~false))~(~'.~'ChainId_8453_ShadowV3QuoterQuoteLatency~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_8453_INFURA_call_SUCCESS~'.~'.)~(~'.~'RPC_GATEWAY_8453_QUIKNODE_call_FAILED~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_8453_QUIKNODE_call_SUCCESS~'.~'.)~(~'.~'RPC_GATEWAY_8453_INFURA_call_FAILED~'.~'.~(visible~false)))~view~'timeSeries~stacked~false~region~'us-east-2~start~'-PT12H~end~'P0D~period~60~stat~'Sum)&query=~'*7bUniswap*2cService*7d*2042220*20RPC*20CALL) only shows minimum increase, which is important because when we live switch, we don't expect to see any further more RPC calls due to our optimized implementations:
![Screenshot 2024-04-25 at 4.14.58 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/3982d517-11eb-4489-9211-59179666d198.png)
