### PR TITLE
feat: tune mainnet batch param for gas limit and multichunk size

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -335,10 +335,12 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
                 provider,
                 multicall2Provider,
                 RETRY_OPTIONS[chainId],
-                (optimisticCachedRoutes) =>
-                  optimisticCachedRoutes
-                    ? OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS[chainId]
-                    : NON_OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS[chainId],
+                (optimisticCachedRoutes, useMixedRouteQuoter) => {
+                  const protocol = useMixedRouteQuoter ? Protocol.MIXED : Protocol.V3
+                  return optimisticCachedRoutes
+                    ? OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS[protocol][chainId]
+                    : NON_OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS[protocol][chainId]
+                },
                 GAS_ERROR_FAILURE_OVERRIDES[chainId],
                 SUCCESS_RATE_FAILURE_OVERRIDES[chainId],
                 BLOCK_NUMBER_CONFIGS[chainId],
@@ -351,10 +353,12 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
                 provider,
                 multicall2Provider,
                 RETRY_OPTIONS[chainId],
-                (optimisticCachedRoutes) =>
-                  optimisticCachedRoutes
-                    ? OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS[chainId]
-                    : NON_OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS[chainId],
+                (optimisticCachedRoutes, useMixedRouteQuoter) => {
+                  const protocol = useMixedRouteQuoter ? Protocol.MIXED : Protocol.V3
+                  return optimisticCachedRoutes
+                    ? OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS[protocol][chainId]
+                    : NON_OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS[protocol][chainId]
+                },
                 GAS_ERROR_FAILURE_OVERRIDES[chainId],
                 SUCCESS_RATE_FAILURE_OVERRIDES[chainId],
                 BLOCK_NUMBER_CONFIGS[chainId],

--- a/lib/util/onChainQuoteProviderConfigs.ts
+++ b/lib/util/onChainQuoteProviderConfigs.ts
@@ -44,7 +44,7 @@ export const RETRY_OPTIONS: { [chainId: number]: AsyncRetry.Options | undefined 
   },
 }
 
