### PR TITLE
fix: add quicknodetest_1 into the secret fetch list

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -217,6 +217,7 @@ export class RoutingAPIPipeline extends Stack {
       'NIRVANA_1',
       'ALCHEMY_1',
       'QUICKNODERETH_1',
+      'QUICKNODETEST_1',
       // Blast
       'QUICKNODE_81457',
       // 'INFURA_81457',


### PR DESCRIPTION
Forgot to add `quicknodetest_1` into the secret fetch list, so that we hit runtime error:

```
2024-06-06T22:10:25.844Z	undefined	ERROR	Unhandled Promise Rejection 	{"errorType":"Runtime.UnhandledPromiseRejection","errorMessage":"Error: Environmental variable QUICKNODETEST_1 isn't defined!","reason":{"errorType":"Error","errorMessage":"Environmental variable QUICKNODETEST_1 isn't defined!","stack":["Error: Environmental variable QUICKNODETEST_1 isn't defined!","    at Function.validateProdConfig (/lib/rpc/GlobalRpcProviders.ts:36:17)","    at Function.getGlobalUniRpcProviders (/lib/rpc/GlobalRpcProviders.ts:121:43)","    at <anonymous> (/lib/handlers/injector-sor.ts:168:35)","    at h (/node_modules/lodash/lodash.js:653:23)","    at Function.Kk (/node_modules/lodash/lodash.js:9622:14)","    at Zie.buildContainerInjected (/lib/handlers/injector-sor.ts:166:11)","    at Zie.build (/lib/handlers/handler.ts:51:41)","    at Object.<anonymous> (/lib/handlers/index.ts:13:74)","    at Module._compile (node:internal/modules/cjs/loader:1364:14)","    at Module._extensions..js (node:internal/modules/cjs/loader:1422:10)"]},"promise":{},"stack":["Runtime.UnhandledPromiseRejection: Error: Environmental variable QUICKNODETEST_1 isn't defined!","    at process.<anonymous> (file:///var/runtime/index.mjs:1276:17)","    at process.emit (node:events:517:28)","    at process.emit (node:domain:489:12)","    at emit (node:internal/process/promises:149:20)","    at processPromiseRejections (node:internal/process/promises:283:27)","    at process.processTicksAndRejections (node:internal/process/task_queues:96:32)"]}
```