### PR TITLE
fix: bump lambda version to pick up secrets in env var

### DIFF
--- a/bin/stacks/routing-lambda-stack.ts
+++ b/bin/stacks/routing-lambda-stack.ts
@@ -117,7 +117,7 @@ export class RoutingLambdaStack extends cdk.NestedStack {
 
       description: 'Routing Lambda',
       environment: {
-        VERSION: '22',
+        VERSION: '23',
         NODE_OPTIONS: '--enable-source-maps',
         POOL_CACHE_BUCKET: poolCacheBucket.bucketName,
         POOL_CACHE_BUCKET_2: poolCacheBucket2.bucketName,


### PR DESCRIPTION
have to manually bump up the lambda version to pick up the new secret