### PR TITLE
fix: quicknode test key naming

### DIFF
--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -70,7 +70,7 @@
     "latencyEvaluationSampleProb": 0.05,
     "healthCheckSampleProb": 0.001,
     "providerInitialWeights": [0, 1, 0],
-    "providerUrls": ["ALCHEMY_1", "QUICKNODE_1", "QUICKNODE_TEST_1"]
+    "providerUrls": ["ALCHEMY_1", "QUICKNODE_1", "QUICKNODETEST_1"]
   },
   {
     "chainId": 81457,

--- a/lib/rpc/utils.ts
+++ b/lib/rpc/utils.ts
@@ -102,7 +102,7 @@ export function generateProviderUrl(key: string, value: string): string {
       return `https://${tokens[0]}.zora-mainnet.quiknode.pro/${tokens[1]}`
     }
     // QuickNode test key
-    case 'QUICKNODE_TEST_1': {
+    case 'QUICKNODETEST_1': {
       return `https://${tokens[0]}.quiknode.pro/${tokens[1]}`
     }
     // QuickNode RETH


### PR DESCRIPTION
We cannot name our secret as `QUICKNODE_TEST_1`. The reason is because in https://github.com/Uniswap/routing-api/blob/main/lib/rpc/ProdConfig.ts#L47, we extract provider name by the token before the first underscore. Then in https://github.com/Uniswap/routing-api/blob/main/bin/stacks/rpc-gateway-dashboard.ts#L15, we populate provider name for each chain. Having both `QUICKNODE_1` and `QUICKNODE_TEST_1` will result in duplicate provider name in the RPC dashboard, hence cdk bootstrap failure:

```
Error: There is already a Construct with name 'RoutingAPI-RpcGateway-ErrorRateAlarm-ChainId-1-Provider-QUIKNODE' in RpcGatewayFallbackStack [RpcGatewayFallbackStack]
    at Node.addChild (/Users/siyu.jiang/workspace/routing-api/node_modules/constructs/src/construct.ts:403:13)
    at new Node (/Users/siyu.jiang/workspace/routing-api/node_modules/constructs/src/construct.ts:71:17)
    at new Construct (/Users/siyu.jiang/workspace/routing-api/node_modules/constructs/src/construct.ts:463:17)
    at new Resource (/Users/siyu.jiang/workspace/routing-api/node_modules/aws-cdk-lib/core/lib/resource.js:1:1309)
    at new AlarmBase (/Users/siyu.jiang/workspace/routing-api/node_modules/aws-cdk-lib/aws-cloudwatch/lib/alarm-base.js:1:343)
    at new Alarm (/Users/siyu.jiang/workspace/routing-api/node_modules/aws-cdk-lib/aws-cloudwatch/lib/alarm.js:1:2624)
    at new RpcGatewayFallbackStack (/Users/siyu.jiang/workspace/routing-api/bin/stacks/rpc-gateway-fallback-stack.ts:87:23)
    at new RoutingAPIStack (/Users/siyu.jiang/workspace/routing-api/bin/stacks/routing-api-stack.ts:244:5)
    at Object.<anonymous> (/Users/siyu.jiang/workspace/routing-api/bin/app.ts:391:1)
    at Module._compile (node:internal/modules/cjs/loader:1218:14)
```