### PR TITLE
shadow sample mixed quoter on base at 100%

### DIFF
--- a/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
+++ b/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
@@ -31,9 +31,9 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
       // Base RPC eth_call traffic is about double mainnet, so we can shadow sample 0.05% of traffic
       return {
         switchExactInPercentage: 100,
-        samplingExactInPercentage: 1,
+        samplingExactInPercentage: 100,
         switchExactOutPercentage: 100,
-        samplingExactOutPercentage: 1,
+        samplingExactOutPercentage: 100,
       } as QuoteProviderTrafficSwitchConfiguration
     case ChainId.MAINNET:
       // Total RPM for 'QuoteTotalCallsToProvider' is around 20k-30k (across all chains), so 0.1% means 20-30 RPM shadow sampling


### PR DESCRIPTION
At 1% shadow sampling mixed quoter on Base, there's no traffic at all:
<img width="1288" alt="Screenshot 2024-05-08 at 8 22 30 AM" src="https://github.com/Uniswap/routing-api/assets/91580504/95fe4ab3-33fd-4431-a558-73dba54cfcd1">


I want to increase to 100%, to see how many prod traffic will go through mixed routes, if at all.