### PR TITLE
shadow sample mixed quoter on Base at 1%

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -305,7 +305,9 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
                 BLOCK_NUMBER_CONFIGS[chainId],
                 // We will only enable shadow sample mixed quoter on Base
                 (useMixedRouteQuoter: boolean) =>
-                  useMixedRouteQuoter ? '0xe544efae946f0008ae9a8d64493efa7886b73776' : NEW_QUOTER_V2_ADDRESSES[chainId],
+                  useMixedRouteQuoter
+                    ? MIXED_ROUTE_QUOTER_V1_ADDRESSES[chainId] ?? '0xe544efae946f0008ae9a8d64493efa7886b73776'
+                    : NEW_QUOTER_V2_ADDRESSES[chainId]
               )
               const targetQuoteProvider = new OnChainQuoteProvider(
                 chainId,

--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -62,6 +62,7 @@ import {
   BATCH_PARAMS,
   BLOCK_NUMBER_CONFIGS,
   GAS_ERROR_FAILURE_OVERRIDES,
+  NEW_MIXED_ROUTE_QUOTER_V1_ADDRESSES,
   RETRY_OPTIONS,
   SUCCESS_RATE_FAILURE_OVERRIDES,
 } from '../util/onChainQuoteProviderConfigs'
@@ -305,9 +306,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
                 BLOCK_NUMBER_CONFIGS[chainId],
                 // We will only enable shadow sample mixed quoter on Base
                 (useMixedRouteQuoter: boolean) =>
-                  useMixedRouteQuoter
-                    ? MIXED_ROUTE_QUOTER_V1_ADDRESSES[chainId] ?? '0xe544efae946f0008ae9a8d64493efa7886b73776'
-                    : NEW_QUOTER_V2_ADDRESSES[chainId]
+                  useMixedRouteQuoter ? NEW_MIXED_ROUTE_QUOTER_V1_ADDRESSES[chainId] : NEW_QUOTER_V2_ADDRESSES[chainId]
               )
               const targetQuoteProvider = new OnChainQuoteProvider(
                 chainId,

--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -302,7 +302,10 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
                 BATCH_PARAMS[chainId],
                 GAS_ERROR_FAILURE_OVERRIDES[chainId],
                 SUCCESS_RATE_FAILURE_OVERRIDES[chainId],
-                BLOCK_NUMBER_CONFIGS[chainId]
+                BLOCK_NUMBER_CONFIGS[chainId],
+                // We will only enable shadow sample mixed quoter on Base
+                (useMixedRouteQuoter: boolean) =>
+                  useMixedRouteQuoter ? '0xe544efae946f0008ae9a8d64493efa7886b73776' : NEW_QUOTER_V2_ADDRESSES[chainId],
               )
               const targetQuoteProvider = new OnChainQuoteProvider(
                 chainId,

--- a/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
+++ b/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
@@ -31,17 +31,17 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
       // Base RPC eth_call traffic is about double mainnet, so we can shadow sample 0.05% of traffic
       return {
         switchExactInPercentage: 100,
-        samplingExactInPercentage: 0,
+        samplingExactInPercentage: 1,
         switchExactOutPercentage: 100,
-        samplingExactOutPercentage: 0,
+        samplingExactOutPercentage: 1,
       } as QuoteProviderTrafficSwitchConfiguration
     case ChainId.MAINNET:
       // Total RPM for 'QuoteTotalCallsToProvider' is around 20k-30k (across all chains), so 0.1% means 20-30 RPM shadow sampling
       return {
         switchExactInPercentage: 100,
-        samplingExactInPercentage: 1,
+        samplingExactInPercentage: 0,
         switchExactOutPercentage: 100,
-        samplingExactOutPercentage: 1,
+        samplingExactOutPercentage: 0,
       } as QuoteProviderTrafficSwitchConfiguration
     case ChainId.ARBITRUM_ONE:
       // Arbitrum RPC eth_call traffic is about half of mainnet, so we can shadow sample 0.2% of traffic

--- a/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
+++ b/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
@@ -39,9 +39,9 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
       // Total RPM for 'QuoteTotalCallsToProvider' is around 20k-30k (across all chains), so 0.1% means 20-30 RPM shadow sampling
       return {
         switchExactInPercentage: 100,
-        samplingExactInPercentage: 0,
+        samplingExactInPercentage: 1,
         switchExactOutPercentage: 100,
-        samplingExactOutPercentage: 0,
+        samplingExactOutPercentage: 1,
       } as QuoteProviderTrafficSwitchConfiguration
     case ChainId.ARBITRUM_ONE:
       // Arbitrum RPC eth_call traffic is about half of mainnet, so we can shadow sample 0.2% of traffic

--- a/lib/util/onChainQuoteProviderConfigs.ts
+++ b/lib/util/onChainQuoteProviderConfigs.ts
@@ -10,9 +10,9 @@ import {
   DEFAULT_RETRY_OPTIONS,
   DEFAULT_SUCCESS_RATE_FAILURE_OVERRIDES,
 } from '@uniswap/smart-order-router/build/main/util/onchainQuoteProviderConfigs'
-import { ChainId } from '@uniswap/sdk-core'
+import { CHAIN_TO_ADDRESSES_MAP, ChainId } from '@uniswap/sdk-core'
 import AsyncRetry from 'async-retry'
-import { BatchParams, BlockNumberConfig, FailureOverrides } from '@uniswap/smart-order-router'
+import { AddressMap, BatchParams, BlockNumberConfig, FailureOverrides } from '@uniswap/smart-order-router'
 
 export const RETRY_OPTIONS: { [chainId: number]: AsyncRetry.Options | undefined } = {
   ...constructSameRetryOptionsMap(DEFAULT_RETRY_OPTIONS),
@@ -209,4 +209,11 @@ export const LIKELY_OUT_OF_GAS_THRESHOLD: { [chainId in ChainId]: number } = {
   [ChainId.ZORA_SEPOLIA]: 0,
   [ChainId.ROOTSTOCK]: 0,
   [ChainId.BLAST]: 17540 * 2, // 17540 is the single tick.cross cost on blast. We multiply by 2 to be safe
+}
+
+// TODO: Move this new addresses to SOR
+export const NEW_MIXED_ROUTE_QUOTER_V1_ADDRESSES: AddressMap = {
+  [ChainId.MAINNET]: CHAIN_TO_ADDRESSES_MAP[ChainId.MAINNET].v1MixedRouteQuoterAddress,
+  [ChainId.GOERLI]: CHAIN_TO_ADDRESSES_MAP[ChainId.GOERLI].v1MixedRouteQuoterAddress,
+  [ChainId.BASE]: '0xe544efae946f0008ae9a8d64493efa7886b73776',
 }


### PR DESCRIPTION
### TL;DR

This pull request introduces changes that enable shadow sample mixed quoter on Base.

### What changed?

The code now includes logic to use a different quoter ('0xe544efae946f0008ae9a8d64493efa7886b73776') when the useMixedRouteQuoter flag is enabled.

### How to test?

Test by setting the useMixedRouteQuoter to true and observe if the shadow sample mixed quoter is being used.

### Why make this change?

Because we want to try out the mixed quoter on Base, before we proceed to support mixed quoting on different L2s.

---

