### PR TITLE
fix: no on-chain quote retry for celo

### DIFF
--- a/lib/util/onChainQuoteProviderConfigs.ts
+++ b/lib/util/onChainQuoteProviderConfigs.ts
@@ -32,7 +32,7 @@ export const RETRY_OPTIONS: { [chainId: number]: AsyncRetry.Options | undefined 
     maxTimeout: 1000,
   },
   [ChainId.CELO]: {
-    retries: 2,
+    retries: 0,
     minTimeout: 100,
     maxTimeout: 1000,
   },


### PR DESCRIPTION
I think there's no need to retry failed on-chain quoter for Celo. If we look at max:
![Screenshot 2024-05-09 at 9.43.08 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/56bc03c0-732d-42fb-b583-9f6bb4a0ad44.png)

this tells me in the worst case scenario, we always exhausted all the attempts (2), and also the first time batch param vs the low success rate param do not improve success rate at all (0% -> 0%).

Then looking at p95 and p98:
![Screenshot 2024-05-09 at 9.42.47 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/d807ed37-4a9e-4aaf-b57b-973d65423b20.png)
![Screenshot 2024-05-09 at 9.42.59 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/84f98f1d-d3c6-4282-8cf9-8a1b4c16a3da.png)

It tells me, sometimes there's retry due to low success rate, otherwise it doesn't retry and just give up. In both cases, the success rate is low at 0%.

Eventually look at min:
![Screenshot 2024-05-09 at 9.48.06 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/bfc9a467-58d5-4af3-aa1a-c8a498f71957.png)

This tells me that the min quote success rate still stays at 0%, despite no retry loop.

All those metrics together tells me, whether we retry or not, for those failed on-chain quoting, they will fail regardless of retry attempts. Therefore, there's no point in retrying, and hopefully with no retry, this brings celo quote endpoint latency down.

