### PR TITLE
feat: remove quicknode geth to see pure reth perf

### DIFF
--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -69,8 +69,8 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.001,
     "healthCheckSampleProb": 0.001,
-    "providerInitialWeights": [1, 0, 0, 0, 0],
-    "providerUrls": ["INFURA_1", "ALCHEMY_1", "QUICKNODE_1", "NIRVANA_1", "QUICKNODERETH_1"]
+    "providerInitialWeights": [1, 0, 0, 0],
+    "providerUrls": ["INFURA_1", "ALCHEMY_1", "NIRVANA_1", "QUICKNODERETH_1"]
   },
   {
     "chainId": 81457,


### PR DESCRIPTION
It's not obvious to me about the quicknode reth perf, because the quicknode latency is now a mix of reth and geth. I'm removing geth shadow calls.