### PR TITLE
fix: add missing ALCHEMY_324

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -227,6 +227,7 @@ export class RoutingAPIPipeline extends Stack {
       'QUICKNODE_7777777',
       // ZkSync
       'QUICKNODE_324',
+      'ALCHEMY_324',
     ]
     for (const provider of RPC_GATEWAY_PROVIDERS) {
       jsonRpcProviders[provider] = jsonRpcProvidersSecret.secretValueFromJson(provider).toString()


### PR DESCRIPTION
From routing beta lambda:

```
    "errorType": "Runtime.UnhandledPromiseRejection",
    "errorMessage": "Error: Environmental variable ALCHEMY_324 isn't defined!",
    "reason": {
        "errorType": "Error",
        "errorMessage": "Environmental variable ALCHEMY_324 isn't defined!",
        "stack": [
            "Error: Environmental variable ALCHEMY_324 isn't defined!",
            "    at Function.validateProdConfig (/lib/rpc/GlobalRpcProviders.ts:36:17)",
            "    at Function.getGlobalUniRpcProviders (/lib/rpc/GlobalRpcProviders.ts:121:43)",
            "    at <anonymous> (/lib/handlers/injector-sor.ts:169:35)",
            "    at h (/node_modules/lodash/lodash.js:653:23)",
            "    at Function.gv (/node_modules/lodash/lodash.js:9622:14)",
            "    at Lee.buildContainerInjected (/lib/handlers/injector-sor.ts:167:11)",
            "    at Lee.build (/lib/handlers/handler.ts:51:41)",
            "    at Object.<anonymous> (/lib/handlers/index.ts:13:74)",
            "    at Module._compile (node:internal/modules/cjs/loader:1364:14)",
            "    at Module._extensions..js (node:internal/modules/cjs/loader:1422:10)"
        ]
    },
    "promise": {},
    "stack": [
        "Runtime.UnhandledPromiseRejection: Error: Environmental variable ALCHEMY_324 isn't defined!",
        "    at process.<anonymous> (file:///var/runtime/index.mjs:1276:17)",
        "    at process.emit (node:events:517:28)",
        "    at process.emit (node:domain:489:12)",
        "    at emit (node:internal/process/promises:149:20)",
        "    at processPromiseRejections (node:internal/process/promises:283:27)",
        "    at process.processTicksAndRejections (node:internal/process/task_queues:96:32)"
    ]
```

Then I realized `ALCHEMY_324` is missing from the rpc gateway array