### PR TITLE
Revert "fix: manually filter out fantom cached routes (#712)"

### DIFF
--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -217,28 +217,9 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
       cachedRoutes.routes.forEach((cachedRoute) => {
         // we use the stringified route as identifier
         const routeId = routeToString(cachedRoute.route)
-
-        const routeHasNoFATMOM =
-          cachedRoute.protocol === Protocol.V2 &&
-          (cachedRoute.route as V2Route).chainId === ChainId.MAINNET &&
-          // either one of the below two conditions should allow us to filter out v2 route containing FATMOM,
-          // we use both to be extra certain we can filter out
-          ((cachedRoute.route as V2Route).path.find(
-            (token) => token.address !== '0xe4b48B6bbAFcA1F82Ad2976E30A81c800C249Aa3'
-          ) ||
-            (cachedRoute.route as V2Route).pairs.find(
-              (pair) =>
-                pair.token0.address !== '0xe4b48B6bbAFcA1F82Ad2976E30A81c800C249Aa3' ||
-                pair.token1.address !== '0xe4b48B6bbAFcA1F82Ad2976E30A81c800C249Aa3'
-            ))
-
-        if (!routeHasNoFATMOM) {
-          log.warn(`Route ${routeId} has FATMOM, skipping. This is a temporary fix.`)
-        }
-
         // Using a map to remove duplicates, we will the different percents of different routes.
         // We also filter by protocol, in case we are loading a route from a protocol that wasn't requested
-        if (!routesMap.has(routeId) && protocols.includes(cachedRoute.protocol) && routeHasNoFATMOM) {
+        if (!routesMap.has(routeId) && protocols.includes(cachedRoute.protocol)) {
           routesMap.set(routeId, cachedRoute)
         }
       })


### PR DESCRIPTION
This reverts commit 3f68d2e62083268e683c4657c63869b8f8378f16.

This is an arbitrary fix, that is short-term. Also I figured out a way to delete the cached routes entry in dynamo DB, so in future, we shouldn't need to apply this kind of hack, if we need to make sure certain cached routes don't get returned.