### PR TITLE
feat: double sampling tenderly node estimate gas api

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -396,7 +396,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
             undefined,
             // The timeout for the underlying axios call to Tenderly, measured in milliseconds.
             2.5 * 1000,
-            10,
+            20,
             [ChainId.MAINNET]
           )
 


### PR DESCRIPTION
We want to double the tenderly node endpoint sampling traffic from 10% to 20%, to make sure the latencies stay consistent