### PR TITLE
fix: try shuffle the ordering of shadow providers in mainnet to see latencies evaluation change

### DIFF
--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -52,7 +52,7 @@
     "chainId": 1,
     "useMultiProviderProb": 0.1,
     "providerInitialWeights": [1, 0, 0, 0],
-    "providerUrls": ["INFURA_1", "QUICKNODE_1", "NIRVANA_1", "ALCHEMY_1"]
+    "providerUrls": ["INFURA_1", "ALCHEMY_1", "QUICKNODE_1", "NIRVANA_1"]
   },
   {
     "chainId": 81457,


### PR DESCRIPTION
In RPC_GATEWAY_1_[provider]_evaluated_2_latency_call metrics, I see that the latency ranking (from best to worst) is the same ordering as [providerUrls](https://github.com/Uniswap/routing-api/blob/main/lib/config/rpcProviderProdConfig.json#L55C6-L55C18). I have a hunch, because we fire and forget the [latencyEvaluation](https://github.com/Uniswap/routing-api/blob/1479b65f0865888094d50a98df30bbc149226cd3/lib/rpc/UniJsonRpcProvider.ts#L237), we might have messed up the latency measurement.

I want to test my theory by shuffling the shadow provider in mainnet in different sequence.