-export const OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [protocol: string] : { [chainId: number]: BatchParams } } = {
+export const OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [protocol: string]: { [chainId: number]: BatchParams } } = {
   [Protocol.V3]: {
     ...constructSameBatchParamsMap(DEFAULT_BATCH_PARAMS),
     [ChainId.BASE]: {
@@ -135,10 +135,10 @@ export const OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [protocol: string] : { [ch
       gasLimitPerCall: 80_000,
       quoteMinSuccessRate: 0.15,
     },
-  }
+  },
 }
 
-export const NON_OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [protocol: string] : { [chainId: number]: BatchParams } } = {
+export const NON_OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [protocol: string]: { [chainId: number]: BatchParams } } = {
   [Protocol.V3]: {
     ...constructSameBatchParamsMap(DEFAULT_BATCH_PARAMS),
     [ChainId.BASE]: {
@@ -229,7 +229,7 @@ export const NON_OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [protocol: string] : {
       gasLimitPerCall: 150_000,
       quoteMinSuccessRate: 0.15,
     },
-  }
+  },
 }
 
 export const GAS_ERROR_FAILURE_OVERRIDES: { [chainId: number]: FailureOverrides } = {

--- a/lib/util/onChainQuoteProviderConfigs.ts
+++ b/lib/util/onChainQuoteProviderConfigs.ts
@@ -13,6 +13,7 @@ import {
 import { CHAIN_TO_ADDRESSES_MAP, ChainId } from '@uniswap/sdk-core'
 import AsyncRetry from 'async-retry'
 import { AddressMap, BatchParams, BlockNumberConfig, FailureOverrides } from '@uniswap/smart-order-router'
+import { Protocol } from '@uniswap/router-sdk'
 
 export const RETRY_OPTIONS: { [chainId: number]: AsyncRetry.Options | undefined } = {
   ...constructSameRetryOptionsMap(DEFAULT_RETRY_OPTIONS),
@@ -43,92 +44,192 @@ export const RETRY_OPTIONS: { [chainId: number]: AsyncRetry.Options | undefined 
   },
 }
 
-export const OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [chainId: number]: BatchParams } = {
-  ...constructSameBatchParamsMap(DEFAULT_BATCH_PARAMS),
-  [ChainId.BASE]: {
-    multicallChunk: 1320,
-    gasLimitPerCall: 100_000,
-    quoteMinSuccessRate: 0.1,
+export const OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [protocol: string] : { [chainId: number]: BatchParams } } = {
+  [Protocol.V3]: {
+    ...constructSameBatchParamsMap(DEFAULT_BATCH_PARAMS),
+    [ChainId.BASE]: {
+      multicallChunk: 1320,
+      gasLimitPerCall: 100_000,
+      quoteMinSuccessRate: 0.1,
+    },
+    [ChainId.ARBITRUM_ONE]: {
+      multicallChunk: 3000,
+      gasLimitPerCall: 75_000,
+      quoteMinSuccessRate: 0.15,
+    },
+    [ChainId.OPTIMISM]: {
+      multicallChunk: 1650,
+      gasLimitPerCall: 80_000,
+      quoteMinSuccessRate: 0.1,
+    },
+    [ChainId.CELO]: {
+      multicallChunk: 6240,
+      gasLimitPerCall: 80_000,
+      quoteMinSuccessRate: 0,
+    },
+    [ChainId.BLAST]: {
+      multicallChunk: 1200,
+      gasLimitPerCall: 80_000,
+      quoteMinSuccessRate: 0.1,
+    },
+    [ChainId.AVALANCHE]: {
+      multicallChunk: 2625,
+      gasLimitPerCall: 60_000,
+      quoteMinSuccessRate: 0.15,
+    },
+    [ChainId.BNB]: {
+      multicallChunk: 1850,
+      gasLimitPerCall: 80_000,
+      quoteMinSuccessRate: 0.15,
+    },
+    [ChainId.POLYGON]: {
+      multicallChunk: 1850,
+      gasLimitPerCall: 80_000,
+      quoteMinSuccessRate: 0.15,
+    },
+    [ChainId.MAINNET]: {
+      multicallChunk: 1974,
+      gasLimitPerCall: 75_000,
+      quoteMinSuccessRate: 0.15,
+    },
   },
-  [ChainId.ARBITRUM_ONE]: {
-    multicallChunk: 3000,
-    gasLimitPerCall: 75_000,
-    quoteMinSuccessRate: 0.15,
-  },
-  [ChainId.OPTIMISM]: {
-    multicallChunk: 1650,
-    gasLimitPerCall: 80_000,
-    quoteMinSuccessRate: 0.1,
-  },
-  [ChainId.CELO]: {
-    multicallChunk: 6240,
-    gasLimitPerCall: 80_000,
-    quoteMinSuccessRate: 0,
-  },
-  [ChainId.BLAST]: {
-    multicallChunk: 1200,
-    gasLimitPerCall: 80_000,
-    quoteMinSuccessRate: 0.1,
-  },
-  [ChainId.AVALANCHE]: {
-    multicallChunk: 2625,
-    gasLimitPerCall: 60_000,
-    quoteMinSuccessRate: 0.15,
-  },
-  [ChainId.BNB]: {
-    multicallChunk: 1850,
-    gasLimitPerCall: 80_000,
-    quoteMinSuccessRate: 0.15,
-  },
-  [ChainId.POLYGON]: {
-    multicallChunk: 1850,
-    gasLimitPerCall: 80_000,
-    quoteMinSuccessRate: 0.15,
-  },
+  [Protocol.MIXED]: {
+    ...constructSameBatchParamsMap(DEFAULT_BATCH_PARAMS),
+    [ChainId.BASE]: {
+      multicallChunk: 1320,
+      gasLimitPerCall: 100_000,
+      quoteMinSuccessRate: 0.1,
+    },
+    [ChainId.ARBITRUM_ONE]: {
+      multicallChunk: 3000,
+      gasLimitPerCall: 75_000,
+      quoteMinSuccessRate: 0.15,
+    },
+    [ChainId.OPTIMISM]: {
+      multicallChunk: 1650,
+      gasLimitPerCall: 80_000,
+      quoteMinSuccessRate: 0.1,
+    },
+    [ChainId.CELO]: {
+      multicallChunk: 6240,
+      gasLimitPerCall: 80_000,
+      quoteMinSuccessRate: 0,
+    },
+    [ChainId.BLAST]: {
+      multicallChunk: 1200,
+      gasLimitPerCall: 80_000,
+      quoteMinSuccessRate: 0.1,
+    },
+    [ChainId.AVALANCHE]: {
+      multicallChunk: 2625,
+      gasLimitPerCall: 60_000,
+      quoteMinSuccessRate: 0.15,
+    },
+    [ChainId.BNB]: {
+      multicallChunk: 1850,
+      gasLimitPerCall: 80_000,
+      quoteMinSuccessRate: 0.15,
+    },
+    [ChainId.POLYGON]: {
+      multicallChunk: 1850,
+      gasLimitPerCall: 80_000,
+      quoteMinSuccessRate: 0.15,
+    },
+  }
 }
 
-export const NON_OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [chainId: number]: BatchParams } = {
-  ...constructSameBatchParamsMap(DEFAULT_BATCH_PARAMS),
-  [ChainId.BASE]: {
-    multicallChunk: 660,
-    gasLimitPerCall: 200_000,
-    quoteMinSuccessRate: 0.1,
+export const NON_OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [protocol: string] : { [chainId: number]: BatchParams } } = {
+  [Protocol.V3]: {
+    ...constructSameBatchParamsMap(DEFAULT_BATCH_PARAMS),
+    [ChainId.BASE]: {
+      multicallChunk: 660,
+      gasLimitPerCall: 200_000,
+      quoteMinSuccessRate: 0.1,
+    },
+    [ChainId.ARBITRUM_ONE]: {
+      multicallChunk: 1125,
+      gasLimitPerCall: 200_000,
+      quoteMinSuccessRate: 0.15,
+    },
+    [ChainId.OPTIMISM]: {
+      multicallChunk: 880,
+      gasLimitPerCall: 150_000,
+      quoteMinSuccessRate: 0.1,
+    },
+    [ChainId.CELO]: {
+      multicallChunk: 3120,
+      gasLimitPerCall: 160_000,
+      quoteMinSuccessRate: 0,
+    },
+    [ChainId.BLAST]: {
+      multicallChunk: 1200,
+      gasLimitPerCall: 80_000,
+      quoteMinSuccessRate: 0.1,
+    },
+    [ChainId.AVALANCHE]: {
+      multicallChunk: 420,
+      gasLimitPerCall: 375_000,
+      quoteMinSuccessRate: 0.15,
+    },
+    [ChainId.BNB]: {
+      multicallChunk: 2961,
+      gasLimitPerCall: 50_000,
+      quoteMinSuccessRate: 0.15,
+    },
+    [ChainId.POLYGON]: {
+      multicallChunk: 987,
+      gasLimitPerCall: 150_000,
+      quoteMinSuccessRate: 0.15,
+    },
+    [ChainId.MAINNET]: {
+      multicallChunk: 987,
+      gasLimitPerCall: 150_000,
+      quoteMinSuccessRate: 0.15,
+    },
   },
-  [ChainId.ARBITRUM_ONE]: {
-    multicallChunk: 1125,
-    gasLimitPerCall: 200_000,
-    quoteMinSuccessRate: 0.15,
-  },
-  [ChainId.OPTIMISM]: {
-    multicallChunk: 880,
-    gasLimitPerCall: 150_000,
-    quoteMinSuccessRate: 0.1,
-  },
-  [ChainId.CELO]: {
-    multicallChunk: 3120,
-    gasLimitPerCall: 160_000,
-    quoteMinSuccessRate: 0,
-  },
-  [ChainId.BLAST]: {
-    multicallChunk: 1200,
-    gasLimitPerCall: 80_000,
-    quoteMinSuccessRate: 0.1,
-  },
-  [ChainId.AVALANCHE]: {
-    multicallChunk: 420,
-    gasLimitPerCall: 375_000,
-    quoteMinSuccessRate: 0.15,
-  },
-  [ChainId.BNB]: {
-    multicallChunk: 2961,
-    gasLimitPerCall: 50_000,
-    quoteMinSuccessRate: 0.15,
-  },
-  [ChainId.POLYGON]: {
-    multicallChunk: 987,
-    gasLimitPerCall: 150_000,
-    quoteMinSuccessRate: 0.15,
-  },
+  [Protocol.MIXED]: {
+    ...constructSameBatchParamsMap(DEFAULT_BATCH_PARAMS),
+    [ChainId.BASE]: {
+      multicallChunk: 660,
+      gasLimitPerCall: 200_000,
+      quoteMinSuccessRate: 0.1,
+    },
+    [ChainId.ARBITRUM_ONE]: {
+      multicallChunk: 1125,
+      gasLimitPerCall: 200_000,
+      quoteMinSuccessRate: 0.15,
+    },
+    [ChainId.OPTIMISM]: {
+      multicallChunk: 880,
+      gasLimitPerCall: 150_000,
+      quoteMinSuccessRate: 0.1,
+    },
+    [ChainId.CELO]: {
+      multicallChunk: 3120,
+      gasLimitPerCall: 160_000,
+      quoteMinSuccessRate: 0,
+    },
+    [ChainId.BLAST]: {
+      multicallChunk: 1200,
+      gasLimitPerCall: 80_000,
+      quoteMinSuccessRate: 0.1,
+    },
+    [ChainId.AVALANCHE]: {
+      multicallChunk: 420,
+      gasLimitPerCall: 375_000,
+      quoteMinSuccessRate: 0.15,
+    },
+    [ChainId.BNB]: {
+      multicallChunk: 2961,
+      gasLimitPerCall: 50_000,
+      quoteMinSuccessRate: 0.15,
+    },
+    [ChainId.POLYGON]: {
+      multicallChunk: 987,
+      gasLimitPerCall: 150_000,
+      quoteMinSuccessRate: 0.15,
+    },
+  }
 }
 
 export const GAS_ERROR_FAILURE_OVERRIDES: { [chainId: number]: FailureOverrides } = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@uniswap/permit2-sdk": "^1.2.0",
         "@uniswap/router-sdk": "^1.9.0",
         "@uniswap/sdk-core": "^4.2.0",
-        "@uniswap/smart-order-router": "3.29.0",
+        "@uniswap/smart-order-router": "3.30.0",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^1.8.1",
         "@uniswap/v2-sdk": "^4.3.0",
@@ -4745,9 +4745,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.29.0.tgz",
-      "integrity": "sha512-Wim0KqdwSVBiEl1U5sg2SXkVHhs4kG7GsXo3WhoqqwIVDy1KEpjJUBAFR2uWMNX7a+3/imEabAlpysedx1ePug==",
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.30.0.tgz",
+      "integrity": "sha512-xoT90NP3B2jmKNE5EVGw8u6yN3k5LAMpUD6rEe1RyvRTm22A1uA1fQPyTpi38U86t1JAuQsTmca/vgKMgO9T6A==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -28379,9 +28379,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.29.0.tgz",
-      "integrity": "sha512-Wim0KqdwSVBiEl1U5sg2SXkVHhs4kG7GsXo3WhoqqwIVDy1KEpjJUBAFR2uWMNX7a+3/imEabAlpysedx1ePug==",
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.30.0.tgz",
+      "integrity": "sha512-xoT90NP3B2jmKNE5EVGw8u6yN3k5LAMpUD6rEe1RyvRTm22A1uA1fQPyTpi38U86t1JAuQsTmca/vgKMgO9T6A==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@uniswap/router-sdk": "^1.9.0",
     "@uniswap/sdk-core": "^4.2.0",
     "@types/semver": "^7.5.8",
-    "@uniswap/smart-order-router": "3.29.0",
+    "@uniswap/smart-order-router": "3.30.0",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^1.8.1",
     "@uniswap/v2-sdk": "^4.3.0",


### PR DESCRIPTION
Release SOR on https://github.com/Uniswap/smart-order-router/pull/576

On top of that, we only ensure to tune Mainnet gas param for V3, not mixed quoter, because mixed quoter is still gas-inefficient.

Then we are ready to look at P50 gas:
![Screenshot 2024-05-13 at 4.34.57 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/9df34f2c-5985-474d-9f84-ee76ffd1f50b.png)

Also P75:
![Screenshot 2024-05-13 at 5.01.15 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/16a0b458-221c-442c-a83c-c0e3a51f85da.png)

At P50, optimistic cached routes gas limit averages around 50k, meanhile P75, non-optimistic is about ~150k. We will tune V3 part of the mainnet quote to see if the V3 onchain quote latencies can improve. It's hard to see endpoint latency improvement for mainnet due to mixed onchain quoting.