### PR TITLE
feat: download compressed s3 pools with fallback

### DIFF
--- a/bin/stacks/routing-caching-stack.ts
+++ b/bin/stacks/routing-caching-stack.ts
@@ -16,6 +16,7 @@ import { Construct } from 'constructs'
 import * as path from 'path'
 import { chainProtocols } from '../../lib/cron/cache-config'
 import { STAGE } from '../../lib/util/stage'
+import { PoolCachingFilePrefixes } from '../../lib/util/poolCachingFilePrefixes'
 
 export interface RoutingCachingStackProps extends cdk.NestedStackProps {
   stage: string
@@ -73,8 +74,8 @@ export class RoutingCachingStack extends cdk.NestedStack {
       expiration: cdk.Duration.days(365 * 10),
     })
 
-    this.poolCacheKey = 'poolCache.json'
-    this.poolCacheGzipKey = 'poolCacheGzip.json'
+    this.poolCacheKey = PoolCachingFilePrefixes.PlainText
+    this.poolCacheGzipKey = PoolCachingFilePrefixes.GzipText
 
     const { stage, route53Arn, pinata_key, pinata_secret, hosted_zone } = props
 

--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -20,8 +20,6 @@ import {
   IV3PoolProvider,
   IV3SubgraphProvider,
   LegacyGasPriceProvider,
-  metric,
-  MetricLoggerUnit,
   MIXED_ROUTE_QUOTER_V1_ADDRESSES,
   NEW_QUOTER_V2_ADDRESSES,
   NodeJSCache,
@@ -271,7 +269,6 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
                       { err },
                       'compressed s3 subgraph pool caching unavailable, fall back to the existing s3 subgraph pool caching'
                     )
-                    metric.putMetric('V3SubgraphProviderPlainTextFallback', 1, MetricLoggerUnit.Count)
 
                     return await V3AWSSubgraphProvider.EagerBuild(POOL_CACHE_BUCKET_2!, POOL_CACHE_KEY!, chainId)
                   })
@@ -300,7 +297,6 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
                       { err },
                       'compressed s3 subgraph pool caching unavailable, fall back to the existing s3 subgraph pool caching'
                     )
-                    metric.putMetric('V2SubgraphProviderPlainTextFallback', 1, MetricLoggerUnit.Count)
 
                     return await V2AWSSubgraphProvider.EagerBuild(POOL_CACHE_BUCKET_2!, POOL_CACHE_KEY!, chainId)
                   })

--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -20,6 +20,8 @@ import {
   IV3PoolProvider,
   IV3SubgraphProvider,
   LegacyGasPriceProvider,
+  metric,
+  MetricLoggerUnit,
   MIXED_ROUTE_QUOTER_V1_ADDRESSES,
   NEW_QUOTER_V2_ADDRESSES,
   NodeJSCache,
@@ -269,6 +271,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
                       { err },
                       'compressed s3 subgraph pool caching unavailable, fall back to the existing s3 subgraph pool caching'
                     )
+                    metric.putMetric('V3SubgraphProviderPlainTextFallback', 1, MetricLoggerUnit.Count)
 
                     return await V3AWSSubgraphProvider.EagerBuild(POOL_CACHE_BUCKET_2!, POOL_CACHE_KEY!, chainId)
                   })
@@ -297,6 +300,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
                       { err },
                       'compressed s3 subgraph pool caching unavailable, fall back to the existing s3 subgraph pool caching'
                     )
+                    metric.putMetric('V2SubgraphProviderPlainTextFallback', 1, MetricLoggerUnit.Count)
 
                     return await V2AWSSubgraphProvider.EagerBuild(POOL_CACHE_BUCKET_2!, POOL_CACHE_KEY!, chainId)
                   })

--- a/lib/util/poolCachingFilePrefixes.ts
+++ b/lib/util/poolCachingFilePrefixes.ts
@@ -1,0 +1,4 @@
+export const PoolCachingFilePrefixes = {
+  PlainText: 'poolCache.json',
+  GzipText: 'poolCacheGzip.json',
+}


### PR DESCRIPTION
In this part, we will download the compressed s3 pool files and decompress them in-memory, with the fallback to the plain-text s3 pool files.

I cross checked the pool sizes between the plain text and compressed
- mainnet V2 subgraph
<img width="1194" alt="Screenshot 2024-05-07 at 2 41 03 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/4374b607-b0a3-42d9-b9fd-feabdda4e725">
<img width="1169" alt="Screenshot 2024-05-07 at 2 41 07 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/8f6063d1-4d02-4f5c-a629-35fa604b94ae">

- mainnet V3 subgraph
<img width="1179" alt="Screenshot 2024-05-07 at 2 41 39 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/c9d8896e-e66b-4db6-8bf1-161b1cb87028">
<img width="1194" alt="Screenshot 2024-05-07 at 2 41 47 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/9fa2186c-f459-43fb-af19-bcfff9906adb">

- base V3 subgraph
<img width="1192" alt="Screenshot 2024-05-07 at 2 42 01 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/27d0e81d-ff3e-4c02-8fc7-b967dff4d168">
<img width="1165" alt="Screenshot 2024-05-07 at 2 42 17 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/ed55bc39-5ec4-4e38-826b-42cda3496f33">

and they all look aligned.

In addition, because we are adding this additional fallback logic per chain, in case some chains don't have the subgraph pool s3 files, they will take longer to fallback to static subgraph provider. We will preemptively check whether the cache-config contains the subgraph for such chain and such protocol version. If not, we fail fast to the static subgraph provider.