### PR TITLE
fix: add wstETH/USDC and wstETH/DOG liquid pools for routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The best way to develop and test the API is to deploy your own instance to AWS.
    TENDERLY_PROJECT = '' # For enabling Tenderly simulations
    TENDERLY_ACCESS_KEY = '' # For enabling Tenderly simulations
    TENDERLY_NODE_API_KEY = '' # For enabling Tenderly node-level RPC access
+   ALCHEMY_QUERY_KEY = '' For Alchemy subgraph query access
    ```
 3. Install and build the package
    ```

--- a/lib/cron/cache-config.ts
+++ b/lib/cron/cache-config.ts
@@ -2,6 +2,10 @@ import { Protocol } from '@uniswap/router-sdk'
 import { V2SubgraphProvider, V3SubgraphProvider } from '@uniswap/smart-order-router'
 import { ChainId } from '@uniswap/sdk-core'
 
+// during local cdk stack update, the env vars are not populated
+// make sure to fill in the env vars below
+// process.env.ALCHEMY_QUERY_KEY = ''
+
 export const v3SubgraphUrlOverride = (chainId: ChainId) => {
   switch (chainId) {
     case ChainId.MAINNET:

--- a/lib/cron/cache-config.ts
+++ b/lib/cron/cache-config.ts
@@ -28,7 +28,7 @@ const v3SubgraphUrlOverride = (chainId: ChainId) => {
   }
 }
 
-const v2SubgraphUrlOverride = (chainId: ChainId) => {
+export const v2SubgraphUrlOverride = (chainId: ChainId) => {
   switch (chainId) {
     case ChainId.MAINNET:
       return `https://subgraph.satsuma-prod.com/${process.env.ALCHEMY_QUERY_KEY}/uniswap/uniswap-v2-mainnet/api`
@@ -54,7 +54,7 @@ const v2SubgraphUrlOverride = (chainId: ChainId) => {
 const v3TrackedEthThreshold = 0.01 // Pools need at least 0.01 of trackedEth to be selected
 const v3UntrackedUsdThreshold = 25000 // Pools need at least 25K USD (untracked) to be selected (for metrics only)
 
-const v2TrackedEthThreshold = 0.025 // Pairs need at least 0.025 of trackedEth to be selected
+export const v2TrackedEthThreshold = 0.025 // Pairs need at least 0.025 of trackedEth to be selected
 const v2UntrackedUsdThreshold = Number.MAX_VALUE // Pairs need at least 1K USD (untracked) to be selected (for metrics only)
 
 export const chainProtocols = [

--- a/lib/cron/cache-config.ts
+++ b/lib/cron/cache-config.ts
@@ -2,7 +2,7 @@ import { Protocol } from '@uniswap/router-sdk'
 import { V2SubgraphProvider, V3SubgraphProvider } from '@uniswap/smart-order-router'
 import { ChainId } from '@uniswap/sdk-core'
 
-const v3SubgraphUrlOverride = (chainId: ChainId) => {
+export const v3SubgraphUrlOverride = (chainId: ChainId) => {
   switch (chainId) {
     case ChainId.MAINNET:
       return `https://subgraph.satsuma-prod.com/${process.env.ALCHEMY_QUERY_KEY}/uniswap/uniswap-v3-mainnet/api`
@@ -51,7 +51,7 @@ export const v2SubgraphUrlOverride = (chainId: ChainId) => {
   }
 }
 
-const v3TrackedEthThreshold = 0.01 // Pools need at least 0.01 of trackedEth to be selected
+export const v3TrackedEthThreshold = 0.01 // Pools need at least 0.01 of trackedEth to be selected
 const v3UntrackedUsdThreshold = 25000 // Pools need at least 25K USD (untracked) to be selected (for metrics only)
 
 export const v2TrackedEthThreshold = 0.025 // Pairs need at least 0.025 of trackedEth to be selected

--- a/lib/cron/cache-pools.ts
+++ b/lib/cron/cache-pools.ts
@@ -1,9 +1,5 @@
 import { Protocol } from '@uniswap/router-sdk'
-import {
-  setGlobalLogger,
-  setGlobalMetric,
-  V2SubgraphProvider,
-} from '@uniswap/smart-order-router'
+import { setGlobalLogger, setGlobalMetric, V2SubgraphProvider } from '@uniswap/smart-order-router'
 import { EventBridgeEvent, ScheduledHandler } from 'aws-lambda'
 import { S3 } from 'aws-sdk'
 import { ChainId } from '@uniswap/sdk-core'
@@ -58,7 +54,11 @@ const handler: ScheduledHandler = metricScope((metrics) => async (event: EventBr
         v2SubgraphUrlOverride(ChainId.MAINNET)
       )
       const additionalPools = await v2MainnetSubgraphProvider.getPools()
-      const filteredPools = additionalPools.filter((pool) => pool.id.toLowerCase() === '0x801c868ce08fb5b396e6911eac351beb259d386c' || pool.id.toLowerCase() === '0x4622Df6fB2d9Bee0DCDaCF545aCDB6a2b2f4f863')
+      const filteredPools = additionalPools.filter(
+        (pool) =>
+          pool.id.toLowerCase() === '0x801c868ce08fb5b396e6911eac351beb259d386c' ||
+          pool.id.toLowerCase() === '0x4622df6fb2d9bee0dcdacf545acdb6a2b2f4f863'
+      )
       log.info({ additionalPools }, `Additional filtered pool for ${protocol} on ${chainId}`)
 
       filteredPools.forEach((pool) => pools.push(pool))

--- a/lib/cron/cache-pools.ts
+++ b/lib/cron/cache-pools.ts
@@ -15,6 +15,12 @@ import {
 import { AWSMetricsLogger } from '../handlers/router-entities/aws-metrics-logger'
 import { metricScope } from 'aws-embedded-metrics'
 import * as zlib from 'zlib'
+import dotenv from 'dotenv'
+
+// Needed for local stack dev, not needed for staging or prod
+// But it still doesn't work on the local cdk stack update,
+// so we will manually populate ALCHEMY_QUERY_KEY env var in the cron job lambda in cache-config.ts
+dotenv.config()
 
 const handler: ScheduledHandler = metricScope((metrics) => async (event: EventBridgeEvent<string, void>) => {
   const beforeAll = Date.now()
@@ -63,7 +69,7 @@ const handler: ScheduledHandler = metricScope((metrics) => async (event: EventBr
       const filteredPools = additionalPools.filter(
         (pool) => pool.id.toLowerCase() === '0x801c868ce08fb5b396e6911eac351beb259d386c'
       )
-      log.info({ additionalPools }, `Additional filtered pool for ${protocol} on ${chainId}`)
+      log.info({ filteredPools }, `Additional filtered pool for ${protocol} on ${chainId}`)
 
       filteredPools.forEach((pool) => pools.push(pool))
     }
@@ -82,7 +88,7 @@ const handler: ScheduledHandler = metricScope((metrics) => async (event: EventBr
       const filteredPools = additionalPools.filter(
         (pool) => pool.id.toLowerCase() === '0x4622df6fb2d9bee0dcdacf545acdb6a2b2f4f863'
       )
-      log.info({ additionalPools }, `Additional filtered pool for ${protocol} on ${chainId}`)
+      log.info({ filteredPools }, `Additional filtered pool for ${protocol} on ${chainId}`)
 
       filteredPools.forEach((pool) => pools.push(pool))
     }

--- a/lib/cron/cache-pools.ts
+++ b/lib/cron/cache-pools.ts
@@ -1,11 +1,17 @@
 import { Protocol } from '@uniswap/router-sdk'
-import { setGlobalLogger, setGlobalMetric, V2SubgraphProvider } from '@uniswap/smart-order-router'
+import { setGlobalLogger, setGlobalMetric, V2SubgraphProvider, V3SubgraphProvider } from '@uniswap/smart-order-router'
 import { EventBridgeEvent, ScheduledHandler } from 'aws-lambda'
 import { S3 } from 'aws-sdk'
 import { ChainId } from '@uniswap/sdk-core'
 import { default as bunyan, default as Logger } from 'bunyan'
 import { S3_POOL_CACHE_KEY } from '../util/pool-cache-key'
-import { chainProtocols, v2SubgraphUrlOverride, v2TrackedEthThreshold } from './cache-config'
+import {
+  chainProtocols,
+  v2SubgraphUrlOverride,
+  v2TrackedEthThreshold,
+  v3SubgraphUrlOverride,
+  v3TrackedEthThreshold,
+} from './cache-config'
 import { AWSMetricsLogger } from '../handlers/router-entities/aws-metrics-logger'
 import { metricScope } from 'aws-embedded-metrics'
 import * as zlib from 'zlib'
@@ -50,14 +56,31 @@ const handler: ScheduledHandler = metricScope((metrics) => async (event: EventBr
         true,
         1000,
         v2TrackedEthThreshold,
-        1000, // Pairs need at least 1K USD (untracked) to be selected (for metrics only),
+        0, // wstETH/DOG reserveUSD is 0, but the pool balance (https://app.uniswap.org/explore/pools/ethereum/0x801c868ce08fb5b396e6911eac351beb259d386c) is sufficiently hight
         v2SubgraphUrlOverride(ChainId.MAINNET)
       )
       const additionalPools = await v2MainnetSubgraphProvider.getPools()
       const filteredPools = additionalPools.filter(
-        (pool) =>
-          pool.id.toLowerCase() === '0x801c868ce08fb5b396e6911eac351beb259d386c' ||
-          pool.id.toLowerCase() === '0x4622df6fb2d9bee0dcdacf545acdb6a2b2f4f863'
+        (pool) => pool.id.toLowerCase() === '0x801c868ce08fb5b396e6911eac351beb259d386c'
+      )
+      log.info({ additionalPools }, `Additional filtered pool for ${protocol} on ${chainId}`)
+
+      filteredPools.forEach((pool) => pools.push(pool))
+    }
+
+    if (protocol === Protocol.V3 && chainId === ChainId.MAINNET) {
+      const v3MainnetSubgraphProvider = new V3SubgraphProvider(
+        ChainId.MAINNET,
+        3,
+        90000,
+        true,
+        v3TrackedEthThreshold,
+        0, // wstETH/USDC totalValueLockedUSDUntracked is 0, but the pool balance (https://app.uniswap.org/explore/pools/ethereum/0x4622df6fb2d9bee0dcdacf545acdb6a2b2f4f863) is sufficiently hight
+        v3SubgraphUrlOverride(ChainId.MAINNET)
+      )
+      const additionalPools = await v3MainnetSubgraphProvider.getPools()
+      const filteredPools = additionalPools.filter(
+        (pool) => pool.id.toLowerCase() === '0x4622df6fb2d9bee0dcdacf545acdb6a2b2f4f863'
       )
       log.info({ additionalPools }, `Additional filtered pool for ${protocol} on ${chainId}`)
 


### PR DESCRIPTION
[wstETH/USDC](https://app.uniswap.org/explore/pools/ethereum/0x4622Df6fB2d9Bee0DCDaCF545aCDB6a2b2f4f863) and [wstETH/DOG](https://app.uniswap.org/explore/pools/ethereum/0x801c868ce08fb5b396e6911eac351beb259d386c) are liquid, so we will route through them.

I can see v3 [wstETH/USDC](https://app.uniswap.org/explore/pools/ethereum/0x4622Df6fB2d9Bee0DCDaCF545aCDB6a2b2f4f863) getting into the pools s3 file:
<img width="1146" alt="Screenshot 2024-06-12 at 3 45 26 PM" src="https://github.com/Uniswap/routing-api/assets/91580504/1c6cc073-8042-43ea-bc9d-543de8de0246">

for [wstETH/DOG](https://app.uniswap.org/explore/pools/ethereum/0x801c868ce08fb5b396e6911eac351beb259d386c), I don't see it. But I think it's because alchemy v2-mainnet subgraph is only sync'ing around block 18701239, meanwhile the pool deployed at block [18737159](https://etherscan.io/block/18737159)