### PR TITLE
feat: enable mixed quote on base at 100%

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -25,6 +25,7 @@ import {
   NodeJSCache,
   OnChainGasPriceProvider,
   OnChainQuoteProvider,
+  QUOTER_V2_ADDRESSES,
   setGlobalLogger,
   Simulator,
   StaticV2SubgraphProvider,
@@ -340,7 +341,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
                 BLOCK_NUMBER_CONFIGS[chainId],
                 // We will only enable shadow sample mixed quoter on Base
                 (useMixedRouteQuoter: boolean) =>
-                  useMixedRouteQuoter ? NEW_MIXED_ROUTE_QUOTER_V1_ADDRESSES[chainId] : NEW_QUOTER_V2_ADDRESSES[chainId]
+                  useMixedRouteQuoter ? MIXED_ROUTE_QUOTER_V1_ADDRESSES[chainId] : QUOTER_V2_ADDRESSES[chainId]
               )
               const targetQuoteProvider = new OnChainQuoteProvider(
                 chainId,
@@ -352,7 +353,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
                 SUCCESS_RATE_FAILURE_OVERRIDES[chainId],
                 BLOCK_NUMBER_CONFIGS[chainId],
                 (useMixedRouteQuoter: boolean) =>
-                  useMixedRouteQuoter ? MIXED_ROUTE_QUOTER_V1_ADDRESSES[chainId] : NEW_QUOTER_V2_ADDRESSES[chainId],
+                  useMixedRouteQuoter ? NEW_MIXED_ROUTE_QUOTER_V1_ADDRESSES[chainId] : NEW_QUOTER_V2_ADDRESSES[chainId],
                 (chainId: ChainId, useMixedRouteQuoter: boolean) =>
                   useMixedRouteQuoter ? `ChainId_${chainId}_ShadowMixedQuoter` : `ChainId_${chainId}_ShadowV3Quoter`
               )

--- a/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
+++ b/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
@@ -31,9 +31,9 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
       // Base RPC eth_call traffic is about double mainnet, so we can shadow sample 0.05% of traffic
       return {
         switchExactInPercentage: 100,
-        samplingExactInPercentage: 100,
+        samplingExactInPercentage: 0,
         switchExactOutPercentage: 100,
-        samplingExactOutPercentage: 100,
+        samplingExactOutPercentage: 0,
       } as QuoteProviderTrafficSwitchConfiguration
     case ChainId.MAINNET:
       // Total RPM for 'QuoteTotalCallsToProvider' is around 20k-30k (across all chains), so 0.1% means 20-30 RPM shadow sampling


### PR DESCRIPTION
We see some shadow mixed quotes on Base since I started in April 26th https://github.com/Uniswap/routing-api/pull/645:
![Screenshot 2024-05-08 at 10 30 36 AM](https://github.com/Uniswap/routing-api/assets/91580504/12c968af-e3f2-4cc1-aeb0-99c727ed11ee)

Now we want to enable the mixed quotes on Base, so as to see how many more mixed quotes are now returned:
![Screenshot 2024-05-08 at 11 06 57 AM](https://github.com/Uniswap/routing-api/assets/91580504/a5da0cdf-c6d9-41b5-b886-5dd429a88c5e)

This indicates how much mixed quoter on Base improved the quotes.