### PR TITLE
fix: set untracked usd threshold to max on v2 mainnet

### DIFF
--- a/lib/cron/cache-config.ts
+++ b/lib/cron/cache-config.ts
@@ -179,15 +179,7 @@ export const chainProtocols = [
     protocol: Protocol.V2,
     chainId: ChainId.MAINNET,
     timeout: 840000,
-    provider: new V2SubgraphProvider(
-      ChainId.MAINNET,
-      3,
-      900000,
-      true,
-      1000,
-      v2TrackedEthThreshold,
-      Number.MAX_VALUE,
-    ), // 1000 is the largest page size supported by thegraph
+    provider: new V2SubgraphProvider(ChainId.MAINNET, 3, 900000, true, 1000, v2TrackedEthThreshold, Number.MAX_VALUE), // 1000 is the largest page size supported by thegraph
   },
   {
     protocol: Protocol.V2,

--- a/lib/cron/cache-config.ts
+++ b/lib/cron/cache-config.ts
@@ -50,7 +50,7 @@ const v3TrackedEthThreshold = 0.01 // Pools need at least 0.01 of trackedEth to 
 const v3UntrackedUsdThreshold = 25000 // Pools need at least 25K USD (untracked) to be selected (for metrics only)
 
 const v2TrackedEthThreshold = 0.025 // Pairs need at least 0.025 of trackedEth to be selected
-const v2UntrackedUsdThreshold = 1000 // Pairs need at least 1K USD (untracked) to be selected (for metrics only)
+const v2UntrackedUsdThreshold = Number.MAX_VALUE // Pairs need at least 1K USD (untracked) to be selected (for metrics only)
 
 export const chainProtocols = [
   // V3.
@@ -179,7 +179,15 @@ export const chainProtocols = [
     protocol: Protocol.V2,
     chainId: ChainId.MAINNET,
     timeout: 840000,
-    provider: new V2SubgraphProvider(ChainId.MAINNET, 3, 900000, true, 1000, v2TrackedEthThreshold, Number.MAX_VALUE), // 1000 is the largest page size supported by thegraph
+    provider: new V2SubgraphProvider(
+      ChainId.MAINNET,
+      3,
+      900000,
+      true,
+      1000,
+      v2TrackedEthThreshold,
+      v2UntrackedUsdThreshold
+    ), // 1000 is the largest page size supported by thegraph
   },
   {
     protocol: Protocol.V2,

--- a/lib/cron/cache-config.ts
+++ b/lib/cron/cache-config.ts
@@ -186,7 +186,7 @@ export const chainProtocols = [
       true,
       1000,
       v2TrackedEthThreshold,
-      v2UntrackedUsdThreshold
+      Number.MAX_VALUE,
     ), // 1000 is the largest page size supported by thegraph
   },
   {


### PR DESCRIPTION
we see HarryPotterObamaSonic10Inu (BITCOIN) going through  [V2] 100.00% = WETH -- [0x1058E2644E066031B7b4a76a4bB42208838eF938] --> FATMOM -- [0xA7776F25cc032549b7517154c0F0164db94478BA] --> BITCOIN. We think it might be related to filtering subgraph pools by untracked usd threshold in recent changes. We set that to max on v2 mainnet, so we only filter by tracked eth threshold.