### PR TITLE
fix: distinguish evaluate latency metrics from normall call metrics

### DIFF
--- a/lib/rpc/SingleJsonRpcProvider.ts
+++ b/lib/rpc/SingleJsonRpcProvider.ts
@@ -21,7 +21,7 @@ import { ProviderHealthStateDynamoDbRepository } from './ProviderHealthStateDyna
 
 export const MAJOR_METHOD_NAMES: string[] = ['getBlockNumber', 'call', 'send']
 
-enum CallType {
+export enum CallType {
   NORMAL,
   // Extra call to check health against an unhealthy provider
   HEALTH_CHECK,
@@ -202,7 +202,11 @@ export class SingleJsonRpcProvider extends StaticJsonRpcProvider {
   }
 
   logLatencyMetrics(methodName: string, latencyInMs: number, callType: CallType) {
-    metric.putMetric(`${this.metricPrefix}_evaluated_${callType}_latency_${methodName}`, latencyInMs, MetricLoggerUnit.Milliseconds)
+    metric.putMetric(
+      `${this.metricPrefix}_evaluated_${callType}_latency_${methodName}`,
+      latencyInMs,
+      MetricLoggerUnit.Milliseconds
+    )
   }
 
   logCheckHealth() {

--- a/lib/rpc/SingleJsonRpcProvider.ts
+++ b/lib/rpc/SingleJsonRpcProvider.ts
@@ -145,7 +145,7 @@ export class SingleJsonRpcProvider extends StaticJsonRpcProvider {
 
   private recordProviderCallSuccess(perf: SingleCallPerf) {
     this.logProviderCallSuccessMetric(perf.methodName)
-    this.logLatencyMetrics(perf.methodName, perf.latencyInMs)
+    this.logLatencyMetrics(perf.methodName, perf.latencyInMs, perf.callType)
     this.log.debug(`Succeeded at calling provider: ${this.url} method: ${perf.methodName}`)
 
     if (perf.callType === CallType.HEALTH_CHECK) {
@@ -201,8 +201,8 @@ export class SingleJsonRpcProvider extends StaticJsonRpcProvider {
     metric.putMetric(`${this.metricPrefix}_${methodName}_FAILED`, 1, MetricLoggerUnit.Count)
   }
 
-  logLatencyMetrics(methodName: string, latencyInMs: number) {
-    metric.putMetric(`${this.metricPrefix}_evaluated_latency_${methodName}`, latencyInMs, MetricLoggerUnit.None)
+  logLatencyMetrics(methodName: string, latencyInMs: number, callType: CallType) {
+    metric.putMetric(`${this.metricPrefix}_evaluated_${callType}_latency_${methodName}`, latencyInMs, MetricLoggerUnit.Milliseconds)
   }
 
   logCheckHealth() {

--- a/lib/rpc/UniJsonRpcProvider.ts
+++ b/lib/rpc/UniJsonRpcProvider.ts
@@ -233,6 +233,16 @@ export class UniJsonRpcProvider extends StaticJsonRpcProvider {
         count++
       }
     }
+
+    if (count > 0) {
+      // Not ideal to re-evaluate the latency of the selected provider, but since the wait time is 10min for selected provider
+      // the number of additional call from the selected provider should be low.
+      if (!selectedProvider.isEvaluatingLatency() &&
+        selectedProvider.hasEnoughWaitSinceLastLatencyEvaluation(1000 * this.config.LATENCY_EVALUATION_WAIT_PERIOD_IN_S)) {
+        selectedProvider.evaluateLatency(methodName, args)
+      }
+    }
+
     this.log.debug(`Evaluated ${count} other healthy providers`)
   }
 

--- a/lib/rpc/UniJsonRpcProvider.ts
+++ b/lib/rpc/UniJsonRpcProvider.ts
@@ -1,4 +1,4 @@
-import { MAJOR_METHOD_NAMES, SingleJsonRpcProvider } from './SingleJsonRpcProvider'
+import { CallType, MAJOR_METHOD_NAMES, SingleJsonRpcProvider } from './SingleJsonRpcProvider'
 import { StaticJsonRpcProvider, TransactionRequest } from '@ethersproject/providers'
 import { isEmpty } from 'lodash'
 import { ChainId } from '@uniswap/sdk-core'
@@ -210,7 +210,7 @@ export class UniJsonRpcProvider extends StaticJsonRpcProvider {
 
   // Shadow call to other health providers that are not selected for performing current request
   // to gather their health states from time to time.
-  private checkOtherHealthyProvider(selectedProvider: SingleJsonRpcProvider, methodName: string, args: any[]) {
+  private checkOtherHealthyProvider(latency: number, selectedProvider: SingleJsonRpcProvider, methodName: string, args: any[]) {
     const healthyProviders = this.providers.filter((provider) => provider.isHealthy())
     let count = 0
     for (let provider of healthyProviders) {
@@ -235,12 +235,7 @@ export class UniJsonRpcProvider extends StaticJsonRpcProvider {
     }
 
     if (count > 0) {
-      // Not ideal to re-evaluate the latency of the selected provider, but since the wait time is 10min for selected provider
-      // the number of additional call from the selected provider should be low.
-      if (!selectedProvider.isEvaluatingLatency() &&
-        selectedProvider.hasEnoughWaitSinceLastLatencyEvaluation(1000 * this.config.LATENCY_EVALUATION_WAIT_PERIOD_IN_S)) {
-        selectedProvider.evaluateLatency(methodName, args)
-      }
+      selectedProvider.logLatencyMetrics(methodName, latency, CallType.LATENCY_EVALUATION)
     }
 
     this.log.debug(`Evaluated ${count} other healthy providers`)
@@ -292,8 +287,12 @@ export class UniJsonRpcProvider extends StaticJsonRpcProvider {
     )
     const selectedProvider = this.selectPreferredProvider(sessionId)
     selectedProvider.logProviderSelection()
+    let latency = 0
     try {
-      return await (selectedProvider as any)[`${fnName}`](...args)
+      const start = Date.now()
+      const result = await (selectedProvider as any)[`${fnName}`](...args)
+      latency = Date.now() - start
+      return result
     } catch (error: any) {
       this.log.error(JSON.stringify(error))
       throw error
@@ -301,7 +300,7 @@ export class UniJsonRpcProvider extends StaticJsonRpcProvider {
       this.lastUsedProvider = selectedProvider
       if (this.shouldEvaluate) {
         if (this.config.ENABLE_SHADOW_LATENCY_EVALUATION) {
-          this.checkOtherHealthyProvider(selectedProvider, fnName, args)
+          this.checkOtherHealthyProvider(latency, selectedProvider, fnName, args)
         }
         this.checkUnhealthyProviders(selectedProvider)
       }

--- a/lib/rpc/UniJsonRpcProvider.ts
+++ b/lib/rpc/UniJsonRpcProvider.ts
@@ -210,7 +210,12 @@ export class UniJsonRpcProvider extends StaticJsonRpcProvider {
 
   // Shadow call to other health providers that are not selected for performing current request
   // to gather their health states from time to time.
-  private checkOtherHealthyProvider(latency: number, selectedProvider: SingleJsonRpcProvider, methodName: string, args: any[]) {
+  private checkOtherHealthyProvider(
+    latency: number,
+    selectedProvider: SingleJsonRpcProvider,
+    methodName: string,
+    args: any[]
+  ) {
     const healthyProviders = this.providers.filter((provider) => provider.isHealthy())
     let count = 0
     for (let provider of healthyProviders) {


### PR DESCRIPTION
Right now the logged evaluated latency [metric](https://github.com/Uniswap/routing-api/blob/e5827cfd59df80bb234e47727db2495d80da6471/lib/rpc/SingleJsonRpcProvider.ts#L205) doesn't distinguish different [CallType](https://github.com/Uniswap/routing-api/blob/e5827cfd59df80bb234e47727db2495d80da6471/lib/rpc/SingleJsonRpcProvider.ts#L24).

For the accurate providers' benchmarking, we definitely need to benchmark the same RPC method on the same type of evaluation metrics.