### PR TITLE
lower success rate threshold to 0 for celo

### DIFF
--- a/lib/util/onChainQuoteProviderConfigs.ts
+++ b/lib/util/onChainQuoteProviderConfigs.ts
@@ -63,7 +63,7 @@ export const BATCH_PARAMS: { [chainId: number]: BatchParams } = {
   [ChainId.CELO]: {
     multicallChunk: 16,
     gasLimitPerCall: 3_120_000,
-    quoteMinSuccessRate: 0.1,
+    quoteMinSuccessRate: 0,
   },
   [ChainId.BLAST]: {
     multicallChunk: 80,


### PR DESCRIPTION
In previous PR https://github.com/Uniswap/routing-api/pull/667, I made the mistake of not lowering the success rate threshold to 0 for celo. This resulted in some quote returning http 500. The reason is because with no retry, but non-zero success rate threshold, SOR will throw [SuccessRateError](https://github.com/Uniswap/smart-order-router/blob/main/src/providers/on-chain-quote-provider.ts#L1072) now. I can repro via https://app.warp.dev/block/pkX8kMjwbWjrnPqcDrWG1d.

To fix, I will also lower the success rate threshold to 0, so that the error should no longer be repro-able https://app.warp.dev/block/XKXnXk9Fy2MpG7fpA4efov.

Since our beta pipeline only tests the basic quote on CELO, it won't touch the case where the first time on-chain quoting fails, so I explicitly disabled prod transition, until I merge this PR in.