### PR TITLE
feat: tune base gas on optimistic cached routes

### DIFF
--- a/lib/util/onChainQuoteProviderConfigs.ts
+++ b/lib/util/onChainQuoteProviderConfigs.ts
@@ -46,8 +46,8 @@ export const RETRY_OPTIONS: { [chainId: number]: AsyncRetry.Options | undefined 
 export const OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [chainId: number]: BatchParams } = {
   ...constructSameBatchParamsMap(DEFAULT_BATCH_PARAMS),
   [ChainId.BASE]: {
-    multicallChunk: 110,
-    gasLimitPerCall: 1_200_000,
+    multicallChunk: 1760,
+    gasLimitPerCall: 75_000,
     quoteMinSuccessRate: 0.1,
   },
   [ChainId.ARBITRUM_ONE]: {
@@ -90,8 +90,8 @@ export const OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [chainId: number]: BatchPa
 export const NON_OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [chainId: number]: BatchParams } = {
   ...constructSameBatchParamsMap(DEFAULT_BATCH_PARAMS),
   [ChainId.BASE]: {
-    multicallChunk: 110,
-    gasLimitPerCall: 1_200_000,
+    multicallChunk: 660,
+    gasLimitPerCall: 200_000,
     quoteMinSuccessRate: 0.1,
   },
   [ChainId.ARBITRUM_ONE]: {


### PR DESCRIPTION
We are ready to tune the gas batch params in Base to see if it can speed up. If we check the gas used on P50:
![Screenshot 2024-05-13 at 4.03.05 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/88e6a6bd-8a35-404f-8bd3-7ec616147f63.png)

gas limit on optimistic cached routes averages ~75k per call.

If we check P75:
![Screenshot 2024-05-13 at 4.03.13 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/0634d421-520f-4292-8f4d-eb3c56010ca9.png)

Non-optimistic gas limit is ~200k.
