### PR TITLE
chore(subgraph-cache): Increase retries on decentralized network endpoints

### DIFF
--- a/lib/cron/cache-config.ts
+++ b/lib/cron/cache-config.ts
@@ -79,7 +79,7 @@ export const chainProtocols = [
     timeout: 90000,
     provider: new V3SubgraphProvider(
       ChainId.ARBITRUM_ONE,
-      3,
+      5,
       90000,
       true,
       v3TrackedEthThreshold,
@@ -194,7 +194,7 @@ export const chainProtocols = [
     timeout: 840000,
     provider: new V2SubgraphProvider(
       ChainId.MAINNET,
-      3,
+      5,
       900000,
       true,
       1000,


### PR DESCRIPTION
The decentralized network from the graph is prone to timeouts or other errors, this setting will increase the retries to 5 to try to get more successful runs
