### PR TITLE
chore: bump sor to 3.35.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.9.2",
         "@uniswap/sdk-core": "^5.3.0",
-        "@uniswap/smart-order-router": "3.35.1",
+        "@uniswap/smart-order-router": "3.35.2",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^2.2.0",
         "@uniswap/v2-sdk": "^4.3.2",
@@ -4748,9 +4748,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.35.1",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.35.1.tgz",
-      "integrity": "sha512-FHL+ViNfP6CFxAHS7ldmmt/2DIFwZMcyNHm+R0UyILS2oXH8PGHD0/TomC0LNhw/68sGgrBmQbVzasoL4rPp/Q==",
+      "version": "3.35.2",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.35.2.tgz",
+      "integrity": "sha512-lRpOgEeB7Lz25/b2tWE8pceqUOTfYqBQgs8MO7iHBwH5YtWTq9IhbEAuUA9rXVDG53NQTBHrLCvnki+dvQGLpw==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -28385,9 +28385,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.35.1",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.35.1.tgz",
-      "integrity": "sha512-FHL+ViNfP6CFxAHS7ldmmt/2DIFwZMcyNHm+R0UyILS2oXH8PGHD0/TomC0LNhw/68sGgrBmQbVzasoL4rPp/Q==",
+      "version": "3.35.2",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.35.2.tgz",
+      "integrity": "sha512-lRpOgEeB7Lz25/b2tWE8pceqUOTfYqBQgs8MO7iHBwH5YtWTq9IhbEAuUA9rXVDG53NQTBHrLCvnki+dvQGLpw==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@uniswap/router-sdk": "^1.9.2",
     "@uniswap/sdk-core": "^5.3.0",
     "@types/semver": "^7.5.8",
-    "@uniswap/smart-order-router": "3.35.1",
+    "@uniswap/smart-order-router": "3.35.2",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^2.2.0",
     "@uniswap/v2-sdk": "^4.3.2",


### PR DESCRIPTION
Release https://github.com/Uniswap/smart-order-router/pull/605, which may unblock trading API team on the permit2 approval flow (TBD).