### PR TITLE
feat: shadow tenderly new node endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The best way to develop and test the API is to deploy your own instance to AWS.
    TENDERLY_USER = '' # For enabling Tenderly simulations
    TENDERLY_PROJECT = '' # For enabling Tenderly simulations
    TENDERLY_ACCESS_KEY = '' # For enabling Tenderly simulations
+   TENDERLY_NODE_API_KEY = '' # For enabling Tenderly node-level RPC access
    ```
 3. Install and build the package
    ```

--- a/bin/app.ts
+++ b/bin/app.ts
@@ -35,6 +35,7 @@ export class RoutingAPIStage extends Stage {
       tenderlyUser: string
       tenderlyProject: string
       tenderlyAccessKey: string
+      tenderlyNodeApiKey: string
       unicornSecret: string
       alchemyQueryKey?: string
       decentralizedNetworkApiKey?: string
@@ -55,6 +56,7 @@ export class RoutingAPIStage extends Stage {
       tenderlyUser,
       tenderlyProject,
       tenderlyAccessKey,
+      tenderlyNodeApiKey,
       unicornSecret,
       alchemyQueryKey,
       decentralizedNetworkApiKey,
@@ -74,6 +76,7 @@ export class RoutingAPIStage extends Stage {
       tenderlyUser,
       tenderlyProject,
       tenderlyAccessKey,
+      tenderlyNodeApiKey,
       unicornSecret,
       alchemyQueryKey,
       decentralizedNetworkApiKey,
@@ -246,6 +249,7 @@ export class RoutingAPIPipeline extends Stack {
       tenderlyUser: tenderlyCreds.secretValueFromJson('tenderly-user').toString(),
       tenderlyProject: tenderlyCreds.secretValueFromJson('tenderly-project').toString(),
       tenderlyAccessKey: tenderlyCreds.secretValueFromJson('tenderly-access-key').toString(),
+      tenderlyNodeApiKey: tenderlyCreds.secretValueFromJson('tenderly-node-api-key').toString(),
       unicornSecret: unicornSecrets.secretValueFromJson('debug-config-unicorn-key').toString(),
       alchemyQueryKey: routingApiNewSecrets.secretValueFromJson('alchemy-query-key').toString(),
       decentralizedNetworkApiKey: routingApiNewSecrets.secretValueFromJson('decentralized-network-api-key').toString(),
@@ -271,6 +275,7 @@ export class RoutingAPIPipeline extends Stack {
       tenderlyUser: tenderlyCreds.secretValueFromJson('tenderly-user').toString(),
       tenderlyProject: tenderlyCreds.secretValueFromJson('tenderly-project').toString(),
       tenderlyAccessKey: tenderlyCreds.secretValueFromJson('tenderly-access-key').toString(),
+      tenderlyNodeApiKey: tenderlyCreds.secretValueFromJson('tenderly-node-api-key').toString(),
       unicornSecret: unicornSecrets.secretValueFromJson('debug-config-unicorn-key').toString(),
       alchemyQueryKey: routingApiNewSecrets.secretValueFromJson('alchemy-query-key').toString(),
       decentralizedNetworkApiKey: routingApiNewSecrets.secretValueFromJson('decentralized-network-api-key').toString(),
@@ -404,6 +409,7 @@ new RoutingAPIStack(app, 'RoutingAPIStack', {
   tenderlyUser: process.env.TENDERLY_USER!,
   tenderlyProject: process.env.TENDERLY_PROJECT!,
   tenderlyAccessKey: process.env.TENDERLY_ACCESS_KEY!,
+  tenderlyNodeApiKey: process.env.TENDERLY_NODE_API_KEY!,
   unicornSecret: process.env.UNICORN_SECRET!,
 })
 

--- a/bin/stacks/routing-api-stack.ts
+++ b/bin/stacks/routing-api-stack.ts
@@ -45,6 +45,7 @@ export class RoutingAPIStack extends cdk.Stack {
       tenderlyUser: string
       tenderlyProject: string
       tenderlyAccessKey: string
+      tenderlyNodeApiKey: string
       unicornSecret: string
       alchemyQueryKey?: string
       decentralizedNetworkApiKey?: string
@@ -67,6 +68,7 @@ export class RoutingAPIStack extends cdk.Stack {
       tenderlyUser,
       tenderlyProject,
       tenderlyAccessKey,
+      tenderlyNodeApiKey,
       unicornSecret,
       alchemyQueryKey,
       decentralizedNetworkApiKey,
@@ -117,6 +119,7 @@ export class RoutingAPIStack extends cdk.Stack {
       tenderlyUser,
       tenderlyProject,
       tenderlyAccessKey,
+      tenderlyNodeApiKey,
       routesDynamoDb,
       routesDbCachingRequestFlagDynamoDb,
       cachedRoutesDynamoDb,

--- a/bin/stacks/routing-lambda-stack.ts
+++ b/bin/stacks/routing-lambda-stack.ts
@@ -27,6 +27,7 @@ export interface RoutingLambdaStackProps extends cdk.NestedStackProps {
   tenderlyUser: string
   tenderlyProject: string
   tenderlyAccessKey: string
+  tenderlyNodeApiKey: string
   chatbotSNSArn?: string
   routesDynamoDb: aws_dynamodb.Table
   routesDbCachingRequestFlagDynamoDb: aws_dynamodb.Table
@@ -58,6 +59,7 @@ export class RoutingLambdaStack extends cdk.NestedStack {
       tenderlyUser,
       tenderlyProject,
       tenderlyAccessKey,
+      tenderlyNodeApiKey,
       routesDynamoDb,
       routesDbCachingRequestFlagDynamoDb,
       cachedRoutesDynamoDb,
@@ -117,7 +119,7 @@ export class RoutingLambdaStack extends cdk.NestedStack {
 
       description: 'Routing Lambda',
       environment: {
-        VERSION: '23',
+        VERSION: '24',
         NODE_OPTIONS: '--enable-source-maps',
         POOL_CACHE_BUCKET: poolCacheBucket.bucketName,
         POOL_CACHE_BUCKET_2: poolCacheBucket2.bucketName,
@@ -129,6 +131,7 @@ export class RoutingLambdaStack extends cdk.NestedStack {
         TENDERLY_USER: tenderlyUser,
         TENDERLY_PROJECT: tenderlyProject,
         TENDERLY_ACCESS_KEY: tenderlyAccessKey,
+        TENDERLY_NODE_API_KEY: tenderlyNodeApiKey,
         // WARNING: Dynamo table name should be the tableinstance.name, e.g. routesDynamoDb.tableName.
         //          But we tried and had seen lambd version error:
         //          The following resource(s) failed to create: [RoutingLambda2CurrentVersion49A1BB948389ce4f9c26b15e2ccb07b4c1bab726].

--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -37,7 +37,7 @@ import {
   UniswapMulticallProvider,
   V2PoolProvider,
   V2QuoteProvider,
-  V3PoolProvider,
+  V3PoolProvider
 } from '@uniswap/smart-order-router'
 import { TokenList } from '@uniswap/token-lists'
 import { default as bunyan, default as Logger } from 'bunyan'
@@ -60,12 +60,12 @@ import { GlobalRpcProviders } from '../rpc/GlobalRpcProviders'
 import { StaticJsonRpcProvider } from '@ethersproject/providers'
 import { TrafficSwitchOnChainQuoteProvider } from './quote/provider-migration/v3/traffic-switch-on-chain-quote-provider'
 import {
-  NON_OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS,
   BLOCK_NUMBER_CONFIGS,
   GAS_ERROR_FAILURE_OVERRIDES,
-  RETRY_OPTIONS,
-  SUCCESS_RATE_FAILURE_OVERRIDES,
+  NON_OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS,
   OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS,
+  RETRY_OPTIONS,
+  SUCCESS_RATE_FAILURE_OVERRIDES
 } from '../util/onChainQuoteProviderConfigs'
 import { v4 } from 'uuid/index'
 import { chainProtocols } from '../cron/cache-config'
@@ -388,13 +388,16 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
             process.env.TENDERLY_USER!,
             process.env.TENDERLY_PROJECT!,
             process.env.TENDERLY_ACCESS_KEY!,
+            process.env.TENDERLY_NODE_API_KEY!,
             v2PoolProvider,
             v3PoolProvider,
             provider,
             portionProvider,
             undefined,
             // The timeout for the underlying axios call to Tenderly, measured in milliseconds.
-            2.5 * 1000
+            2.5 * 1000,
+            10,
+            [ChainId.MAINNET]
           )
 
           const ethEstimateGasSimulator = new EthEstimateGasSimulator(

--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -37,7 +37,7 @@ import {
   UniswapMulticallProvider,
   V2PoolProvider,
   V2QuoteProvider,
-  V3PoolProvider
+  V3PoolProvider,
 } from '@uniswap/smart-order-router'
 import { TokenList } from '@uniswap/token-lists'
 import { default as bunyan, default as Logger } from 'bunyan'
@@ -65,7 +65,7 @@ import {
   NON_OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS,
   OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS,
   RETRY_OPTIONS,
-  SUCCESS_RATE_FAILURE_OVERRIDES
+  SUCCESS_RATE_FAILURE_OVERRIDES,
 } from '../util/onChainQuoteProviderConfigs'
 import { v4 } from 'uuid/index'
 import { chainProtocols } from '../cron/cache-config'

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@uniswap/permit2-sdk": "^1.2.0",
         "@uniswap/router-sdk": "^1.9.2",
         "@uniswap/sdk-core": "^4.2.0",
-        "@uniswap/smart-order-router": "3.33.1",
+        "@uniswap/smart-order-router": "3.34.0",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^2.1.0",
         "@uniswap/v2-sdk": "^4.3.2",
@@ -4761,9 +4761,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.33.1",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.33.1.tgz",
-      "integrity": "sha512-w6LaNgsMdsz3M+DX98M3PzosHg1nn2mIH/1uXVydNhYG9XyIRLS71x/75mx/jfp1MCoqw/OernLE2cMRq5YQUg==",
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.34.0.tgz",
+      "integrity": "sha512-/cWIxmvrsaEvpvGYsGGgmU47FNKZKpo53LJHvzCjFdBNWG/0vPF8OeiecaSi+H4o16f4HTM2UgBzv+E0HVXK4w==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -28474,9 +28474,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.33.1",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.33.1.tgz",
-      "integrity": "sha512-w6LaNgsMdsz3M+DX98M3PzosHg1nn2mIH/1uXVydNhYG9XyIRLS71x/75mx/jfp1MCoqw/OernLE2cMRq5YQUg==",
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.34.0.tgz",
+      "integrity": "sha512-/cWIxmvrsaEvpvGYsGGgmU47FNKZKpo53LJHvzCjFdBNWG/0vPF8OeiecaSi+H4o16f4HTM2UgBzv+E0HVXK4w==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@uniswap/router-sdk": "^1.9.2",
     "@uniswap/sdk-core": "^4.2.0",
     "@types/semver": "^7.5.8",
-    "@uniswap/smart-order-router": "3.33.1",
+    "@uniswap/smart-order-router": "3.34.0",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^2.1.0",
     "@uniswap/v2-sdk": "^4.3.2",


### PR DESCRIPTION
We want to test out the new node endpoint latencies at 10% of prod traffic scale in shadow sampling.

tested on local routing-api:

![Screenshot 2024-06-07 at 12.31.39 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/b579e1db-c885-4039-b774-2a22fe5bce21.png)

