### PR TITLE
lower zksync gas limit per quote from 3 million to 500k

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -335,6 +335,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
             case ChainId.AVALANCHE:
             case ChainId.BLAST:
             case ChainId.ZORA:
+            case ChainId.ZKSYNC:
               const currentQuoteProvider = new OnChainQuoteProvider(
                 chainId,
                 provider,

--- a/lib/util/onChainQuoteProviderConfigs.ts
+++ b/lib/util/onChainQuoteProviderConfigs.ts
@@ -275,8 +275,8 @@ export const GAS_ERROR_FAILURE_OVERRIDES: { [chainId: number]: FailureOverrides 
     multicallChunk: 45,
   },
   [ChainId.ZKSYNC]: {
-    gasLimitOverride: 1_000_000,
-    multicallChunk: 81,
+    gasLimitOverride: 3_000_000,
+    multicallChunk: 27,
   },
 }
 
@@ -303,8 +303,8 @@ export const SUCCESS_RATE_FAILURE_OVERRIDES: { [chainId: number]: FailureOverrid
     multicallChunk: 45,
   },
   [ChainId.ZKSYNC]: {
-    gasLimitOverride: 1_000_000,
-    multicallChunk: 81,
+    gasLimitOverride: 3_000_000,
+    multicallChunk: 27,
   },
 }
 

--- a/lib/util/onChainQuoteProviderConfigs.ts
+++ b/lib/util/onChainQuoteProviderConfigs.ts
@@ -92,6 +92,11 @@ export const OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [protocol: string]: { [cha
       gasLimitPerCall: 75_000,
       quoteMinSuccessRate: 0.15,
     },
+    [ChainId.ZKSYNC]: {
+      multicallChunk: 162,
+      gasLimitPerCall: 500_000,
+      quoteMinSuccessRate: 0.15,
+    },
   },
   [Protocol.MIXED]: {
     ...constructSameBatchParamsMap(DEFAULT_BATCH_PARAMS),
@@ -133,6 +138,11 @@ export const OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [protocol: string]: { [cha
     [ChainId.POLYGON]: {
       multicallChunk: 1850,
       gasLimitPerCall: 80_000,
+      quoteMinSuccessRate: 0.15,
+    },
+    [ChainId.ZKSYNC]: {
+      multicallChunk: 162,
+      gasLimitPerCall: 500_000,
       quoteMinSuccessRate: 0.15,
     },
   },
@@ -186,6 +196,11 @@ export const NON_OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [protocol: string]: { 
       gasLimitPerCall: 150_000,
       quoteMinSuccessRate: 0.15,
     },
+    [ChainId.ZKSYNC]: {
+      multicallChunk: 162,
+      gasLimitPerCall: 500_000,
+      quoteMinSuccessRate: 0.15,
+    },
   },
   [Protocol.MIXED]: {
     ...constructSameBatchParamsMap(DEFAULT_BATCH_PARAMS),
@@ -229,6 +244,11 @@ export const NON_OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [protocol: string]: { 
       gasLimitPerCall: 150_000,
       quoteMinSuccessRate: 0.15,
     },
+    [ChainId.ZKSYNC]: {
+      multicallChunk: 162,
+      gasLimitPerCall: 500_000,
+      quoteMinSuccessRate: 0.15,
+    },
   },
 }
 
@@ -254,6 +274,10 @@ export const GAS_ERROR_FAILURE_OVERRIDES: { [chainId: number]: FailureOverrides 
     gasLimitOverride: 3_000_000,
     multicallChunk: 45,
   },
+  [ChainId.ZKSYNC]: {
+    gasLimitOverride: 1_000_000,
+    multicallChunk: 81,
+  },
 }
 
 export const SUCCESS_RATE_FAILURE_OVERRIDES: { [chainId: number]: FailureOverrides } = {
@@ -277,6 +301,10 @@ export const SUCCESS_RATE_FAILURE_OVERRIDES: { [chainId: number]: FailureOverrid
   [ChainId.BLAST]: {
     gasLimitOverride: 3_000_000,
     multicallChunk: 45,
+  },
+  [ChainId.ZKSYNC]: {
+    gasLimitOverride: 1_000_000,
+    multicallChunk: 81,
   },
 }
 


### PR DESCRIPTION
decrease zksync gas limit from [3 million](https://github.com/Uniswap/smart-order-router/blob/main/src/routers/alpha-router/alpha-router.ts#L605) to 500k to increase the multicall batch size, hence improving latencies.