### PR TITLE
disable new mixed quoter on Base

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -63,7 +63,6 @@ import {
   NON_OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS,
   BLOCK_NUMBER_CONFIGS,
   GAS_ERROR_FAILURE_OVERRIDES,
-  NEW_MIXED_ROUTE_QUOTER_V1_ADDRESSES,
   RETRY_OPTIONS,
   SUCCESS_RATE_FAILURE_OVERRIDES,
   OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS,
@@ -360,7 +359,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
                 SUCCESS_RATE_FAILURE_OVERRIDES[chainId],
                 BLOCK_NUMBER_CONFIGS[chainId],
                 (useMixedRouteQuoter: boolean) =>
-                  useMixedRouteQuoter ? NEW_MIXED_ROUTE_QUOTER_V1_ADDRESSES[chainId] : NEW_QUOTER_V2_ADDRESSES[chainId],
+                  useMixedRouteQuoter ? MIXED_ROUTE_QUOTER_V1_ADDRESSES[chainId] : NEW_QUOTER_V2_ADDRESSES[chainId],
                 (chainId: ChainId, useMixedRouteQuoter: boolean, optimisticCachedRoutes: boolean) =>
                   useMixedRouteQuoter
                     ? `ChainId_${chainId}_ShadowMixedQuoter_OptimisticCachedRoutes${optimisticCachedRoutes}_`


### PR DESCRIPTION
There's certainly some [mixed routes on Base](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:logs-insights$3FqueryDetail$3D~(end~0~start~-1814400~timeType~'RELATIVE~unit~'seconds~editorString~'fields*20*40timestamp*2c*20*40message*2c*20*40logStream*2c*20*40log*0a*7c*20filter*20*40message*20like*20*27possible*20routes*20for*20type*20MIXED*27*20and*20chainId*20*3d*3d*208453*0a*7c*20sort*20*40timestamp*20desc*0a*7c*20limit*201000~queryId~'625782e588840af-8d8aec8f-4c64925-cbe0c0f1-b52b45f164a8ae344cde511c~source~(~'*2faws*2flambda*2fprod-us-east-2-RoutingAPI-Ro-RoutingLambdaF7AD8A1A-erFTueZgLnZ1~'*2faws*2flambda*2fprod-us-east-2-RoutingAPI-R-RoutingLambda2C4DF0900-Bbcx5MI4vlM6))) Since I shadow sampled on April 26th. But, since I enabled live mixed quotes 100% on Base, I don't see the [best mixed quote returned on Base](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~'Uniswap~'ChainId_42220_ShadowV3QuoterQuoteApproxGasUsedPerSuccessfulCall~'Service~'RoutingAPI~(visible~false))~(~'.~'ChainId_43114_ShadowV3QuoterQuoteApproxGasUsedPerSuccessfulCall~'.~'.~(visible~false))~(~'.~'ChainId_8453_V3QuoterQuoteUnknownReasonRetry~'.~'.))~view~'timeSeries~stacked~false~start~'-PT2160H~end~'P0D~region~'us-east-2~stat~'Maximum~period~60)&query=~'*7bUniswap*2cService*7d*20Mixed*20ForChain) at all. This tells me that on Base, the best quote is not from mixed routes.

![Screenshot 2024-05-08 at 12.08.19 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/759fa37d-dbec-4ed8-bed2-cd5a6596b44f.png)

![Screenshot 2024-05-08 at 12.06.36 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/16d0706e-3e0e-4042-8734-c0568cec4a70.png)

Since the mixed quoter has to support exact out and FOT, meanwhile there's no mixed quotes returned from Base, we are disabling mixed quotes on Base for now.