### PR TITLE
fix: manually filter out fantom cached routes

### DIFF
--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -217,9 +217,28 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
       cachedRoutes.routes.forEach((cachedRoute) => {
         // we use the stringified route as identifier
         const routeId = routeToString(cachedRoute.route)
+
+        const routeHasNoFantom =
+          cachedRoute.protocol === Protocol.V2 &&
+          (cachedRoute.route as V2Route).chainId === ChainId.MAINNET &&
+          // either one of the below two conditions should allow us to filter out v2 route containing fantom,
+          // we use both to be extra certain we can filter out
+          ((cachedRoute.route as V2Route).path.find(
+            (token) => token.address === '0xe4b48B6bbAFcA1F82Ad2976E30A81c800C249Aa3'
+          ) ||
+            (cachedRoute.route as V2Route).pairs.find(
+              (pair) =>
+                pair.token0.address === '0xe4b48B6bbAFcA1F82Ad2976E30A81c800C249Aa3' ||
+                pair.token1.address === '0xe4b48B6bbAFcA1F82Ad2976E30A81c800C249Aa3'
+            ))
+
+        if (!routeHasNoFantom) {
+          log.warn(`Route ${routeId} has Fantom, skipping. This is a temporary fix.`)
+        }
+
         // Using a map to remove duplicates, we will the different percents of different routes.
         // We also filter by protocol, in case we are loading a route from a protocol that wasn't requested
-        if (!routesMap.has(routeId) && protocols.includes(cachedRoute.protocol)) {
+        if (!routesMap.has(routeId) && protocols.includes(cachedRoute.protocol) && routeHasNoFantom) {
           routesMap.set(routeId, cachedRoute)
         }
       })

--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -224,12 +224,12 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
           // either one of the below two conditions should allow us to filter out v2 route containing fantom,
           // we use both to be extra certain we can filter out
           ((cachedRoute.route as V2Route).path.find(
-            (token) => token.address === '0xe4b48B6bbAFcA1F82Ad2976E30A81c800C249Aa3'
+            (token) => token.address !== '0xe4b48B6bbAFcA1F82Ad2976E30A81c800C249Aa3'
           ) ||
             (cachedRoute.route as V2Route).pairs.find(
               (pair) =>
-                pair.token0.address === '0xe4b48B6bbAFcA1F82Ad2976E30A81c800C249Aa3' ||
-                pair.token1.address === '0xe4b48B6bbAFcA1F82Ad2976E30A81c800C249Aa3'
+                pair.token0.address !== '0xe4b48B6bbAFcA1F82Ad2976E30A81c800C249Aa3' ||
+                pair.token1.address !== '0xe4b48B6bbAFcA1F82Ad2976E30A81c800C249Aa3'
             ))
 
         if (!routeHasNoFantom) {

--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -218,10 +218,10 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
         // we use the stringified route as identifier
         const routeId = routeToString(cachedRoute.route)
 
-        const routeHasNoFantom =
+        const routeHasNoFATMOM =
           cachedRoute.protocol === Protocol.V2 &&
           (cachedRoute.route as V2Route).chainId === ChainId.MAINNET &&
-          // either one of the below two conditions should allow us to filter out v2 route containing fantom,
+          // either one of the below two conditions should allow us to filter out v2 route containing FATMOM,
           // we use both to be extra certain we can filter out
           ((cachedRoute.route as V2Route).path.find(
             (token) => token.address !== '0xe4b48B6bbAFcA1F82Ad2976E30A81c800C249Aa3'
@@ -232,13 +232,13 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
                 pair.token1.address !== '0xe4b48B6bbAFcA1F82Ad2976E30A81c800C249Aa3'
             ))
 
-        if (!routeHasNoFantom) {
-          log.warn(`Route ${routeId} has Fantom, skipping. This is a temporary fix.`)
+        if (!routeHasNoFATMOM) {
+          log.warn(`Route ${routeId} has FATMOM, skipping. This is a temporary fix.`)
         }
 
         // Using a map to remove duplicates, we will the different percents of different routes.
         // We also filter by protocol, in case we are loading a route from a protocol that wasn't requested
-        if (!routesMap.has(routeId) && protocols.includes(cachedRoute.protocol) && routeHasNoFantom) {
+        if (!routesMap.has(routeId) && protocols.includes(cachedRoute.protocol) && routeHasNoFATMOM) {
           routesMap.set(routeId, cachedRoute)
         }
       })


### PR DESCRIPTION
We still include FATMOM in the ETH -> HarryPotterObamaSonic10Inu (BITCOIN) quote route, despite the subgraph pool filtering logic changed to not consider untracked usd pools. I think this is because in caching intent routing-api lambda invocation, we keep hitting the ETH -> FATMOM -> HarryPotterObamaSonic10Inu (BITCOIN) routes from dynamo, but also getting the fresh routes from subgraph pools. However in SOR, it just meshes all those routes together to do the best quote comparison. SOR doesn't invalidate the cached routes, if the fresh routes from subgraph pools no longer contains any of the cached routes.