### PR TITLE
chore(subgraph-cache): Migrate to Alchemy's subgraph

### DIFF
--- a/lib/cron/cache-config.ts
+++ b/lib/cron/cache-config.ts
@@ -31,7 +31,7 @@ const v3SubgraphUrlOverride = (chainId: ChainId) => {
 const v2SubgraphUrlOverride = (chainId: ChainId) => {
   switch (chainId) {
     case ChainId.MAINNET:
-      return `https://gateway-arbitrum.network.thegraph.com/api/${process.env.DCN_API_KEY}/subgraphs/id/FEtpnfQ1aqF8um2YktEkfzFD11ZKrfurvBLPeQzv9JB1`
+      return `https://subgraph.satsuma-prod.com/${process.env.ALCHEMY_QUERY_KEY}/uniswap/uniswap-v2-mainnet/api`
     case ChainId.ARBITRUM_ONE:
       return `https://subgraph.satsuma-prod.com/${process.env.ALCHEMY_QUERY_KEY}/uniswap/uniswap-v2-arbitrum/api`
     case ChainId.POLYGON:


### PR DESCRIPTION
This PR migrates the V2 Subgraph Provider for the CachePools cron job from the decentralized network to Alchemy,