### PR TITLE
fix: manually fail over op, arb, avax traffic to quicknode geth

### DIFF
--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -12,7 +12,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.1,
     "healthCheckSampleProb": 0.1,
-    "providerInitialWeights": [1, 0, 0],
+    "providerInitialWeights": [0, 1, 0],
     "providerUrls": ["INFURA_43114", "QUICKNODE_43114", "NIRVANA_43114"]
   },
   {
@@ -28,7 +28,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.01,
     "healthCheckSampleProb": 0.01,
-    "providerInitialWeights": [1, 0, 0],
+    "providerInitialWeights": [0, 1, 0],
     "providerUrls": ["INFURA_10", "QUICKNODE_10", "ALCHEMY_10"]
   },
   {
@@ -53,7 +53,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.002,
     "healthCheckSampleProb": 0.002,
-    "providerInitialWeights": [1, 0, 0, 0],
+    "providerInitialWeights": [0, 1, 0, 0],
     "providerUrls": ["INFURA_42161", "QUICKNODE_42161", "NIRVANA_42161", "ALCHEMY_42161"]
   },
   {


### PR DESCRIPTION
Infura now having issue across op, arb, and avax. Our quote endpoint success rate below 10%. We have to urgently switch over to quicknode 