### PR TITLE
fix: remove alchemy from the fast endpoint on Sepolia

### DIFF
--- a/bin/stacks/routing-lambda-stack.ts
+++ b/bin/stacks/routing-lambda-stack.ts
@@ -117,7 +117,7 @@ export class RoutingLambdaStack extends cdk.NestedStack {
 
       description: 'Routing Lambda',
       environment: {
-        VERSION: '17',
+        VERSION: '18',
         NODE_OPTIONS: '--enable-source-maps',
         POOL_CACHE_BUCKET: poolCacheBucket.bucketName,
         POOL_CACHE_BUCKET_2: poolCacheBucket2.bucketName,

--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -26,7 +26,7 @@
   {
     "chainId": 11155111,
     "useMultiProviderProb": 1,
-    "providerInitialWeights": [1, -1],
+    "providerInitialWeights": [-1, 1],
     "providerUrls": ["ALCHEMY_11155111", "INFURA_11155111"],
     "enableDbSync": true
   },

--- a/lib/rpc/utils.ts
+++ b/lib/rpc/utils.ts
@@ -108,6 +108,9 @@ export function generateProviderUrl(key: string, value: string): string {
     case 'ALCHEMY_8453': {
       return `https://base-mainnet.g.alchemy.com/v2/${tokens[0]}`
     }
+    case 'ALCHEMY_11155111': {
+      return `https://eth-sepolia.g.alchemy.com/v2/${tokens[0]}`
+    }
     case 'ALCHEMY_42161': {
       return `https://arb-mainnet.g.alchemy.com/v2/${tokens[0]}`
     }

--- a/lib/rpc/utils.ts
+++ b/lib/rpc/utils.ts
@@ -108,9 +108,6 @@ export function generateProviderUrl(key: string, value: string): string {
     case 'ALCHEMY_8453': {
       return `https://base-mainnet.g.alchemy.com/v2/${tokens[0]}`
     }
-    case 'ALCHEMY_11155111': {
-      return `https://eth-sepolia.g.alchemy.com/v2/${tokens[0]}`
-    }
     case 'ALCHEMY_42161': {
       return `https://arb-mainnet.g.alchemy.com/v2/${tokens[0]}`
     }


### PR DESCRIPTION
Alchemy provisioned fast endpoint on some chains, but Sepolia is not one of them. We will use Infura as primary provider on Sepolia and Alchemy only as fallback.

On some chains, the API keys will be updated, so we bump lambda version to pick those up from the secrets.