### PR TITLE
feat: tune arbitrum batch param for gas limit and multichunk size

### DIFF
--- a/lib/util/onChainQuoteProviderConfigs.ts
+++ b/lib/util/onChainQuoteProviderConfigs.ts
@@ -51,8 +51,8 @@ export const OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [chainId: number]: BatchPa
     quoteMinSuccessRate: 0.1,
   },
   [ChainId.ARBITRUM_ONE]: {
-    multicallChunk: 15,
-    gasLimitPerCall: 15_000_000,
+    multicallChunk: 4500,
+    gasLimitPerCall: 50_000,
     quoteMinSuccessRate: 0.15,
   },
   [ChainId.OPTIMISM]: {
@@ -90,8 +90,8 @@ export const NON_OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [chainId: number]: Bat
     quoteMinSuccessRate: 0.1,
   },
   [ChainId.ARBITRUM_ONE]: {
-    multicallChunk: 15,
-    gasLimitPerCall: 15_000_000,
+    multicallChunk: 1125,
+    gasLimitPerCall: 200_000,
     quoteMinSuccessRate: 0.15,
   },
   [ChainId.OPTIMISM]: {


### PR DESCRIPTION
We are ready to tune the gas batch params in Arbitrum to see if it can speed up. If we check the gas used on P50:
![Screenshot 2024-05-13 at 1.50.41 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/8b3ba76d-ac7c-4ad6-9714-973f603bbc50.png)

average gas limit per call is ~50k. 

If we check P75:
![Screenshot 2024-05-13 at 1.50.49 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/3ae5a8b2-223a-4be6-a1cf-edd01683c6cd.png)

average gas limit per call is ~200k. 

If we check the retried loops and retried calls at P90, there's no retry:
![Screenshot 2024-05-13 at 1.50.01 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/a3967c9d-4c7f-45c3-b9c8-7b551c17bd8d.png)

At P95, there's slight retry, but not much:
![Screenshot 2024-05-13 at 1.50.09 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/5fb6072a-47f8-4ca4-97a6-e433c40e6eed.png)

