### PR TITLE
tune provisioned concurrency back down to 1 for beta

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -229,7 +229,7 @@ export class RoutingAPIPipeline extends Stack {
       env: { account: '145079444317', region: 'us-east-2' },
       jsonRpcProviders: jsonRpcProviders,
       internalApiKey: internalApiKey.secretValue.toString(),
-      provisionedConcurrency: 10,
+      provisionedConcurrency: 1,
       ethGasStationInfoUrl: ethGasStationInfoUrl.secretValue.toString(),
       stage: STAGE.BETA,
       route53Arn: route53Arn.secretValueFromJson('arn').toString(),


### PR DESCRIPTION
Now that we've addressed the cold start via compressing the pool s3 files, we should be able to let beta integ-test consistently pass by hosting beta lambda at provisioned concurrency of 1.