### PR TITLE
Update SOR to 3.31.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@uniswap/permit2-sdk": "^1.2.0",
         "@uniswap/router-sdk": "^1.9.0",
         "@uniswap/sdk-core": "^4.2.0",
-        "@uniswap/smart-order-router": "3.30.1",
+        "@uniswap/smart-order-router": "3.31.0",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^1.8.1",
         "@uniswap/v2-sdk": "^4.3.0",
@@ -4745,9 +4745,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.30.1",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.30.1.tgz",
-      "integrity": "sha512-Ea5+skr0BxDHFb0s+bZsqZsYOr/nhbVwiLN7qApinKeUyehoFnU+IRPUz4JyhRrDjkaYGWbbrkqz0V/y1vc3Ag==",
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.31.0.tgz",
+      "integrity": "sha512-BZKsbkXU4JUyZ5pC4a4/p3eq9PGWO8rmIKBKkThIspIbbWZsO+SOIrfRSYdpJ5Ok1fdZV3MwT/Gn2y92SNV5pw==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -28379,9 +28379,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.30.1",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.30.1.tgz",
-      "integrity": "sha512-Ea5+skr0BxDHFb0s+bZsqZsYOr/nhbVwiLN7qApinKeUyehoFnU+IRPUz4JyhRrDjkaYGWbbrkqz0V/y1vc3Ag==",
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.31.0.tgz",
+      "integrity": "sha512-BZKsbkXU4JUyZ5pC4a4/p3eq9PGWO8rmIKBKkThIspIbbWZsO+SOIrfRSYdpJ5Ok1fdZV3MwT/Gn2y92SNV5pw==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@uniswap/router-sdk": "^1.9.0",
     "@uniswap/sdk-core": "^4.2.0",
     "@types/semver": "^7.5.8",
-    "@uniswap/smart-order-router": "3.30.1",
+    "@uniswap/smart-order-router": "3.31.0",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^1.8.1",
     "@uniswap/v2-sdk": "^4.3.0",


### PR DESCRIPTION
Includes a change that allows V2 pools with untracked USD balances to be considered for routing
