### PR TITLE
chore: stop sampling on avax

### DIFF
--- a/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
+++ b/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
@@ -95,9 +95,9 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
       // Avalanche RPC eth_call traffic is about 1/100 of mainnet, so we can shadow sample 10% of traffic
       return {
         switchExactInPercentage: 100,
-        samplingExactInPercentage: 1,
+        samplingExactInPercentage: 0,
         switchExactOutPercentage: 100,
-        samplingExactOutPercentage: 1,
+        samplingExactOutPercentage: 0,
       } as QuoteProviderTrafficSwitchConfiguration
     // If we accidentally switch a traffic, we have the protection to shadow sample only 0.1% of traffic
     default:


### PR DESCRIPTION
We no longer need to sample avax revert quoter, because we collected enough datapoints on how much gas used per call