### PR TITLE
feat: tune gas param by optimistic cached routes and bump sor to v3.29.0

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -60,12 +60,13 @@ import { GlobalRpcProviders } from '../rpc/GlobalRpcProviders'
 import { StaticJsonRpcProvider } from '@ethersproject/providers'
 import { TrafficSwitchOnChainQuoteProvider } from './quote/provider-migration/v3/traffic-switch-on-chain-quote-provider'
 import {
-  BATCH_PARAMS,
+  NON_OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS,
   BLOCK_NUMBER_CONFIGS,
   GAS_ERROR_FAILURE_OVERRIDES,
   NEW_MIXED_ROUTE_QUOTER_V1_ADDRESSES,
   RETRY_OPTIONS,
   SUCCESS_RATE_FAILURE_OVERRIDES,
+  OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS,
 } from '../util/onChainQuoteProviderConfigs'
 import { v4 } from 'uuid/index'
 import { chainProtocols } from '../cron/cache-config'
@@ -335,7 +336,10 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
                 provider,
                 multicall2Provider,
                 RETRY_OPTIONS[chainId],
-                BATCH_PARAMS[chainId],
+                (optimisticCachedRoutes) =>
+                  optimisticCachedRoutes
+                    ? OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS[chainId]
+                    : NON_OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS[chainId],
                 GAS_ERROR_FAILURE_OVERRIDES[chainId],
                 SUCCESS_RATE_FAILURE_OVERRIDES[chainId],
                 BLOCK_NUMBER_CONFIGS[chainId],
@@ -348,7 +352,10 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
                 provider,
                 multicall2Provider,
                 RETRY_OPTIONS[chainId],
-                BATCH_PARAMS[chainId],
+                (optimisticCachedRoutes) =>
+                  optimisticCachedRoutes
+                    ? OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS[chainId]
+                    : NON_OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS[chainId],
                 GAS_ERROR_FAILURE_OVERRIDES[chainId],
                 SUCCESS_RATE_FAILURE_OVERRIDES[chainId],
                 BLOCK_NUMBER_CONFIGS[chainId],

--- a/lib/util/onChainQuoteProviderConfigs.ts
+++ b/lib/util/onChainQuoteProviderConfigs.ts
@@ -43,7 +43,7 @@ export const RETRY_OPTIONS: { [chainId: number]: AsyncRetry.Options | undefined 
   },
 }
 
-export const BATCH_PARAMS: { [chainId: number]: BatchParams } = {
+export const OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [chainId: number]: BatchParams } = {
   ...constructSameBatchParamsMap(DEFAULT_BATCH_PARAMS),
   [ChainId.BASE]: {
     multicallChunk: 110,
@@ -61,8 +61,42 @@ export const BATCH_PARAMS: { [chainId: number]: BatchParams } = {
     quoteMinSuccessRate: 0.1,
   },
   [ChainId.CELO]: {
-    multicallChunk: 16,
-    gasLimitPerCall: 3_120_000,
+    multicallChunk: 6240,
+    gasLimitPerCall: 80_000,
+    quoteMinSuccessRate: 0,
+  },
+  [ChainId.BLAST]: {
+    multicallChunk: 1200,
+    gasLimitPerCall: 80_000,
+    quoteMinSuccessRate: 0.1,
+  },
+  [ChainId.AVALANCHE]: {
+    multicallChunk: 2625,
+    gasLimitPerCall: 60_000,
+    quoteMinSuccessRate: 0.15,
+  },
+}
+
+export const NON_OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [chainId: number]: BatchParams } = {
+  ...constructSameBatchParamsMap(DEFAULT_BATCH_PARAMS),
+  [ChainId.BASE]: {
+    multicallChunk: 110,
+    gasLimitPerCall: 1_200_000,
+    quoteMinSuccessRate: 0.1,
+  },
+  [ChainId.ARBITRUM_ONE]: {
+    multicallChunk: 15,
+    gasLimitPerCall: 15_000_000,
+    quoteMinSuccessRate: 0.15,
+  },
+  [ChainId.OPTIMISM]: {
+    multicallChunk: 110,
+    gasLimitPerCall: 1_200_000,
+    quoteMinSuccessRate: 0.1,
+  },
+  [ChainId.CELO]: {
+    multicallChunk: 3120,
+    gasLimitPerCall: 160_000,
     quoteMinSuccessRate: 0,
   },
   [ChainId.BLAST]: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@uniswap/permit2-sdk": "^1.2.0",
         "@uniswap/router-sdk": "^1.9.0",
         "@uniswap/sdk-core": "^4.2.0",
-        "@uniswap/smart-order-router": "3.28.13",
+        "@uniswap/smart-order-router": "3.29.0",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^1.8.1",
         "@uniswap/v2-sdk": "^4.3.0",
@@ -4745,9 +4745,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.28.13",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.28.13.tgz",
-      "integrity": "sha512-/x712SiWXGwYcDElzBrx1X5Yla2mUJxi7LUouEYUYdyHZfuxUipIlZ+eCXeq7gZewciZ3/HvWvO/ttkYofBQXg==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.29.0.tgz",
+      "integrity": "sha512-Wim0KqdwSVBiEl1U5sg2SXkVHhs4kG7GsXo3WhoqqwIVDy1KEpjJUBAFR2uWMNX7a+3/imEabAlpysedx1ePug==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -28379,9 +28379,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.28.13",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.28.13.tgz",
-      "integrity": "sha512-/x712SiWXGwYcDElzBrx1X5Yla2mUJxi7LUouEYUYdyHZfuxUipIlZ+eCXeq7gZewciZ3/HvWvO/ttkYofBQXg==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.29.0.tgz",
+      "integrity": "sha512-Wim0KqdwSVBiEl1U5sg2SXkVHhs4kG7GsXo3WhoqqwIVDy1KEpjJUBAFR2uWMNX7a+3/imEabAlpysedx1ePug==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@uniswap/router-sdk": "^1.9.0",
     "@uniswap/sdk-core": "^4.2.0",
     "@types/semver": "^7.5.8",
-    "@uniswap/smart-order-router": "3.28.13",
+    "@uniswap/smart-order-router": "3.29.0",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^1.8.1",
     "@uniswap/v2-sdk": "^4.3.0",


### PR DESCRIPTION
Release SOR https://github.com/Uniswap/smart-order-router/pull/572.

On top of that, we will optimize the gas params for celo and avax even more. 

Celo P50 is:
![Screenshot 2024-05-13 at 10.14.55 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/c1d6fc1b-3f61-4fe6-8637-fe16e338e893.png)

Celo P75 is:
![Screenshot 2024-05-13 at 10.14.32 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/d9770ff8-ccee-4707-9d3c-ff108a62cfe3.png)

So Im going to lower gas limit to 80k for celo on optimistic cached routes path, which quote-intent quote endpoint.

Avax P50 is:
![Screenshot 2024-05-13 at 10.16.46 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/93360f6c-2b5c-4b3e-b455-4278d87173c5.png)

Avax P75 is:
![Screenshot 2024-05-13 at 10.17.39 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/f7587e4d-e31c-482e-ae60-a759ae262f63.png)

I will lower gas limit to 60k for avax on optimistic cached routes path, which quote-intent quote endpoint.
