### PR TITLE
fix(caching): bump SOR version to 3.35.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.9.2",
         "@uniswap/sdk-core": "^5.3.0",
-        "@uniswap/smart-order-router": "3.35.0",
+        "@uniswap/smart-order-router": "3.35.1",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^2.2.0",
         "@uniswap/v2-sdk": "^4.3.2",
@@ -4748,9 +4748,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.35.0.tgz",
-      "integrity": "sha512-RNieO2HboHwPGkP02K0XLLwPKjnWprEL27zj07HqHaLHA2X9rGraypu7z4Sd8xf5L2NAehgixTMJAOdo1mWHUw==",
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.35.1.tgz",
+      "integrity": "sha512-FHL+ViNfP6CFxAHS7ldmmt/2DIFwZMcyNHm+R0UyILS2oXH8PGHD0/TomC0LNhw/68sGgrBmQbVzasoL4rPp/Q==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -28385,9 +28385,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.35.0.tgz",
-      "integrity": "sha512-RNieO2HboHwPGkP02K0XLLwPKjnWprEL27zj07HqHaLHA2X9rGraypu7z4Sd8xf5L2NAehgixTMJAOdo1mWHUw==",
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.35.1.tgz",
+      "integrity": "sha512-FHL+ViNfP6CFxAHS7ldmmt/2DIFwZMcyNHm+R0UyILS2oXH8PGHD0/TomC0LNhw/68sGgrBmQbVzasoL4rPp/Q==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@uniswap/router-sdk": "^1.9.2",
     "@uniswap/sdk-core": "^5.3.0",
     "@types/semver": "^7.5.8",
-    "@uniswap/smart-order-router": "3.35.0",
+    "@uniswap/smart-order-router": "3.35.1",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^2.2.0",
     "@uniswap/v2-sdk": "^4.3.2",


### PR DESCRIPTION
Bump SOR version to 3.35.1 that contains the [fee fetcher cache fix](https://github.com/Uniswap/smart-order-router/pull/596)

## Testing
Ran e2e tests against test aws environment
```
npm run test:e2e

  211 passing (5m)
  4 pending
```