### PR TITLE
tune arbitrum gas lower to 75k

### DIFF
--- a/lib/util/onChainQuoteProviderConfigs.ts
+++ b/lib/util/onChainQuoteProviderConfigs.ts
@@ -51,8 +51,8 @@ export const OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [chainId: number]: BatchPa
     quoteMinSuccessRate: 0.1,
   },
   [ChainId.ARBITRUM_ONE]: {
-    multicallChunk: 2250,
-    gasLimitPerCall: 100_000,
+    multicallChunk: 3000,
+    gasLimitPerCall: 75_000,
     quoteMinSuccessRate: 0.15,
   },
   [ChainId.OPTIMISM]: {


### PR DESCRIPTION
After tuning gas limit to 100k, I see the latencies went back down to normal:
![Screenshot 2024-05-13 at 3.36.33 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/c2d2b49c-780c-4d48-9f9e-7236b280fd15.png)

But I can see P50 gas limit is around 72k, so I'm trying to tune the gas limit lower to 75k:
![Screenshot 2024-05-13 at 3.36.16 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/8a5224fa-a912-43a7-a453-0c9e19f79eaf.png)

