### PR TITLE
fix: deterministic and probabilistic shadow evaluate latency across providers on mainnet

### DIFF
--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -50,7 +50,8 @@
   },
   {
     "chainId": 1,
-    "useMultiProviderProb": 0.1,
+    "useMultiProviderProb": 1,
+    "latencyEvaluationSampleProb": 0.01,
     "providerInitialWeights": [1, 0, 0, 0],
     "providerUrls": ["INFURA_1", "ALCHEMY_1", "QUICKNODE_1", "NIRVANA_1"]
   },

--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -61,6 +61,7 @@
     "useMultiProviderProb": 0.1,
     "latencyEvaluationSampleProb": 0.0005,
     "healthCheckSampleProb": 0.0005,
+    "useMultiProviderProb": 1,
     "providerInitialWeights": [1, 0, 0],
     "providerUrls": ["QUICKNODE_8453", "ALCHEMY_8453", "NIRVANA_8453"]
   },

--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -61,7 +61,6 @@
     "useMultiProviderProb": 0.1,
     "latencyEvaluationSampleProb": 0.0005,
     "healthCheckSampleProb": 0.0005,
-    "useMultiProviderProb": 1,
     "providerInitialWeights": [1, 0, 0],
     "providerUrls": ["QUICKNODE_8453", "ALCHEMY_8453", "NIRVANA_8453"]
   },

--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -32,19 +32,19 @@
   },
   {
     "chainId": 137,
-    "useMultiProviderProb": 0.1,
+    "useMultiProviderProb": 1,
     "providerInitialWeights": [1, 0, 0],
     "providerUrls": ["QUICKNODE_137", "INFURA_137", "ALCHEMY_137"]
   },
   {
     "chainId": 42161,
-    "useMultiProviderProb": 0.1,
+    "useMultiProviderProb": 1,
     "providerInitialWeights": [1, 0, 0, 0],
     "providerUrls": ["INFURA_42161", "QUICKNODE_42161", "NIRVANA_42161", "ALCHEMY_42161"]
   },
   {
     "chainId": 8453,
-    "useMultiProviderProb": 0.1,
+    "useMultiProviderProb": 1,
     "providerInitialWeights": [1, 0, 0],
     "providerUrls": ["QUICKNODE_8453", "ALCHEMY_8453", "NIRVANA_8453"]
   },
@@ -57,7 +57,7 @@
   },
   {
     "chainId": 81457,
-    "useMultiProviderProb": 0.1,
+    "useMultiProviderProb": 1,
     "providerInitialWeights": [1, 0],
     "providerUrls": ["QUICKNODE_81457", "INFURA_81457"]
   }

--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -32,19 +32,19 @@
   },
   {
     "chainId": 137,
-    "useMultiProviderProb": 1,
+    "useMultiProviderProb": 0.1,
     "providerInitialWeights": [1, 0, 0],
     "providerUrls": ["QUICKNODE_137", "INFURA_137", "ALCHEMY_137"]
   },
   {
     "chainId": 42161,
-    "useMultiProviderProb": 1,
+    "useMultiProviderProb": 0.1,
     "providerInitialWeights": [1, 0, 0, 0],
     "providerUrls": ["INFURA_42161", "QUICKNODE_42161", "NIRVANA_42161", "ALCHEMY_42161"]
   },
   {
     "chainId": 8453,
-    "useMultiProviderProb": 1,
+    "useMultiProviderProb": 0.1,
     "providerInitialWeights": [1, 0, 0],
     "providerUrls": ["QUICKNODE_8453", "ALCHEMY_8453", "NIRVANA_8453"]
   },
@@ -57,7 +57,7 @@
   },
   {
     "chainId": 81457,
-    "useMultiProviderProb": 1,
+    "useMultiProviderProb": 0.1,
     "providerInitialWeights": [1, 0],
     "providerUrls": ["QUICKNODE_81457", "INFURA_81457"]
   }

