### PR TITLE
feat: tune bnb batch param for gas limit and multichunk size

### DIFF
--- a/lib/util/onChainQuoteProviderConfigs.ts
+++ b/lib/util/onChainQuoteProviderConfigs.ts
@@ -75,6 +75,11 @@ export const OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [chainId: number]: BatchPa
     gasLimitPerCall: 60_000,
     quoteMinSuccessRate: 0.15,
   },
+  [ChainId.BNB]: {
+    multicallChunk: 1850,
+    gasLimitPerCall: 80_000,
+    quoteMinSuccessRate: 0.15,
+  },
 }
 
 export const NON_OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [chainId: number]: BatchParams } = {
@@ -107,6 +112,11 @@ export const NON_OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [chainId: number]: Bat
   [ChainId.AVALANCHE]: {
     multicallChunk: 420,
     gasLimitPerCall: 375_000,
+    quoteMinSuccessRate: 0.15,
+  },
+  [ChainId.BNB]: {
+    multicallChunk: 2961,
+    gasLimitPerCall: 50_000,
     quoteMinSuccessRate: 0.15,
   },
 }


### PR DESCRIPTION
We are ready to tune the gas batch params in BNB to see if it can speed up. If we check the gas used on P50:
<img width="1296" alt="Screenshot 2024-05-13 at 12 39 42 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/80c24c96-9dfc-4ed7-b885-60b0d1dd3392">


gas limit on optimistic cached routes averages ~50k per call, meanwhile non-optimistic ones ~80k per call, so changing the gas limit and multichunk size that way.

Also checked BNB retried loops at P90 level:
<img width="1290" alt="Screenshot 2024-05-13 at 12 39 47 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/76b8afcc-9f87-4734-b2b5-d0ed64ed1674">


On average it's still 0 retries, so it means we can try somewhat aggressive gas tuning on BNB.