### PR TITLE
fix: use alchemy fast endpoint on sepolia

### DIFF
--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -26,7 +26,7 @@
   {
     "chainId": 11155111,
     "useMultiProviderProb": 1,
-    "providerInitialWeights": [-1, 1],
+    "providerInitialWeights": [1, -1],
     "providerUrls": ["ALCHEMY_11155111", "INFURA_11155111"],
     "enableDbSync": true
   },

--- a/lib/rpc/utils.ts
+++ b/lib/rpc/utils.ts
@@ -109,7 +109,7 @@ export function generateProviderUrl(key: string, value: string): string {
       return `https://base-mainnet-fast.g.alchemy.com/v2/${tokens[0]}`
     }
     case 'ALCHEMY_11155111': {
-      return `https://eth-sepolia.g.alchemy.com/v2/${tokens[0]}`
+      return `https://eth-sepolia-fast.g.alchemy.com/v2/${tokens[0]}`
     }
     case 'ALCHEMY_42161': {
       return `https://arb-mainnet-fast.g.alchemy.com/v2/${tokens[0]}`

--- a/test/mocha/unit/rpc/GlobalRpcProviders.test.ts
+++ b/test/mocha/unit/rpc/GlobalRpcProviders.test.ts
@@ -294,7 +294,7 @@ describe('GlobalRpcProviders', () => {
       TEST_PROD_CONFIG
     ).get(ChainId.SEPOLIA)!!
     expect(sepoliaRpcProvider['providers'][0].url).equal('https://sepolia.infura.io/v3/key16')
-    expect(sepoliaRpcProvider['providers'][1].url).equal('https://eth-sepolia.g.alchemy.com/v2/key17')
+    expect(sepoliaRpcProvider['providers'][1].url).equal('https://eth-sepolia-fast.g.alchemy.com/v2/key17')
 
     const arbitrumRpcProvider = GlobalRpcProviders.getGlobalUniRpcProviders(
       log,


### PR DESCRIPTION
Alchemy provisioned sepolia fast endpoint. We can switch now on Sepolia.