--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -2,30 +2,40 @@
   {
     "chainId": 42220,
     "useMultiProviderProb": 1,
+    "latencyEvaluationSampleProb": 0.1,
+    "healthCheckSampleProb": 0.1,
     "providerInitialWeights": [1, 0],
     "providerUrls": ["QUICKNODE_42220", "INFURA_42220"]
   },
   {
     "chainId": 43114,
     "useMultiProviderProb": 1,
+    "latencyEvaluationSampleProb": 0.1,
+    "healthCheckSampleProb": 0.1,
     "providerInitialWeights": [1, 0, 0],
     "providerUrls": ["INFURA_43114", "QUICKNODE_43114", "NIRVANA_43114"]
   },
   {
     "chainId": 56,
     "useMultiProviderProb": 1,
+    "latencyEvaluationSampleProb": 0.01,
+    "healthCheckSampleProb": 0.01,
     "providerInitialWeights": [1],
     "providerUrls": ["QUICKNODE_56"]
   },
   {
     "chainId": 10,
     "useMultiProviderProb": 1,
+    "latencyEvaluationSampleProb": 0.01,
+    "healthCheckSampleProb": 0.01,
     "providerInitialWeights": [1, 0, 0],
     "providerUrls": ["INFURA_10", "QUICKNODE_10", "ALCHEMY_10"]
   },
   {
     "chainId": 11155111,
     "useMultiProviderProb": 1,
+    "latencyEvaluationSampleProb": 0.01,
+    "healthCheckSampleProb": 0.01,
     "providerInitialWeights": [1, -1],
     "providerUrls": ["ALCHEMY_11155111", "INFURA_11155111"],
     "enableDbSync": true
@@ -33,31 +43,40 @@
   {
     "chainId": 137,
     "useMultiProviderProb": 0.1,
+    "latencyEvaluationSampleProb": 0.005,
+    "healthCheckSampleProb": 0.005,
     "providerInitialWeights": [1, 0, 0],
     "providerUrls": ["QUICKNODE_137", "INFURA_137", "ALCHEMY_137"]
   },
   {
     "chainId": 42161,
     "useMultiProviderProb": 0.1,
+    "latencyEvaluationSampleProb": 0.002,
+    "healthCheckSampleProb": 0.002,
     "providerInitialWeights": [1, 0, 0, 0],
     "providerUrls": ["INFURA_42161", "QUICKNODE_42161", "NIRVANA_42161", "ALCHEMY_42161"]
   },
   {
     "chainId": 8453,
     "useMultiProviderProb": 0.1,
+    "latencyEvaluationSampleProb": 0.0005,
+    "healthCheckSampleProb": 0.0005,
     "providerInitialWeights": [1, 0, 0],
     "providerUrls": ["QUICKNODE_8453", "ALCHEMY_8453", "NIRVANA_8453"]
   },
   {
     "chainId": 1,
     "useMultiProviderProb": 1,
-    "latencyEvaluationSampleProb": 0.01,
+    "latencyEvaluationSampleProb": 0.001,
+    "healthCheckSampleProb": 0.001,
     "providerInitialWeights": [1, 0, 0, 0],
     "providerUrls": ["INFURA_1", "ALCHEMY_1", "QUICKNODE_1", "NIRVANA_1"]
   },
   {
     "chainId": 81457,
     "useMultiProviderProb": 0.1,
+    "latencyEvaluationSampleProb": 0.001,
+    "healthCheckSampleProb": 0.001,
     "providerInitialWeights": [1, 0],
     "providerUrls": ["QUICKNODE_81457", "INFURA_81457"]
   }

--- a/lib/rpc/UniJsonRpcProvider.ts
+++ b/lib/rpc/UniJsonRpcProvider.ts
@@ -226,19 +226,12 @@ export class UniJsonRpcProvider extends StaticJsonRpcProvider {
         if (!MAJOR_METHOD_NAMES.includes(methodName)) {
           return
         }
-        if (Math.random() >= this.latencyEvaluationSampleProb) {
-          return
-        }
-        if (
-          !provider.isEvaluatingLatency() &&
-          provider.hasEnoughWaitSinceLastLatencyEvaluation(1000 * this.config.LATENCY_EVALUATION_WAIT_PERIOD_IN_S)
-        ) {
-          // Within each provider latency shadow evaluation, we should do block I/O,
-          // because NodeJS runs in single thread, so it's important to make sure
-          // we benchmark the latencies correctly based on the single-threaded sequential evaluation.
-          await provider.evaluateLatency(methodName, args)
-          count++
-        }
+
+        // Within each provider latency shadow evaluation, we should do block I/O,
+        // because NodeJS runs in single thread, so it's important to make sure
+        // we benchmark the latencies correctly based on the single-threaded sequential evaluation.
+        await provider.evaluateLatency(methodName, args)
+        count++
       })
     )
 
