### PR TITLE
fix: increase base gas limit to 100k

### DIFF
--- a/lib/util/onChainQuoteProviderConfigs.ts
+++ b/lib/util/onChainQuoteProviderConfigs.ts
@@ -46,8 +46,8 @@ export const RETRY_OPTIONS: { [chainId: number]: AsyncRetry.Options | undefined 
 export const OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [chainId: number]: BatchParams } = {
   ...constructSameBatchParamsMap(DEFAULT_BATCH_PARAMS),
   [ChainId.BASE]: {
-    multicallChunk: 1760,
-    gasLimitPerCall: 75_000,
+    multicallChunk: 1320,
+    gasLimitPerCall: 100_000,
     quoteMinSuccessRate: 0.1,
   },
   [ChainId.ARBITRUM_ONE]: {


### PR DESCRIPTION
Base on the optimistic cached routes is lowered to 75k gas limit per call, and we see increase in retries:
![Screenshot 2024-05-13 at 5.24.18 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/d8df5904-6357-4b6d-b421-35cbbff9604a.png)

Since non-optimistic path of 200k gas limit doesn't cause increase in retries, so somewhere between 75k-200k is good.

At P75 gas, I see the non-optimistic gas limit is ~100k:
![Screenshot 2024-05-13 at 5.24.56 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/2daeeacd-5887-4e08-b82f-6a5c00d29470.png)

So Im thinking to increase optimistic gas limit from 75k to 100k as a heuristic.

Overall, by lowering to 75k gas limit doesnt change the onchain quoting latency, so it means even though we have more retries, the increased batch size offset the retries in the overall latencies:
![Screenshot 2024-05-13 at 5.28.42 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/bf0c7653-27a0-4787-9d43-5af23691f507.png)

which means we should either expect to see improved latency from this PR, or still no latency improvement on Base.