### PR TITLE
fix: bump lambda version again

### DIFF
--- a/bin/stacks/routing-lambda-stack.ts
+++ b/bin/stacks/routing-lambda-stack.ts
@@ -119,7 +119,7 @@ export class RoutingLambdaStack extends cdk.NestedStack {
 
       description: 'Routing Lambda',
       environment: {
-        VERSION: '25',
+        VERSION: '26',
         NODE_OPTIONS: '--enable-source-maps',
         POOL_CACHE_BUCKET: poolCacheBucket.bucketName,
         POOL_CACHE_BUCKET_2: poolCacheBucket2.bucketName,


### PR DESCRIPTION
I forgot to add the secret `WEB3_RPC_324`, but it's actually being used in app.ts. I have to manually bump lambda version again.