### PR TITLE
chore: sample celo avax 1 percent

### DIFF
--- a/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
+++ b/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
@@ -87,17 +87,17 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
       // Celo RPC eth_call traffic is about 1/100 of mainnet, so we can shadow sample 10% of traffic
       return {
         switchExactInPercentage: 100,
-        samplingExactInPercentage: 0,
+        samplingExactInPercentage: 1,
         switchExactOutPercentage: 100,
-        samplingExactOutPercentage: 0,
+        samplingExactOutPercentage: 1,
       } as QuoteProviderTrafficSwitchConfiguration
     case ChainId.AVALANCHE:
       // Avalanche RPC eth_call traffic is about 1/100 of mainnet, so we can shadow sample 10% of traffic
       return {
         switchExactInPercentage: 100,
-        samplingExactInPercentage: 0,
+        samplingExactInPercentage: 1,
         switchExactOutPercentage: 100,
-        samplingExactOutPercentage: 0,
+        samplingExactOutPercentage: 1,
       } as QuoteProviderTrafficSwitchConfiguration
     // If we accidentally switch a traffic, we have the protection to shadow sample only 0.1% of traffic
     default:


### PR DESCRIPTION
I realized we have to sample celo and avax at some percent. The reason is because celo and avax doesn't have the non-shadow gas metrics for comparison:
<img width="1278" alt="Screenshot 2024-05-08 at 12 00 36 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/f2216584-d163-4fb1-8aab-5dc76cc56d03">
<img width="1279" alt="Screenshot 2024-05-08 at 12 00 29 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/32cece2a-9254-4f8a-82c8-f0274293aa4d">


This contrasts with other network, which has both non-shadow and shadow gas metrics for comparison, and for easy gas param tuning, for example on Base:
<img width="1266" alt="Screenshot 2024-05-08 at 12 00 44 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/bcdd22c0-09fe-41fe-9cd5-78455665dd69">