@@ -307,7 +300,9 @@ export class UniJsonRpcProvider extends StaticJsonRpcProvider {
     } finally {
       this.lastUsedProvider = selectedProvider
       if (this.shouldEvaluate) {
-        if (this.config.ENABLE_SHADOW_LATENCY_EVALUATION) {
+        // We only want to probabilistically evaluate latency of other healthy providers,
+        // when there's session id populated. Session id being populated means it's from the request processing path.
+        if (this.config.ENABLE_SHADOW_LATENCY_EVALUATION && Math.random() >= this.latencyEvaluationSampleProb && sessionId) {
           // fire and forget to evaluate latency of other healthy providers
           this.checkOtherHealthyProvider(latency, selectedProvider, fnName, args)
         }

--- a/lib/rpc/UniJsonRpcProvider.ts
+++ b/lib/rpc/UniJsonRpcProvider.ts
@@ -302,11 +302,18 @@ export class UniJsonRpcProvider extends StaticJsonRpcProvider {
       if (this.shouldEvaluate) {
         // We only want to probabilistically evaluate latency of other healthy providers,
         // when there's session id populated. Session id being populated means it's from the request processing path.
-        if (this.config.ENABLE_SHADOW_LATENCY_EVALUATION && Math.random() >= this.latencyEvaluationSampleProb && sessionId) {
+        if (
+          this.config.ENABLE_SHADOW_LATENCY_EVALUATION &&
+          Math.random() < this.latencyEvaluationSampleProb &&
+          sessionId
+        ) {
           // fire and forget to evaluate latency of other healthy providers
           this.checkOtherHealthyProvider(latency, selectedProvider, fnName, args)
         }
-        this.checkUnhealthyProviders(selectedProvider)
+
+        if (Math.random() < this.healthCheckSampleProb && sessionId) {
+          this.checkUnhealthyProviders(selectedProvider)
+        }
       }
     }
   }

--- a/test/mocha/unit/rpc/UniJsonRpcProvider.test.ts
+++ b/test/mocha/unit/rpc/UniJsonRpcProvider.test.ts
@@ -739,7 +739,7 @@ describe('UniJsonRpcProvider', () => {
     const spy1 = sandbox.spy(uniProvider['providers'][1], 'evaluateLatency')
     const spy2 = sandbox.spy(uniProvider['providers'][2], 'evaluateLatency')
 
-    await uniProvider.getBlockNumber("sessionId")
+    await uniProvider.getBlockNumber('sessionId')
 
     // Shadow evaluate call should be made
     expect(spy0.callCount).to.equal(0)
@@ -757,7 +757,7 @@ describe('UniJsonRpcProvider', () => {
     spy1.resetHistory()
     spy2.resetHistory()
 
-    await uniProvider.getBlockNumber("sessionId")
+    await uniProvider.getBlockNumber('sessionId')
 
     // 1 second is not long enough to allow another latency evaluation shadow call.
     expect(spy1.callCount).to.equal(1)
@@ -769,7 +769,7 @@ describe('UniJsonRpcProvider', () => {
     spy1.resetHistory()
     spy2.resetHistory()
 
-    await uniProvider.getBlockNumber("sessionId")
+    await uniProvider.getBlockNumber('sessionId')
 
     expect(spy1.callCount).to.equal(1)
     expect(spy1.getCalls()[0].firstArg).to.equal('getBlockNumber')
@@ -811,11 +811,11 @@ describe('UniJsonRpcProvider', () => {
 
     // Make 5 calls in parallel.
     await Promise.all([
-      uniProvider.getBlockNumber("sessionId"),
-      uniProvider.getBlockNumber("sessionId"),
-      uniProvider.getBlockNumber("sessionId"),
-      uniProvider.getBlockNumber("sessionId"),
-      uniProvider.getBlockNumber("sessionId"),
+      uniProvider.getBlockNumber('sessionId'),
+      uniProvider.getBlockNumber('sessionId'),
+      uniProvider.getBlockNumber('sessionId'),
+      uniProvider.getBlockNumber('sessionId'),
+      uniProvider.getBlockNumber('sessionId'),
     ])
 
     expect(spy0.callCount).to.equal(0)
@@ -875,11 +875,11 @@ describe('UniJsonRpcProvider', () => {
 
     // Make another 5 calls in parallel.
     await Promise.all([
-      uniProvider.getBlockNumber("sessionId"),
-      uniProvider.getBlockNumber("sessionId"),
-      uniProvider.getBlockNumber("sessionId"),
-      uniProvider.getBlockNumber("sessionId"),
-      uniProvider.getBlockNumber("sessionId"),
+      uniProvider.getBlockNumber('sessionId'),
+      uniProvider.getBlockNumber('sessionId'),
+      uniProvider.getBlockNumber('sessionId'),
+      uniProvider.getBlockNumber('sessionId'),
+      uniProvider.getBlockNumber('sessionId'),
     ])
 
     // Waited long enough to be able to make shadow calls. However, due to the locking mechanism, only 1 call is made to each shadow provider.
@@ -920,7 +920,7 @@ describe('UniJsonRpcProvider', () => {
     const randStub = sandbox.stub(Math, 'random')
 
     randStub.returns(0.6)
-    await uniProvider.getBlockNumber("sessionId")
+    await uniProvider.getBlockNumber('sessionId')
     // 0.6 >= 0.5, Shadow evaluate call should not be made
     expect(spy0.callCount).to.equal(0)
     expect(spy1.callCount).to.equal(0)
@@ -930,7 +930,7 @@ describe('UniJsonRpcProvider', () => {
     spy2.resetHistory()
 
     randStub.returns(0.5)
-    await uniProvider.getBlockNumber("sessionId")
+    await uniProvider.getBlockNumber('sessionId')
     // 0.5 >= 0.5, Shadow evaluate call should not be made
     expect(spy0.callCount).to.equal(0)
     expect(spy1.callCount).to.equal(0)
@@ -940,7 +940,7 @@ describe('UniJsonRpcProvider', () => {
     spy2.resetHistory()
 
     randStub.returns(0.4)
-    await uniProvider.getBlockNumber("sessionId")
+    await uniProvider.getBlockNumber('sessionId')
     // 0.4 < 0.5, Shadow evaluate call should be made
     expect(spy0.callCount).to.equal(0)
     expect(spy1.callCount).to.equal(1)
@@ -981,7 +981,7 @@ describe('UniJsonRpcProvider', () => {
     const randStub = sandbox.stub(Math, 'random')
 
     randStub.returns(0.6)
-    await uniProvider.getBlockNumber("sessionId")
+    await uniProvider.getBlockNumber('sessionId')
     // 0.6 >= 0.5, Shadow evaluate call should not be made
     expect(spy0.callCount).to.equal(0)
     expect(spy1.callCount).to.equal(0)
@@ -991,7 +991,7 @@ describe('UniJsonRpcProvider', () => {
     spy2.resetHistory()
 
     randStub.returns(0.5)
-    await uniProvider.getBlockNumber("sessionId")
+    await uniProvider.getBlockNumber('sessionId')
     // 0.5 >= 0.5, Shadow evaluate call should not be made
     expect(spy0.callCount).to.equal(0)
     expect(spy1.callCount).to.equal(0)
@@ -1001,7 +1001,7 @@ describe('UniJsonRpcProvider', () => {
     spy2.resetHistory()
 
     randStub.returns(0.4)
-    await uniProvider.getBlockNumber("sessionId")
+    await uniProvider.getBlockNumber('sessionId')
     // 0.4 < 0.5, Shadow evaluate call should be made
     expect(spy0.callCount).to.equal(0)
     expect(spy1.callCount).to.equal(1)

--- a/test/mocha/unit/rpc/UniJsonRpcProvider.test.ts
+++ b/test/mocha/unit/rpc/UniJsonRpcProvider.test.ts
@@ -697,7 +697,7 @@ describe('UniJsonRpcProvider', () => {
     const spy1 = sandbox.spy(uniProvider['providers'][1], 'evaluateLatency')
     const spy2 = sandbox.spy(uniProvider['providers'][2], 'evaluateLatency')
 
-    await uniProvider.getBlockNumber()
+    await uniProvider.getBlockNumber('sessionId')
 
     // Shadow evaluate call should be made
     expect(spy0.callCount).to.equal(0)
@@ -739,7 +739,7 @@ describe('UniJsonRpcProvider', () => {
     const spy1 = sandbox.spy(uniProvider['providers'][1], 'evaluateLatency')
     const spy2 = sandbox.spy(uniProvider['providers'][2], 'evaluateLatency')
 
-    await uniProvider.getBlockNumber()
+    await uniProvider.getBlockNumber("sessionId")
 
     // Shadow evaluate call should be made
     expect(spy0.callCount).to.equal(0)
@@ -757,11 +757,11 @@ describe('UniJsonRpcProvider', () => {
     spy1.resetHistory()
     spy2.resetHistory()
 
-    await uniProvider.getBlockNumber()
+    await uniProvider.getBlockNumber("sessionId")
 
     // 1 second is not long enough to allow another latency evaluation shadow call.
-    expect(spy1.callCount).to.equal(0)
-    expect(spy2.callCount).to.equal(0)
+    expect(spy1.callCount).to.equal(1)
+    expect(spy2.callCount).to.equal(1)
 
     // Advance another 15 seconds.
     sandbox.clock.tick(15000)
@@ -769,7 +769,7 @@ describe('UniJsonRpcProvider', () => {
     spy1.resetHistory()
     spy2.resetHistory()
 
-    await uniProvider.getBlockNumber()
+    await uniProvider.getBlockNumber("sessionId")
 
     expect(spy1.callCount).to.equal(1)
     expect(spy1.getCalls()[0].firstArg).to.equal('getBlockNumber')
@@ -811,17 +811,17 @@ describe('UniJsonRpcProvider', () => {
 
     // Make 5 calls in parallel.
     await Promise.all([
-      uniProvider.getBlockNumber(),
-      uniProvider.getBlockNumber(),
-      uniProvider.getBlockNumber(),
-      uniProvider.getBlockNumber(),
-      uniProvider.getBlockNumber(),
+      uniProvider.getBlockNumber("sessionId"),
+      uniProvider.getBlockNumber("sessionId"),
+      uniProvider.getBlockNumber("sessionId"),
+      uniProvider.getBlockNumber("sessionId"),
+      uniProvider.getBlockNumber("sessionId"),
     ])
 
     expect(spy0.callCount).to.equal(0)
-    expect(spy1.callCount).to.equal(1)
+    expect(spy1.callCount).to.equal(5)
     expect(spy1.getCalls()[0].firstArg).to.equal('getBlockNumber')
-    expect(spy2.callCount).to.equal(1)
+    expect(spy2.callCount).to.equal(5)
     expect(spy2.getCalls()[0].firstArg).to.equal('getBlockNumber')
 
     expect(uniProvider['providers'][1]['lastLatencyEvaluationTimestampInMs']).equals(timestamp)
@@ -875,17 +875,17 @@ describe('UniJsonRpcProvider', () => {
 
     // Make another 5 calls in parallel.
     await Promise.all([
-      uniProvider.getBlockNumber(),
-      uniProvider.getBlockNumber(),
-      uniProvider.getBlockNumber(),
-      uniProvider.getBlockNumber(),
-      uniProvider.getBlockNumber(),
+      uniProvider.getBlockNumber("sessionId"),
+      uniProvider.getBlockNumber("sessionId"),
+      uniProvider.getBlockNumber("sessionId"),
+      uniProvider.getBlockNumber("sessionId"),
+      uniProvider.getBlockNumber("sessionId"),
     ])
 
     // Waited long enough to be able to make shadow calls. However, due to the locking mechanism, only 1 call is made to each shadow provider.
     expect(spy0.callCount).to.equal(0)
-    expect(spy1.callCount).to.equal(1)
-    expect(spy2.callCount).to.equal(1)
+    expect(spy1.callCount).to.equal(5)
+    expect(spy2.callCount).to.equal(5)
 
     expect(uniProvider['providers'][1]['lastLatencyEvaluationTimestampInMs']).equals(timestamp + 16000)
     expect(uniProvider['providers'][2]['lastLatencyEvaluationTimestampInMs']).equals(timestamp + 16000)
@@ -920,7 +920,7 @@ describe('UniJsonRpcProvider', () => {
     const randStub = sandbox.stub(Math, 'random')
 
     randStub.returns(0.6)
-    await uniProvider.getBlockNumber()
+    await uniProvider.getBlockNumber("sessionId")
     // 0.6 >= 0.5, Shadow evaluate call should not be made
     expect(spy0.callCount).to.equal(0)
     expect(spy1.callCount).to.equal(0)
@@ -930,7 +930,7 @@ describe('UniJsonRpcProvider', () => {
     spy2.resetHistory()
 
     randStub.returns(0.5)
-    await uniProvider.getBlockNumber()
+    await uniProvider.getBlockNumber("sessionId")
     // 0.5 >= 0.5, Shadow evaluate call should not be made
     expect(spy0.callCount).to.equal(0)
     expect(spy1.callCount).to.equal(0)
@@ -940,7 +940,7 @@ describe('UniJsonRpcProvider', () => {
     spy2.resetHistory()
 
     randStub.returns(0.4)
-    await uniProvider.getBlockNumber()
+    await uniProvider.getBlockNumber("sessionId")
     // 0.4 < 0.5, Shadow evaluate call should be made
     expect(spy0.callCount).to.equal(0)
     expect(spy1.callCount).to.equal(1)
@@ -981,7 +981,7 @@ describe('UniJsonRpcProvider', () => {
     const randStub = sandbox.stub(Math, 'random')
 
     randStub.returns(0.6)
-    await uniProvider.getBlockNumber()
+    await uniProvider.getBlockNumber("sessionId")
     // 0.6 >= 0.5, Shadow evaluate call should not be made
     expect(spy0.callCount).to.equal(0)
     expect(spy1.callCount).to.equal(0)
@@ -991,7 +991,7 @@ describe('UniJsonRpcProvider', () => {
     spy2.resetHistory()
 
     randStub.returns(0.5)
-    await uniProvider.getBlockNumber()
+    await uniProvider.getBlockNumber("sessionId")
     // 0.5 >= 0.5, Shadow evaluate call should not be made
     expect(spy0.callCount).to.equal(0)
     expect(spy1.callCount).to.equal(0)
@@ -1001,7 +1001,7 @@ describe('UniJsonRpcProvider', () => {
     spy2.resetHistory()
 
     randStub.returns(0.4)
-    await uniProvider.getBlockNumber()
+    await uniProvider.getBlockNumber("sessionId")
     // 0.4 < 0.5, Shadow evaluate call should be made
     expect(spy0.callCount).to.equal(0)
     expect(spy1.callCount).to.equal(1)


### PR DESCRIPTION
On mainnet, so far we use the multi-provider probabilistic sampling upon instantiation. We want to change to always instantiate multi-providers. We want to keep other chains as is, because we care about mainnet latency for the most part.

Also we are removing the 10-minute time-based sampling window to allow more deterministic sampling at some probability per quote request. As a result, we add latencyEvaluationSampleProb and healthCheckSampleProb as extra safety measure. The probability was chosen from the previous shadow sampling rate when implementing view-only quoter:
1. mainnet 0.1% https://github.com/Uniswap/routing-api/pull/584
2. arbitrum 0.2% https://github.com/Uniswap/routing-api/pull/599
3. base 0.05% https://github.com/Uniswap/routing-api/pull/598
4. polygon 0.5% https://github.com/Uniswap/routing-api/pull/595
5. optimism 1% https://github.com/Uniswap/routing-api/pull/603
6. bnb 1% https://github.com/Uniswap/routing-api/pull/608
7. celo 10% https://github.com/Uniswap/routing-api/pull/609