### PR TITLE
fix: routing config only on zksync

### DIFF
--- a/lib/handlers/shared.ts
+++ b/lib/handlers/shared.ts
@@ -67,7 +67,7 @@ export const DEFAULT_ROUTING_CONFIG_BY_CHAIN = (chainId: ChainId): AlphaRouterCo
         distributionPercent: 25,
         forceCrossProtocol: false,
       }
-    default:
+    case ChainId.ZKSYNC:
       return {
         v2PoolSelection: {
           topN: 3,
@@ -95,6 +95,36 @@ export const DEFAULT_ROUTING_CONFIG_BY_CHAIN = (chainId: ChainId): AlphaRouterCo
         minSplits: 1,
         maxSplits: 2,
         distributionPercent: 25,
+        forceCrossProtocol: false,
+      }
+    default:
+      return {
+        v2PoolSelection: {
+          topN: 3,
+          topNDirectSwaps: 1,
+          topNTokenInOut: 5,
+          topNSecondHop: 2,
+          tokensToAvoidOnSecondHops: new LowerCaseStringArray(
+            '0xd46ba6d942050d489dbd938a2c909a5d5039a161' // AMPL on Mainnet
+          ),
+          topNWithEachBaseToken: 2,
+          topNWithBaseToken: 6,
+        },
+        v3PoolSelection: {
+          topN: 2,
+          topNDirectSwaps: 2,
+          topNTokenInOut: 3,
+          topNSecondHop: 1,
+          topNSecondHopForTokenAddress: new MapWithLowerCaseKey<number>([
+            ['0x5f98805a4e8be255a32880fdec7f6728c6568ba0', 2], // LUSD
+          ]),
+          topNWithEachBaseToken: 3,
+          topNWithBaseToken: 5,
+        },
+        maxSwapsPerPath: 3,
+        minSplits: 1,
+        maxSplits: 7,
+        distributionPercent: 5,
         forceCrossProtocol: false,
       }
   }


### PR DESCRIPTION
The fix in https://github.com/Uniswap/routing-api/pull/745 should only apply to ZKSync, but it ended up impacting other networks as well, like mainnet.