### PR TITLE
chore(cron): Reduce v2 threshold to 5k

### DIFF
--- a/lib/cron/cache-config.ts
+++ b/lib/cron/cache-config.ts
@@ -48,7 +48,7 @@ const v3TrackedEthThreshold = 0.01 // Pools need at least 0.01 of trackedEth to 
 const v3UntrackedUsdThreshold = 25000 // Pools need at least 25K USD (untracked) to be selected (for metrics only)
 
 const v2TrackedEthThreshold = 0.025 // Pairs need at least 0.025 of trackedEth to be selected
-const v2UntrackedUsdThreshold = 25000 // Pairs need at least 25K USD (untracked) to be selected (for metrics only)
+const v2UntrackedUsdThreshold = 5000 // Pairs need at least 5K USD (untracked) to be selected (for metrics only)
 
 export const chainProtocols = [
   // V3.


### PR DESCRIPTION
Decreasing the threshold of the v2 untracked USD for the subgraph pools, this is just for metrics collection purposes.