### PR TITLE
fix: bump lambda version to pick up new zksync secret

### DIFF
--- a/bin/stacks/routing-lambda-stack.ts
+++ b/bin/stacks/routing-lambda-stack.ts
@@ -107,7 +107,7 @@ export class RoutingLambdaStack extends cdk.NestedStack {
       // 11/8/23: URA currently calls the Routing API with a timeout of 10 seconds.
       // Set this lambda's timeout to be slightly lower to give them time to
       // log the response in the event of a failure on our end.
-      timeout: cdk.Duration.seconds(30),
+      timeout: cdk.Duration.seconds(9),
       memorySize: 2560,
       deadLetterQueueEnabled: true,
       bundling: {

--- a/bin/stacks/routing-lambda-stack.ts
+++ b/bin/stacks/routing-lambda-stack.ts
@@ -107,7 +107,7 @@ export class RoutingLambdaStack extends cdk.NestedStack {
       // 11/8/23: URA currently calls the Routing API with a timeout of 10 seconds.
       // Set this lambda's timeout to be slightly lower to give them time to
       // log the response in the event of a failure on our end.
-      timeout: cdk.Duration.seconds(9),
+      timeout: cdk.Duration.seconds(30),
       memorySize: 2560,
       deadLetterQueueEnabled: true,
       bundling: {
@@ -119,7 +119,7 @@ export class RoutingLambdaStack extends cdk.NestedStack {
 
       description: 'Routing Lambda',
       environment: {
-        VERSION: '24',
+        VERSION: '25',
         NODE_OPTIONS: '--enable-source-maps',
         POOL_CACHE_BUCKET: poolCacheBucket.bucketName,
         POOL_CACHE_BUCKET_2: poolCacheBucket2.bucketName,

--- a/lib/handlers/quote/injector.ts
+++ b/lib/handlers/quote/injector.ts
@@ -37,7 +37,7 @@ export class QuoteHandlerInjector extends InjectorSOR<
     // All other requests will only log warnings and errors.
     // Note that we use WARN as a default rather than ERROR
     // to capture Tapcompare logs in the smart-order-router.
-    const logLevel = Math.random() < 0.1 ? bunyan.DEBUG : bunyan.DEBUG
+    const logLevel = Math.random() < 0.1 ? bunyan.INFO : bunyan.WARN
 
     const {
       tokenInAddress,

--- a/lib/handlers/quote/injector.ts
+++ b/lib/handlers/quote/injector.ts
@@ -37,7 +37,7 @@ export class QuoteHandlerInjector extends InjectorSOR<
     // All other requests will only log warnings and errors.
     // Note that we use WARN as a default rather than ERROR
     // to capture Tapcompare logs in the smart-order-router.
-    const logLevel = Math.random() < 0.1 ? bunyan.INFO : bunyan.WARN
+    const logLevel = Math.random() < 0.1 ? bunyan.DEBUG : bunyan.DEBUG
 
     const {
       tokenInAddress,


### PR DESCRIPTION
I forgot to update the secret before merging the previous PR. Now the routing-api pipeline is stuck during the CDK update because it's not able to fetch the secret I newly created after the initial CDK update.

I'm manually bumping the lambda version to force re-picking new secrets.