### PR TITLE
feat: tune Celo batch param for gas limit and multichunk size

### DIFF
--- a/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
+++ b/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
@@ -87,9 +87,9 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
       // Celo RPC eth_call traffic is about 1/100 of mainnet, so we can shadow sample 10% of traffic
       return {
         switchExactInPercentage: 100,
-        samplingExactInPercentage: 1,
+        samplingExactInPercentage: 0,
         switchExactOutPercentage: 100,
-        samplingExactOutPercentage: 1,
+        samplingExactOutPercentage: 0,
       } as QuoteProviderTrafficSwitchConfiguration
     case ChainId.AVALANCHE:
       // Avalanche RPC eth_call traffic is about 1/100 of mainnet, so we can shadow sample 10% of traffic

--- a/lib/util/onChainQuoteProviderConfigs.ts
+++ b/lib/util/onChainQuoteProviderConfigs.ts
@@ -61,8 +61,8 @@ export const BATCH_PARAMS: { [chainId: number]: BatchParams } = {
     quoteMinSuccessRate: 0.1,
   },
   [ChainId.CELO]: {
-    multicallChunk: 10,
-    gasLimitPerCall: 5_000_000,
+    multicallChunk: 16,
+    gasLimitPerCall: 3_000_000,
     quoteMinSuccessRate: 0.1,
   },
   [ChainId.BLAST]: {

--- a/lib/util/onChainQuoteProviderConfigs.ts
+++ b/lib/util/onChainQuoteProviderConfigs.ts
@@ -62,7 +62,7 @@ export const BATCH_PARAMS: { [chainId: number]: BatchParams } = {
   },
   [ChainId.CELO]: {
     multicallChunk: 16,
-    gasLimitPerCall: 3_000_000,
+    gasLimitPerCall: 3_120_000,
     quoteMinSuccessRate: 0.1,
   },
   [ChainId.BLAST]: {


### PR DESCRIPTION
We are ready to tune the gas batch params in Celo to see if it can speed up. If we check the gas used on P97, P98, P99 and max levels:
![Screenshot 2024-05-08 at 3.36.19 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/cd463451-2f0f-4211-9be5-b32c00df3e49.png)
![Screenshot 2024-05-08 at 3.36.33 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/94f14eac-f33d-4057-a0fb-dafcbd5da5a9.png)
![Screenshot 2024-05-08 at 3.36.41 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/90dbda34-7292-4e32-b842-a1173770195c.png)
![Screenshot 2024-05-08 at 3.36.55 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/299b25fc-3d2f-49ff-bdb0-881e60924bfe.png)

we see the gas used drops significantly at P98 level to around ~3M per call. Since current batch param sets gas limit per call at 5M, we can drop it to around ~3M. Then we can increase the multichunk size to make sure each multicall can shoehorn more quote calls, reducing the number of RPC calls to multicall. We need to ensure that gas limit per call * multichunk size remains constant, or smaller, but not larger. So we choose 31200000 * 16 = 499200000, or 4.9M.

We choose Celo first, since it's lowest risk, meanwhile the traffic volume should be good enough to see quote endpoint latency improvements, if any.