### PR TITLE
feat: tune OP batch param for gas limit and multichunk size

### DIFF
--- a/lib/util/onChainQuoteProviderConfigs.ts
+++ b/lib/util/onChainQuoteProviderConfigs.ts
@@ -56,8 +56,8 @@ export const OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [chainId: number]: BatchPa
     quoteMinSuccessRate: 0.15,
   },
   [ChainId.OPTIMISM]: {
-    multicallChunk: 110,
-    gasLimitPerCall: 1_200_000,
+    multicallChunk: 1650,
+    gasLimitPerCall: 80_000,
     quoteMinSuccessRate: 0.1,
   },
   [ChainId.CELO]: {
@@ -90,8 +90,8 @@ export const NON_OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [chainId: number]: Bat
     quoteMinSuccessRate: 0.15,
   },
   [ChainId.OPTIMISM]: {
-    multicallChunk: 110,
-    gasLimitPerCall: 1_200_000,
+    multicallChunk: 880,
+    gasLimitPerCall: 150_000,
     quoteMinSuccessRate: 0.1,
   },
   [ChainId.CELO]: {


### PR DESCRIPTION
We are ready to tune the gas batch params in Op to see if it can speed up. If we check the gas used on P50:
![Screenshot 2024-05-13 at 11.17.12 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/dc2d3c10-752e-4325-a3b0-876aa0b1b9f5.png)

optimistic P50 gas limit is around ~80k per call, meanwhile non-optimistic P50 is around 150k per call.  Right now we have 1.2M gas limit per call, which is too high. We decrease the gas limit respectively, so that we can increase the multichunk size for less multicall RPC calls over the network.

And if we look at the retry loop at P90:

![Screenshot 2024-05-13 at 11.19.12 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/46f74fa5-8093-43b1-acd4-a7a1b9934cd7.png)

less than 10% of the calls are retried even once, so we should go for some aggressive but still reasonable gas tuning on OP.