### PR TITLE
fix: measure rpc methods latencies right around the call

### DIFF
--- a/lib/rpc/SingleJsonRpcProvider.ts
+++ b/lib/rpc/SingleJsonRpcProvider.ts
@@ -256,9 +256,19 @@ export class SingleJsonRpcProvider extends StaticJsonRpcProvider {
       startTimestampInMs: Date.now(),
     }
     try {
+      // TODO: consolidate start time here and above
       perf.startTimestampInMs = Date.now()
       const result = await fn(...args)
       perf.latencyInMs = Date.now() - perf.startTimestampInMs
+
+      if (this.url.startsWith('https://eth-mainnet-fast.g.alchemy.com') && perf.latencyInMs >= 500) {
+        this.log.warn(
+          `Provider call latency is high: provider: ${this.url}, fnName: ${fnName}, fn: ${fn}, args: ${JSON.stringify([
+            ...args,
+          ])}, latency: ${perf.latencyInMs}`
+        )
+      }
+
       return result
     } catch (error: any) {
       perf.succeed = false

--- a/lib/rpc/SingleJsonRpcProvider.ts
+++ b/lib/rpc/SingleJsonRpcProvider.ts
@@ -256,7 +256,10 @@ export class SingleJsonRpcProvider extends StaticJsonRpcProvider {
       startTimestampInMs: Date.now(),
     }
     try {
-      return await fn(...args)
+      perf.startTimestampInMs = Date.now()
+      const result = await fn(...args)
+      perf.latencyInMs = Date.now() - perf.startTimestampInMs
+      return result
     } catch (error: any) {
       perf.succeed = false
       this.log.debug(
@@ -266,7 +269,6 @@ export class SingleJsonRpcProvider extends StaticJsonRpcProvider {
       )
       throw error
     } finally {
-      perf.latencyInMs = Date.now() - perf.startTimestampInMs
       this.checkLastCallPerformance(perf)
       if (this.enableDbSync) {
         if (!this.syncingDb && this.hasEnoughWaitSinceLastDbSync(1000 * this.config.DB_SYNC_INTERVAL_IN_S)) {


### PR DESCRIPTION
In order to get the most accurate latency measure for each RPC method, we will shuffle the latency measurement to be exactly where the RPC method invocation happens.

In addition, we will log high latency alchemy RPC method request payload, so as to collaborate to debug.