### PR TITLE
fix: only shadow evaluate providers latencies during request processing path

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -188,10 +188,11 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
               break
           }
 
-          let provider: StaticJsonRpcProvider
+          let provider
           if (GlobalRpcProviders.getGlobalUniRpcProviders(log).has(chainId)) {
             // Use RPC gateway.
             provider = GlobalRpcProviders.getGlobalUniRpcProviders(log).get(chainId)!
+            provider.shouldEvaluate = false
           } else {
             provider = new DefaultEVMClient({
               allProviders: [

--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -70,6 +70,7 @@ import {
 import { v4 } from 'uuid/index'
 import { chainProtocols } from '../cron/cache-config'
 import { Protocol } from '@uniswap/router-sdk'
+import { UniJsonRpcProvider } from '../rpc/UniJsonRpcProvider'
 
 export const SUPPORTED_CHAINS: ChainId[] = [
   ChainId.MAINNET,
@@ -188,11 +189,11 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
               break
           }
 
-          let provider
+          let provider: StaticJsonRpcProvider
           if (GlobalRpcProviders.getGlobalUniRpcProviders(log).has(chainId)) {
             // Use RPC gateway.
-            provider = GlobalRpcProviders.getGlobalUniRpcProviders(log).get(chainId)!
-            provider.shouldEvaluate = false
+            provider = GlobalRpcProviders.getGlobalUniRpcProviders(log).get(chainId)!;
+            (provider as UniJsonRpcProvider).shouldEvaluate = false
           } else {
             provider = new DefaultEVMClient({
               allProviders: [

--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -192,8 +192,8 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
           let provider: StaticJsonRpcProvider
           if (GlobalRpcProviders.getGlobalUniRpcProviders(log).has(chainId)) {
             // Use RPC gateway.
-            provider = GlobalRpcProviders.getGlobalUniRpcProviders(log).get(chainId)!;
-            (provider as UniJsonRpcProvider).shouldEvaluate = false
+            provider = GlobalRpcProviders.getGlobalUniRpcProviders(log).get(chainId)!
+            ;(provider as UniJsonRpcProvider).shouldEvaluate = false
           } else {
             provider = new DefaultEVMClient({
               allProviders: [

--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -63,6 +63,7 @@ export class QuoteHandler extends APIGLambdaHandler<
       if (useRpcGateway) {
         const provider = GlobalRpcProviders.getGlobalUniRpcProviders(log).get(chainId)!
         provider.forceAttachToNewSession()
+        provider.shouldEvaluate = true
       }
 
       result = await this.handleRequestInternal(params, startTime)

--- a/lib/rpc/UniJsonRpcProvider.ts
+++ b/lib/rpc/UniJsonRpcProvider.ts
@@ -41,6 +41,10 @@ export class UniJsonRpcProvider extends StaticJsonRpcProvider {
   // For later RPC calls, we will treat this as the session id, even if the RPC call itself doesn't specify one.
   attachedSessionId: string | null = null
 
+  // A hacky public mutable field to ensure all the shadow calls for provider health evaluation
+  // can only be invoked during the request processing path, but not during lambda initialization time
+  public shouldEvaluate: boolean = false
+
   /**
    *
    * @param chainId
@@ -285,10 +289,12 @@ export class UniJsonRpcProvider extends StaticJsonRpcProvider {
       throw error
     } finally {
       this.lastUsedProvider = selectedProvider
-      if (this.config.ENABLE_SHADOW_LATENCY_EVALUATION) {
-        this.checkOtherHealthyProvider(selectedProvider, fnName, args)
+      if (this.shouldEvaluate) {
+        if (this.config.ENABLE_SHADOW_LATENCY_EVALUATION) {
+          this.checkOtherHealthyProvider(selectedProvider, fnName, args)
+        }
+        this.checkUnhealthyProviders(selectedProvider)
       }
-      this.checkUnhealthyProviders(selectedProvider)
     }
   }
 

--- a/lib/rpc/UniJsonRpcProvider.ts
+++ b/lib/rpc/UniJsonRpcProvider.ts
@@ -43,7 +43,7 @@ export class UniJsonRpcProvider extends StaticJsonRpcProvider {
 
   // A hacky public mutable field to ensure all the shadow calls for provider health evaluation
   // can only be invoked during the request processing path, but not during lambda initialization time
-  public shouldEvaluate: boolean = false
+  public shouldEvaluate: boolean = true
 
   /**
    *


### PR DESCRIPTION
I find we are also shadow evaluating providers' latencies during [quoteInjector](https://github.com/Uniswap/routing-api/blob/e5827cfd59df80bb234e47727db2495d80da6471/lib/handlers/index.ts#L13). This can only happen during the lambda initialization time. We should not evaluate during the lambda initialization time, but rather during the request processing path, a.k.a., within the quote handler.