### PR TITLE
tune arbitrum on optimistic cached routes

### DIFF
--- a/lib/util/onChainQuoteProviderConfigs.ts
+++ b/lib/util/onChainQuoteProviderConfigs.ts
@@ -51,8 +51,8 @@ export const OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [chainId: number]: BatchPa
     quoteMinSuccessRate: 0.1,
   },
   [ChainId.ARBITRUM_ONE]: {
-    multicallChunk: 4500,
-    gasLimitPerCall: 50_000,
+    multicallChunk: 2250,
+    gasLimitPerCall: 100_000,
     quoteMinSuccessRate: 0.15,
   },
   [ChainId.OPTIMISM]: {


### PR DESCRIPTION
Arbitrum gas tuning on optimistic cached routes was too aggressive. 

For retries, optimistic cached routes increased:
![Screenshot 2024-05-13 at 2.52.53 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/907f098e-ddbd-4dd4-bea3-058734b312c9.png)

For latencies, optimistic cached routes also increased:
![Screenshot 2024-05-13 at 2.53.07 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/9bd8bc47-0a95-4b00-850c-b8e57bbf9d39.png)

However, since non-optimistic cached routes latencies and retries stay the same, we can check their gas limit per call, and tune accordingly:
![Screenshot 2024-05-13 at 2.52.40 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/3853d76b-2503-4fed-b7b1-6fd4bdba210d.png)

From non-optimistic cached routes, it appears 100k gas limits per call might be good.

