### PR TITLE
Log optimistic cached routes on-chain quoting metrics

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -354,8 +354,10 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
                 BLOCK_NUMBER_CONFIGS[chainId],
                 (useMixedRouteQuoter: boolean) =>
                   useMixedRouteQuoter ? NEW_MIXED_ROUTE_QUOTER_V1_ADDRESSES[chainId] : NEW_QUOTER_V2_ADDRESSES[chainId],
-                (chainId: ChainId, useMixedRouteQuoter: boolean) =>
-                  useMixedRouteQuoter ? `ChainId_${chainId}_ShadowMixedQuoter` : `ChainId_${chainId}_ShadowV3Quoter`
+                (chainId: ChainId, useMixedRouteQuoter: boolean, optimisticCachedRoutes: boolean) =>
+                  useMixedRouteQuoter
+                    ? `ChainId_${chainId}_ShadowMixedQuoter_OptimisticCachedRoutes${optimisticCachedRoutes}_`
+                    : `ChainId_${chainId}_ShadowV3Quoter_OptimisticCachedRoutes${optimisticCachedRoutes}_`
               )
               quoteProvider = new TrafficSwitchOnChainQuoteProvider({
                 currentQuoteProvider: currentQuoteProvider,

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@uniswap/permit2-sdk": "^1.2.0",
         "@uniswap/router-sdk": "^1.9.0",
         "@uniswap/sdk-core": "^4.2.0",
-        "@uniswap/smart-order-router": "3.28.12",
+        "@uniswap/smart-order-router": "3.28.13",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^1.8.1",
         "@uniswap/v2-sdk": "^4.3.0",
@@ -4745,9 +4745,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.28.12",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.28.12.tgz",
-      "integrity": "sha512-k23XQgax+yN9ZGcUDzT6uJGQCEx4MMvetsWJw+EjyKDwyh/12TpqF5WAmjw8vbeaMpokOQiMPP1B8UFU7xF5Sg==",
+      "version": "3.28.13",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.28.13.tgz",
+      "integrity": "sha512-/x712SiWXGwYcDElzBrx1X5Yla2mUJxi7LUouEYUYdyHZfuxUipIlZ+eCXeq7gZewciZ3/HvWvO/ttkYofBQXg==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -28379,9 +28379,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.28.12",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.28.12.tgz",
-      "integrity": "sha512-k23XQgax+yN9ZGcUDzT6uJGQCEx4MMvetsWJw+EjyKDwyh/12TpqF5WAmjw8vbeaMpokOQiMPP1B8UFU7xF5Sg==",
+      "version": "3.28.13",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.28.13.tgz",
+      "integrity": "sha512-/x712SiWXGwYcDElzBrx1X5Yla2mUJxi7LUouEYUYdyHZfuxUipIlZ+eCXeq7gZewciZ3/HvWvO/ttkYofBQXg==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@uniswap/router-sdk": "^1.9.0",
     "@uniswap/sdk-core": "^4.2.0",
     "@types/semver": "^7.5.8",
-    "@uniswap/smart-order-router": "3.28.12",
+    "@uniswap/smart-order-router": "3.28.13",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^1.8.1",
     "@uniswap/v2-sdk": "^4.3.0",


### PR DESCRIPTION
i was looking at routing dashboard. I can see caching intent quote latency is improving on Blast after gas param tuning, but not quote intent quote latency:

![Screenshot 2024-05-09 at 4.31.38 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/389d8b86-8dd3-4c20-b154-fe0939090d88.png)

![Screenshot 2024-05-09 at 4.31.50 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/2bd78c0f-330e-457c-9b25-e75dfd89dece.png)

![Screenshot 2024-05-09 at 4.32.06 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/69129581-badb-4056-bf42-3c128b54ed5e.png)

This tells me we need to tune the gas param for quote-intent onchain quoting more aggressively. Right now we don't distinguish the metrics between quote-intent vs caching-intent metrics in onchain quoting. We will do so by bumping SOR https://github.com/Uniswap/smart-order-router/pull/568