### PR TITLE
feat: Start GQL fee fetcher shadow sampling at 0.5% of traffic

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -71,6 +71,9 @@ import { v4 } from 'uuid/index'
 import { chainProtocols } from '../cron/cache-config'
 import { Protocol } from '@uniswap/router-sdk'
 import { UniJsonRpcProvider } from '../rpc/UniJsonRpcProvider'
+import { GraphQLTokenFeeFetcher } from '../graphql/graphql-token-fee-fetcher'
+import { UniGraphQLProvider } from '../graphql/graphql-provider'
+import { TrafficSwitcherITokenFeeFetcher } from '../util/traffic-switch/traffic-switcher-i-token-fee-fetcher'
 
 export const SUPPORTED_CHAINS: ChainId[] = [
   ChainId.MAINNET,
@@ -231,7 +234,22 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
             sourceOfTruthPoolProvider: noCacheV3PoolProvider,
           })
 
-          const tokenFeeFetcher = new OnChainTokenFeeFetcher(chainId, provider)
+          const onChainTokenFeeFetcher = new OnChainTokenFeeFetcher(chainId, provider)
+          const graphQLTokenFeeFetcher = new GraphQLTokenFeeFetcher(
+            new UniGraphQLProvider(),
+            onChainTokenFeeFetcher,
+            chainId
+          )
+          const trafficSwitcherTokenFetcher = new TrafficSwitcherITokenFeeFetcher(
+            'TokenFetcherExperiment',
+            onChainTokenFeeFetcher,
+            graphQLTokenFeeFetcher,
+            'onChainTokenFeeFetcher',
+            'graphQLTokenFeeFetcher',
+            0.0,
+            0.05
+          )
+
           const tokenValidatorProvider = new TokenValidatorProvider(
             chainId,
             multicall2Provider,
@@ -240,7 +258,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
           const tokenPropertiesProvider = new TokenPropertiesProvider(
             chainId,
             new NodeJSCache(new NodeCache({ stdTTL: 30000, useClones: false })),
-            tokenFeeFetcher
+            trafficSwitcherTokenFetcher
           )
           const underlyingV2PoolProvider = new V2PoolProvider(chainId, multicall2Provider, tokenPropertiesProvider)
           const v2PoolProvider = new CachingV2PoolProvider(

--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -240,15 +240,16 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
             onChainTokenFeeFetcher,
             chainId
           )
-          const trafficSwitcherTokenFetcher = new TrafficSwitcherITokenFeeFetcher(
-            'TokenFetcherExperiment',
-            onChainTokenFeeFetcher,
-            graphQLTokenFeeFetcher,
-            'onChainTokenFeeFetcher',
-            'graphQLTokenFeeFetcher',
-            0.0,
-            0.005
-          )
+          const trafficSwitcherTokenFetcher = new TrafficSwitcherITokenFeeFetcher('TokenFetcherExperiment', {
+            control: onChainTokenFeeFetcher,
+            treatment: graphQLTokenFeeFetcher,
+            aliasControl: 'onChainTokenFeeFetcher',
+            aliasTreatment: 'graphQLTokenFeeFetcher',
+            customization: {
+              pctEnabled: 0.0,
+              pctShadowSampling: 0.005,
+            },
+          })
 
           const tokenValidatorProvider = new TokenValidatorProvider(
             chainId,

--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -247,7 +247,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
             'onChainTokenFeeFetcher',
             'graphQLTokenFeeFetcher',
             0.0,
-            0.05
+            0.005
           )
 
           const tokenValidatorProvider = new TokenValidatorProvider(

--- a/lib/util/traffic-switch/traffic-switcher-i-token-fee-fetcher.ts
+++ b/lib/util/traffic-switch/traffic-switcher-i-token-fee-fetcher.ts
@@ -1,0 +1,72 @@
+import { TrafficSwitcher } from './traffic-switcher'
+import { ITokenFeeFetcher, TokenFeeMap } from '@uniswap/smart-order-router/build/main/providers/token-fee-fetcher'
+import { ProviderConfig } from '@uniswap/smart-order-router/build/main/providers/provider'
+
+type Address = string
+
+export class TrafficSwitcherITokenFeeFetcher extends TrafficSwitcher<ITokenFeeFetcher> implements ITokenFeeFetcher {
+  constructor(
+    experimentName: string,
+    implementationA: ITokenFeeFetcher,
+    implementationB: ITokenFeeFetcher,
+    aliasA: string,
+    aliasB: string,
+    pctTrafficSwitchToB: number,
+    pctSamplingToCompare: number
+  ) {
+    super(experimentName, implementationA, implementationB, aliasA, aliasB, pctTrafficSwitchToB, pctSamplingToCompare)
+  }
+
+  async fetchFees(addresses: Address[], providerConfig?: ProviderConfig): Promise<TokenFeeMap> {
+    return this.trafficSwitchMethod(
+      () => this.implementationA.fetchFees(addresses, providerConfig),
+      () => this.implementationB.fetchFees(addresses, providerConfig),
+      this.fetchFees.name,
+      {},
+      this.compareResultsForFetchFees.bind(this)
+    )
+  }
+
+  private compareResultsForFetchFees(resultA: TokenFeeMap | undefined, resultB: TokenFeeMap | undefined): void {
+    // Check if both results are undefined or only one of them is. If so, log and return
+    if (!resultA && !resultB) {
+      this.logComparisonResult(this.fetchFees.name, 'IDENTICAL', true)
+      return
+    }
+    if (!resultA) {
+      this.logComparisonResult(this.fetchFees.name, this.aliasA + '_IS_UNDEFINED', true)
+      return
+    }
+    if (!resultB) {
+      this.logComparisonResult(this.fetchFees.name, this.aliasB + '_IS_UNDEFINED', true)
+      return
+    }
+
+    // We have results from both implementations, compare them as a whole
+    const identical = JSON.stringify(resultA) === JSON.stringify(resultB)
+    this.logComparisonResult(this.fetchFees.name, 'IDENTICAL', identical)
+
+    // Go deeper and let's do more granular custom comparisons
+    if (!identical) {
+      // Compare the number of results
+      const comparisonResultLength = Object.keys(resultA).length === Object.keys(resultB).length
+      this.logComparisonResult(this.fetchFees.name, 'LENGTHS_MATCH', comparisonResultLength)
+
+      // find and log the differences: what's missing in A, what's missing in B, and what's different
+      const keysA = Object.keys(resultA)
+      const keysB = Object.keys(resultB)
+      const missingInA = keysB.filter((k) => !keysA.includes(k))
+      const missingInB = keysA.filter((k) => !keysB.includes(k))
+      missingInA.forEach((k) => this.logMetric(this.fetchFees.name, 'MISSING_IN_' + this.aliasA + '__Address__' + k))
+      missingInB.forEach((k) => this.logMetric(this.fetchFees.name, 'MISSING_IN_' + this.aliasB + '__Address__' + k))
+      // find common keys with diffs
+      const commonKeys = keysA.filter((k) => keysB.includes(k))
+      const commonKeysWithDifferentFees = commonKeys.filter(
+        (k) => JSON.stringify(resultA[k]) !== JSON.stringify(resultB[k])
+      )
+      commonKeysWithDifferentFees.forEach((k) => {
+        this.logMetric(this.fetchFees.name, 'DIFFERENT_FEE_FOR__Address__' + k)
+      })
+    }
+  }
+}

--- a/lib/util/traffic-switch/traffic-switcher-i-token-fee-fetcher.ts
+++ b/lib/util/traffic-switch/traffic-switcher-i-token-fee-fetcher.ts
@@ -1,6 +1,7 @@
 import { TrafficSwitcher } from './traffic-switcher'
 import { ITokenFeeFetcher, TokenFeeMap } from '@uniswap/smart-order-router/build/main/providers/token-fee-fetcher'
 import { ProviderConfig } from '@uniswap/smart-order-router/build/main/providers/provider'
+import { log } from '@uniswap/smart-order-router'
 
 type Address = string
 
@@ -58,6 +59,11 @@ export class TrafficSwitcherITokenFeeFetcher extends TrafficSwitcher<ITokenFeeFe
       )
       commonKeysWithDifferentFees.forEach((k) => {
         this.logMetric(this.fetchFees.name, 'DIFFERENT_FEE_FOR__Address__' + k)
+        log.debug(
+          `TrafficSwitcherITokenFeeFetcher compareResultsForFetchFees: Different fee for address ${k}:  in control: ${JSON.stringify(
+            resultA[k]
+          )} and treatment: ${JSON.stringify(resultB[k])}`
+        )
       })
     }
   }

--- a/lib/util/traffic-switch/traffic-switcher.ts
+++ b/lib/util/traffic-switch/traffic-switcher.ts
@@ -67,9 +67,7 @@ export abstract class TrafficSwitcher<TExperiment> {
         // Compare the results if a comparison method is provided
         if (results && results.length == 2) {
           try {
-            if (comparisonMethod) {
-              comparisonMethod(results[0], results[1])
-            }
+            comparisonMethod && comparisonMethod(results[0], results[1])
           } catch (error) {
             log.error(`Error in TrafficSwitcher comparison method ${methodName}`, error)
             this.logMetric(methodName, 'COMPARISON_ERROR')

--- a/lib/util/traffic-switch/traffic-switcher.ts
+++ b/lib/util/traffic-switch/traffic-switcher.ts
@@ -1,0 +1,139 @@
+import { log, metric, MetricLoggerUnit } from '@uniswap/smart-order-router'
+
+/*
+  This class is a base class that can be used for traffic switching or sampling between two implementations of an interface.
+  It provides the ability to switch traffic between two implementations based on a percentage,
+  or to sample traffic between two implementations based on a percentage (one or the other, not both at the same time).
+  ExperimentName, aliasA and aliasB are unique identifiers and will be used for logging purposes.
+ */
+export abstract class TrafficSwitcher<T> {
+  public static readonly METRIC_NAME_TEMPLATE: string = 'TRAFFIC_SWITCHER__{EXP}__{METHOD}__{METRIC}'
+
+  // Used for logging purposes.
+  protected readonly experimentName: string
+  protected readonly aliasA: string
+  protected readonly aliasB: string
+  // 2 implementations of the interface that we want to switch traffic between.
+  protected readonly implementationA: T
+  protected readonly implementationB: T
+
+  // pctTrafficSwitchToB is the percentage of traffic that will be switched to implementationB
+  protected readonly pctTrafficSwitchToB: number
+  // pctSamplingToCompare is the percentage of traffic that will be compared between implementationA and implementationB
+  protected readonly pctSamplingToCompare: number
+
+  constructor(
+    experimentName: string,
+    implementationA: T,
+    implementationB: T,
+    aliasA: string,
+    aliasB: string,
+    pctTrafficSwitchToB: number = 0.0,
+    pctSamplingToCompare: number = 0.0
+  ) {
+    if (pctTrafficSwitchToB < 0 || pctTrafficSwitchToB > 1) {
+      throw new Error('Percentages must be between 0 and 1')
+    }
+    if (pctTrafficSwitchToB > 0 && pctSamplingToCompare > 0) {
+      throw new Error('Only one of pctTrafficSwitchToB and pctSamplingToCompare can be greater than 0')
+    }
+
+    this.experimentName = experimentName
+    this.implementationA = implementationA
+    this.implementationB = implementationB
+    this.aliasA = aliasA
+    this.aliasB = aliasB
+    this.pctTrafficSwitchToB = pctTrafficSwitchToB
+    this.pctSamplingToCompare = pctSamplingToCompare
+  }
+
+  /* This method will do one of the following:
+   *  - Switch traffic between two implementations based on the pctTrafficSwitchToB percentage
+   *  - Sample traffic between two implementations based on the pctSamplingToCompare percentage
+   */
+  protected async trafficSwitchMethod<K>(
+    methodA: () => Promise<K>,
+    methodB: () => Promise<K>,
+    methodName: string,
+    defaultReturnVal: K,
+    comparisonMethod: ((resultA: K | undefined, resultB: K | undefined) => void) | undefined
+  ): Promise<K> {
+    if (this.isSamplingEnabled()) {
+      if (this.shouldSample()) {
+        this.logMetric(methodName, `COMPARISON_SAMPLE`)
+        // If in sampling mode, and we should sample, call both implementations and compare results
+        // Note: here we'll wait for both implementations to finish before comparing results.
+        const results: (K | undefined)[] = await this.allSettled<K>([
+          [methodA(), this.aliasA, methodName],
+          [methodB(), this.aliasB, methodName],
+        ])
+
+        // Compare the results if a comparison method is provided
+        if (results && results.length == 2) {
+          try {
+            if (comparisonMethod) {
+              comparisonMethod(results[0], results[1])
+            }
+          } catch (error) {
+            log.error(`Error in TrafficSwitcher comparison method ${methodName}`, error)
+            this.logMetric(methodName, 'COMPARISON_ERROR')
+          }
+        }
+
+        // Always return the result from the first implementation when in sampling mode, or default value.
+        // Note: when in sampling mode, exceptions in sampling traffic are logged and ignored (default value is returned).
+        return results && results.length > 0 ? results[0] ?? defaultReturnVal : defaultReturnVal
+      } else {
+        // If in sampling mode, but we are not sampling for this call, just call implementation A.
+        return methodA()
+      }
+    } else {
+      // Otherwise we are in switch traffic mode, just call the selected implementation based on the traffic switch percentage
+      if (Math.random() < this.pctTrafficSwitchToB) {
+        this.logMetric(methodName, `SELECTED_IMPL__${this.aliasB}`)
+        return methodB()
+      } else {
+        this.logMetric(methodName, `SELECTED_IMPL__${this.aliasA}`)
+        return methodA()
+      }
+    }
+  }
+
+  protected isSamplingEnabled(): boolean {
+    return this.pctSamplingToCompare > 0
+  }
+
+  protected shouldSample(): boolean {
+    return this.isSamplingEnabled() && Math.random() < this.pctSamplingToCompare
+  }
+
+  protected logComparisonResult(method: string, comparisonType: string, equals: boolean): void {
+    const comparisonResult = equals ? 'YES' : 'NO'
+    this.logMetric(method, `COMPARISON__${comparisonType}__RESULT__${comparisonResult}`)
+  }
+
+  protected logMetric(method: string, metricName: string): void {
+    metric.putMetric(
+      TrafficSwitcher.METRIC_NAME_TEMPLATE.replace('{EXP}', this.experimentName)
+        .replace('{METHOD}', method)
+        .replace('{METRIC}', metricName),
+      1,
+      MetricLoggerUnit.Count
+    )
+  }
+
+  /* All promises are executed concurrently, and will wait for all of them to finish before returning the results */
+  protected allSettled<K>(promises: [Promise<K>, string, string][]): Promise<(K | undefined)[]> {
+    return Promise.all(
+      promises.map(([promise, alias, method]) =>
+        promise
+          .then((value) => value)
+          .catch((error) => {
+            log.error(`TrafficSwitcher: Error in experiment ${this.experimentName} in ${method} for ${alias}`, error)
+            this.logMetric(method, alias + '_EXCEPTION')
+            return undefined
+          })
+      )
+    )
+  }
+}

--- a/test/mocha/unit/traffic-switch/traffic-switcher-i-token-fee-fetcher.test.ts
+++ b/test/mocha/unit/traffic-switch/traffic-switcher-i-token-fee-fetcher.test.ts
@@ -1,0 +1,292 @@
+import sinon, { SinonSpy } from 'sinon'
+import { metric } from '@uniswap/smart-order-router/build/main/util/metric'
+import { ProviderConfig } from '@uniswap/smart-order-router/build/main/providers/provider'
+import { TrafficSwitcherITokenFeeFetcher } from '../../../../lib/util/traffic-switch/traffic-switcher-i-token-fee-fetcher'
+import { GraphQLTokenFeeFetcher } from '../../../../lib/graphql/graphql-token-fee-fetcher'
+import { OnChainTokenFeeFetcher, TokenFeeMap } from '@uniswap/smart-order-router/build/main/providers/token-fee-fetcher'
+import { BigNumber } from 'ethers'
+import { expect } from 'chai'
+import { MetricLoggerUnit } from '@uniswap/smart-order-router'
+import { TrafficSwitcher } from '../../../../lib/util/traffic-switch/traffic-switcher'
+
+describe('TrafficSwitcherITokenFeeFetcher', () => {
+  let spy: SinonSpy
+
+  const methodFetchFeesReturnFee100 = async (addresses: string[], _?: ProviderConfig): Promise<TokenFeeMap> => {
+    const tokenFeeMap: TokenFeeMap = {}
+    addresses.map((address) => {
+      tokenFeeMap[address] = {
+        buyFeeBps: BigNumber.from(100),
+        sellFeeBps: BigNumber.from(100),
+      }
+    })
+    return tokenFeeMap
+  }
+
+  const methodFetchFeesReturnFee200 = async (addresses: string[], _?: ProviderConfig): Promise<TokenFeeMap> => {
+    const tokenFeeMap: TokenFeeMap = {}
+    addresses.map((address) => {
+      tokenFeeMap[address] = {
+        buyFeeBps: BigNumber.from(200),
+        sellFeeBps: BigNumber.from(200),
+      }
+    })
+    return tokenFeeMap
+  }
+
+  const methodFetchFeesThrowsException = async (
+    _addresses: string[],
+    _providerConfig?: ProviderConfig
+  ): Promise<TokenFeeMap> => {
+    throw new Error('Exception!')
+  }
+
+  beforeEach(() => {
+    spy = sinon.spy(metric, 'putMetric')
+  })
+
+  afterEach(() => {
+    spy.restore()
+  })
+
+  it('switch traffic 100% should get result from targetFeeFetcher', async () => {
+    const currentFeeFetcher = sinon.createStubInstance(OnChainTokenFeeFetcher)
+    const targetFeeFetcher = sinon.createStubInstance(GraphQLTokenFeeFetcher)
+    currentFeeFetcher.fetchFees.callsFake(methodFetchFeesReturnFee100)
+    targetFeeFetcher.fetchFees.callsFake(methodFetchFeesReturnFee200)
+
+    const trafficSwitchProvider = new TrafficSwitcherITokenFeeFetcher(
+      'Exp1',
+      currentFeeFetcher,
+      targetFeeFetcher,
+      'Current',
+      'Target',
+      1.0,
+      0.0
+    )
+
+    const tokenFeeMap = await trafficSwitchProvider.fetchFees(['0x1', '0x2'], undefined)
+
+    for (const address in tokenFeeMap) {
+      expect(tokenFeeMap[address]).to.deep.equal({
+        buyFeeBps: BigNumber.from(200),
+        sellFeeBps: BigNumber.from(200),
+      })
+    }
+
+    sinon.assert.notCalled(currentFeeFetcher.fetchFees)
+    sinon.assert.calledOnce(targetFeeFetcher.fetchFees)
+    sinon.assert.calledWith(
+      spy,
+      TrafficSwitcher.METRIC_NAME_TEMPLATE.replace('{EXP}', 'Exp1')
+        .replace('{METHOD}', 'fetchFees')
+        .replace('{METRIC}', 'SELECTED_IMPL__Target'),
+      1,
+      MetricLoggerUnit.Count
+    )
+  })
+
+  it('switch traffic 0% should get result from currentFeeFetcher', async () => {
+    const currentFeeFetcher = sinon.createStubInstance(OnChainTokenFeeFetcher)
+    const targetFeeFetcher = sinon.createStubInstance(GraphQLTokenFeeFetcher)
+    currentFeeFetcher.fetchFees.callsFake(methodFetchFeesReturnFee100)
+    targetFeeFetcher.fetchFees.callsFake(methodFetchFeesReturnFee200)
+
+    const trafficSwitchProvider = new TrafficSwitcherITokenFeeFetcher(
+      'Exp1',
+      currentFeeFetcher,
+      targetFeeFetcher,
+      'Current',
+      'Target',
+      0.0,
+      0.0
+    )
+
+    const tokenFeeMap = await trafficSwitchProvider.fetchFees(['0x1', '0x2'], undefined)
+
+    for (const address in tokenFeeMap) {
+      expect(tokenFeeMap[address]).to.deep.equal({
+        buyFeeBps: BigNumber.from(100),
+        sellFeeBps: BigNumber.from(100),
+      })
+    }
+
+    sinon.assert.notCalled(targetFeeFetcher.fetchFees)
+    sinon.assert.calledOnce(currentFeeFetcher.fetchFees)
+    sinon.assert.calledWith(
+      spy,
+      TrafficSwitcher.METRIC_NAME_TEMPLATE.replace('{EXP}', 'Exp1')
+        .replace('{METHOD}', 'fetchFees')
+        .replace('{METRIC}', 'SELECTED_IMPL__Current'),
+      1,
+      MetricLoggerUnit.Count
+    )
+  })
+
+  it('sampling traffic 100% should get results from both (Identical), and return Current impl result', async () => {
+    const currentFeeFetcher = sinon.createStubInstance(OnChainTokenFeeFetcher)
+    const targetFeeFetcher = sinon.createStubInstance(GraphQLTokenFeeFetcher)
+    currentFeeFetcher.fetchFees.callsFake(methodFetchFeesReturnFee100)
+    targetFeeFetcher.fetchFees.callsFake(methodFetchFeesReturnFee100)
+
+    const trafficSwitchProvider = new TrafficSwitcherITokenFeeFetcher(
+      'Exp1',
+      currentFeeFetcher,
+      targetFeeFetcher,
+      'Current',
+      'Target',
+      0.0,
+      1.0
+    )
+
+    const tokenFeeMap = await trafficSwitchProvider.fetchFees(['0x1', '0x2'], undefined)
+
+    for (const address in tokenFeeMap) {
+      expect(tokenFeeMap[address]).to.deep.equal({
+        buyFeeBps: BigNumber.from(100),
+        sellFeeBps: BigNumber.from(100),
+      })
+    }
+
+    sinon.assert.calledOnce(targetFeeFetcher.fetchFees)
+    sinon.assert.calledOnce(currentFeeFetcher.fetchFees)
+    sinon.assert.calledWith(
+      spy,
+      TrafficSwitcher.METRIC_NAME_TEMPLATE.replace('{EXP}', 'Exp1')
+        .replace('{METHOD}', 'fetchFees')
+        .replace('{METRIC}', 'COMPARISON_SAMPLE'),
+      1,
+      MetricLoggerUnit.Count
+    )
+    sinon.assert.calledWith(
+      spy,
+      TrafficSwitcher.METRIC_NAME_TEMPLATE.replace('{EXP}', 'Exp1')
+        .replace('{METHOD}', 'fetchFees')
+        .replace('{METRIC}', 'COMPARISON__IDENTICAL__RESULT__YES'),
+      1,
+      MetricLoggerUnit.Count
+    )
+  })
+
+  it('sampling traffic 100% should get results from both (Different), and return Current impl result', async () => {
+    const currentFeeFetcher = sinon.createStubInstance(OnChainTokenFeeFetcher)
+    const targetFeeFetcher = sinon.createStubInstance(GraphQLTokenFeeFetcher)
+    currentFeeFetcher.fetchFees.callsFake(methodFetchFeesReturnFee100)
+    targetFeeFetcher.fetchFees.callsFake(methodFetchFeesReturnFee200)
+
+    const trafficSwitchProvider = new TrafficSwitcherITokenFeeFetcher(
+      'Exp1',
+      currentFeeFetcher,
+      targetFeeFetcher,
+      'Current',
+      'Target',
+      0.0,
+      1.0
+    )
+
+    const tokenFeeMap = await trafficSwitchProvider.fetchFees(['0x1', '0x2'], undefined)
+
+    for (const address in tokenFeeMap) {
+      expect(tokenFeeMap[address]).to.deep.equal({
+        buyFeeBps: BigNumber.from(100),
+        sellFeeBps: BigNumber.from(100),
+      })
+    }
+
+    sinon.assert.calledOnce(targetFeeFetcher.fetchFees)
+    sinon.assert.calledOnce(currentFeeFetcher.fetchFees)
+    sinon.assert.calledWith(
+      spy,
+      TrafficSwitcher.METRIC_NAME_TEMPLATE.replace('{EXP}', 'Exp1')
+        .replace('{METHOD}', 'fetchFees')
+        .replace('{METRIC}', 'COMPARISON_SAMPLE'),
+      1,
+      MetricLoggerUnit.Count
+    )
+    sinon.assert.calledWith(
+      spy,
+      TrafficSwitcher.METRIC_NAME_TEMPLATE.replace('{EXP}', 'Exp1')
+        .replace('{METHOD}', 'fetchFees')
+        .replace('{METRIC}', 'COMPARISON__IDENTICAL__RESULT__NO'),
+      1,
+      MetricLoggerUnit.Count
+    )
+    sinon.assert.calledWith(
+      spy,
+      TrafficSwitcher.METRIC_NAME_TEMPLATE.replace('{EXP}', 'Exp1')
+        .replace('{METHOD}', 'fetchFees')
+        .replace('{METRIC}', 'COMPARISON__LENGTHS_MATCH__RESULT__YES'),
+      1,
+      MetricLoggerUnit.Count
+    )
+    sinon.assert.calledWith(
+      spy,
+      TrafficSwitcher.METRIC_NAME_TEMPLATE.replace('{EXP}', 'Exp1')
+        .replace('{METHOD}', 'fetchFees')
+        .replace('{METRIC}', 'DIFFERENT_FEE_FOR__Address__0x1'),
+      1,
+      MetricLoggerUnit.Count
+    )
+    sinon.assert.calledWith(
+      spy,
+      TrafficSwitcher.METRIC_NAME_TEMPLATE.replace('{EXP}', 'Exp1')
+        .replace('{METHOD}', 'fetchFees')
+        .replace('{METRIC}', 'DIFFERENT_FEE_FOR__Address__0x2'),
+      1,
+      MetricLoggerUnit.Count
+    )
+  })
+
+  it('sampling traffic 100% with target impl exception should still return Current impl result', async () => {
+    const currentFeeFetcher = sinon.createStubInstance(OnChainTokenFeeFetcher)
+    const targetFeeFetcher = sinon.createStubInstance(GraphQLTokenFeeFetcher)
+    currentFeeFetcher.fetchFees.callsFake(methodFetchFeesReturnFee100)
+    targetFeeFetcher.fetchFees.callsFake(methodFetchFeesThrowsException)
+
+    const trafficSwitchProvider = new TrafficSwitcherITokenFeeFetcher(
+      'Exp1',
+      currentFeeFetcher,
+      targetFeeFetcher,
+      'Current',
+      'Target',
+      0.0,
+      1.0
+    )
+
+    const tokenFeeMap = await trafficSwitchProvider.fetchFees(['0x1', '0x2'], undefined)
+
+    for (const address in tokenFeeMap) {
+      expect(tokenFeeMap[address]).to.deep.equal({
+        buyFeeBps: BigNumber.from(100),
+        sellFeeBps: BigNumber.from(100),
+      })
+    }
+
+    sinon.assert.calledOnce(targetFeeFetcher.fetchFees)
+    sinon.assert.calledOnce(currentFeeFetcher.fetchFees)
+    sinon.assert.calledWith(
+      spy,
+      TrafficSwitcher.METRIC_NAME_TEMPLATE.replace('{EXP}', 'Exp1')
+        .replace('{METHOD}', 'fetchFees')
+        .replace('{METRIC}', 'COMPARISON_SAMPLE'),
+      1,
+      MetricLoggerUnit.Count
+    )
+    sinon.assert.calledWith(
+      spy,
+      TrafficSwitcher.METRIC_NAME_TEMPLATE.replace('{EXP}', 'Exp1')
+        .replace('{METHOD}', 'fetchFees')
+        .replace('{METRIC}', 'Target_EXCEPTION'),
+      1,
+      MetricLoggerUnit.Count
+    )
+    sinon.assert.calledWith(
+      spy,
+      TrafficSwitcher.METRIC_NAME_TEMPLATE.replace('{EXP}', 'Exp1')
+        .replace('{METHOD}', 'fetchFees')
+        .replace('{METRIC}', 'COMPARISON__Target_IS_UNDEFINED__RESULT__YES'),
+      1,
+      MetricLoggerUnit.Count
+    )
+  })
+})

--- a/test/mocha/unit/traffic-switch/traffic-switcher-i-token-fee-fetcher.test.ts
+++ b/test/mocha/unit/traffic-switch/traffic-switcher-i-token-fee-fetcher.test.ts
@@ -55,15 +55,16 @@ describe('TrafficSwitcherITokenFeeFetcher', () => {
     currentFeeFetcher.fetchFees.callsFake(methodFetchFeesReturnFee100)
     targetFeeFetcher.fetchFees.callsFake(methodFetchFeesReturnFee200)
 
-    const trafficSwitchProvider = new TrafficSwitcherITokenFeeFetcher(
-      'Exp1',
-      currentFeeFetcher,
-      targetFeeFetcher,
-      'Current',
-      'Target',
-      1.0,
-      0.0
-    )
+    const trafficSwitchProvider = new TrafficSwitcherITokenFeeFetcher('Exp1', {
+      control: currentFeeFetcher,
+      treatment: targetFeeFetcher,
+      aliasControl: 'Current',
+      aliasTreatment: 'Target',
+      customization: {
+        pctEnabled: 1.0,
+        pctShadowSampling: 0.0,
+      },
+    })
 
     const tokenFeeMap = await trafficSwitchProvider.fetchFees(['0x1', '0x2'], undefined)
 
@@ -92,15 +93,16 @@ describe('TrafficSwitcherITokenFeeFetcher', () => {
     currentFeeFetcher.fetchFees.callsFake(methodFetchFeesReturnFee100)
     targetFeeFetcher.fetchFees.callsFake(methodFetchFeesReturnFee200)
 
-    const trafficSwitchProvider = new TrafficSwitcherITokenFeeFetcher(
-      'Exp1',
-      currentFeeFetcher,
-      targetFeeFetcher,
-      'Current',
-      'Target',
-      0.0,
-      0.0
-    )
+    const trafficSwitchProvider = new TrafficSwitcherITokenFeeFetcher('Exp1', {
+      control: currentFeeFetcher,
+      treatment: targetFeeFetcher,
+      aliasControl: 'Current',
+      aliasTreatment: 'Target',
+      customization: {
+        pctEnabled: 0.0,
+        pctShadowSampling: 0.0,
+      },
+    })
 
     const tokenFeeMap = await trafficSwitchProvider.fetchFees(['0x1', '0x2'], undefined)
 
@@ -129,15 +131,16 @@ describe('TrafficSwitcherITokenFeeFetcher', () => {
     currentFeeFetcher.fetchFees.callsFake(methodFetchFeesReturnFee100)
     targetFeeFetcher.fetchFees.callsFake(methodFetchFeesReturnFee100)
 
-    const trafficSwitchProvider = new TrafficSwitcherITokenFeeFetcher(
-      'Exp1',
-      currentFeeFetcher,
-      targetFeeFetcher,
-      'Current',
-      'Target',
-      0.0,
-      1.0
-    )
+    const trafficSwitchProvider = new TrafficSwitcherITokenFeeFetcher('Exp1', {
+      control: currentFeeFetcher,
+      treatment: targetFeeFetcher,
+      aliasControl: 'Current',
+      aliasTreatment: 'Target',
+      customization: {
+        pctEnabled: 0.0,
+        pctShadowSampling: 1.0,
+      },
+    })
 
     const tokenFeeMap = await trafficSwitchProvider.fetchFees(['0x1', '0x2'], undefined)
 
@@ -174,15 +177,16 @@ describe('TrafficSwitcherITokenFeeFetcher', () => {
     currentFeeFetcher.fetchFees.callsFake(methodFetchFeesReturnFee100)
     targetFeeFetcher.fetchFees.callsFake(methodFetchFeesReturnFee200)
 
-    const trafficSwitchProvider = new TrafficSwitcherITokenFeeFetcher(
-      'Exp1',
-      currentFeeFetcher,
-      targetFeeFetcher,
-      'Current',
-      'Target',
-      0.0,
-      1.0
-    )
+    const trafficSwitchProvider = new TrafficSwitcherITokenFeeFetcher('Exp1', {
+      control: currentFeeFetcher,
+      treatment: targetFeeFetcher,
+      aliasControl: 'Current',
+      aliasTreatment: 'Target',
+      customization: {
+        pctEnabled: 0.0,
+        pctShadowSampling: 1.0,
+      },
+    })
 
     const tokenFeeMap = await trafficSwitchProvider.fetchFees(['0x1', '0x2'], undefined)
 
@@ -243,15 +247,16 @@ describe('TrafficSwitcherITokenFeeFetcher', () => {
     currentFeeFetcher.fetchFees.callsFake(methodFetchFeesReturnFee100)
     targetFeeFetcher.fetchFees.callsFake(methodFetchFeesThrowsException)
 
-    const trafficSwitchProvider = new TrafficSwitcherITokenFeeFetcher(
-      'Exp1',
-      currentFeeFetcher,
-      targetFeeFetcher,
-      'Current',
-      'Target',
-      0.0,
-      1.0
-    )
+    const trafficSwitchProvider = new TrafficSwitcherITokenFeeFetcher('Exp1', {
+      control: currentFeeFetcher,
+      treatment: targetFeeFetcher,
+      aliasControl: 'Current',
+      aliasTreatment: 'Target',
+      customization: {
+        pctEnabled: 0.0,
+        pctShadowSampling: 1.0,
+      },
+    })
 
     const tokenFeeMap = await trafficSwitchProvider.fetchFees(['0x1', '0x2'], undefined)
 

--- a/test/mocha/unit/traffic-switch/traffic-switcher.test.ts
+++ b/test/mocha/unit/traffic-switch/traffic-switcher.test.ts
@@ -1,0 +1,345 @@
+import sinon, { SinonSpy } from 'sinon'
+import { metric } from '@uniswap/smart-order-router/build/main/util/metric'
+import { expect } from 'chai'
+import { MetricLoggerUnit } from '@uniswap/smart-order-router'
+import { TrafficSwitcher } from '../../../../lib/util/traffic-switch/traffic-switcher'
+
+interface ISimpleTester {
+  simpleMethod(): Promise<Record<string, number>>
+}
+
+class SimpleTesterControl implements ISimpleTester {
+  async simpleMethod(): Promise<Record<string, number>> {
+    return {
+      "0x1": 1,
+      "0x2": 2
+    }
+  }
+}
+
+class SimpleTesterTreatment implements ISimpleTester {
+  async simpleMethod(): Promise<Record<string, number>> {
+    return {
+      "0x1": 1,
+      "0x2": 2
+    }
+  }
+}
+
+class TrafficSwitcherISimpleTester extends TrafficSwitcher<ISimpleTester> implements ISimpleTester {
+  async simpleMethod(): Promise<Record<string, number>> {
+    return this.trafficSwitchMethod(
+      () => this.props.control.simpleMethod(),
+      () => this.props.treatment.simpleMethod(),
+      this.simpleMethod.name,
+      {},
+      this.compareResults.bind(this)
+    )
+  }
+
+  private compareResults(resultA: Record<string, number> | undefined, resultB: Record<string, number> | undefined): void {
+    // Check if both results are undefined or only one of them is. If so, log and return
+    if (!resultA && !resultB) {
+      this.logComparisonResult(this.simpleMethod.name, 'IDENTICAL', true)
+      return
+    }
+    if (!resultA) {
+      this.logComparisonResult(this.simpleMethod.name, this.props.aliasControl + '_IS_UNDEFINED', true)
+      return
+    }
+    if (!resultB) {
+      this.logComparisonResult(this.simpleMethod.name, this.props.aliasTreatment + '_IS_UNDEFINED', true)
+      return
+    }
+
+    // We have results from both implementations, compare them as a whole
+    const identical = JSON.stringify(resultA) === JSON.stringify(resultB)
+    this.logComparisonResult(this.simpleMethod.name, 'IDENTICAL', identical)
+
+    // Go deeper and let's do more granular custom comparisons
+    if (!identical) {
+      // Compare the number of results
+      const comparisonResultLength = Object.keys(resultA).length === Object.keys(resultB).length
+      this.logComparisonResult(this.simpleMethod.name, 'LENGTHS_MATCH', comparisonResultLength)
+
+      // find and log the differences: what's missing in A, what's missing in B, and what's different
+      const keysA = Object.keys(resultA)
+      const keysB = Object.keys(resultB)
+      const missingInA = keysB.filter((k) => !keysA.includes(k))
+      const missingInB = keysA.filter((k) => !keysB.includes(k))
+      missingInA.forEach((k) =>
+        this.logMetric(this.simpleMethod.name, 'MISSING_IN_' + this.props.aliasControl + '__Address__' + k)
+      )
+      missingInB.forEach((k) =>
+        this.logMetric(this.simpleMethod.name, 'MISSING_IN_' + this.props.aliasTreatment + '__Address__' + k)
+      )
+      // find common keys with diffs
+      const commonKeys = keysA.filter((k) => keysB.includes(k))
+      const commonKeysWithDifferentFees = commonKeys.filter(
+        (k) => JSON.stringify(resultA[k]) !== JSON.stringify(resultB[k])
+      )
+      commonKeysWithDifferentFees.forEach((k) => {
+        this.logMetric(this.simpleMethod.name, 'DIFFERENT_FEE_FOR__Address__' + k)
+      })
+    }
+  }
+}
+
+describe('TrafficSwitcher', () => {
+  let spy: SinonSpy
+
+  const methodReturn100 = async (): Promise<Record<string, number>> => {
+    return {
+      "0x1": 100,
+      "0x2": 100
+    }
+  }
+  const methodReturn200 = async (): Promise<Record<string, number>> => {
+    return {
+      "0x1": 200,
+      "0x2": 200
+    }
+  }
+  const methodThrowsException = async (): Promise<Record<string, number>> => {
+    throw new Error('Exception!')
+  }
+
+  beforeEach(() => {
+    spy = sinon.spy(metric, 'putMetric')
+  })
+
+  afterEach(() => {
+    spy.restore()
+  })
+
+  it('switch traffic 100% should get result from treatment', async () => {
+    const controlImplentation = sinon.createStubInstance(SimpleTesterControl)
+    const treatmentImplementation = sinon.createStubInstance(SimpleTesterTreatment)
+    controlImplentation.simpleMethod.callsFake(methodReturn100)
+    treatmentImplementation.simpleMethod.callsFake(methodReturn200)
+
+    const trafficSwitchProvider = new TrafficSwitcherISimpleTester('Exp1', {
+      control: controlImplentation,
+      treatment: treatmentImplementation,
+      aliasControl: 'Current',
+      aliasTreatment: 'Target',
+      customization: {
+        pctEnabled: 1.0,
+        pctShadowSampling: 0.0,
+      },
+    })
+
+    const result = await trafficSwitchProvider.simpleMethod()
+
+    for (const key in result) {
+      expect(result[key]).to.equal(200)
+    }
+
+    sinon.assert.notCalled(controlImplentation.simpleMethod)
+    sinon.assert.calledOnce(treatmentImplementation.simpleMethod)
+    sinon.assert.calledWith(
+      spy,
+      TrafficSwitcher.METRIC_NAME_TEMPLATE.replace('{EXP}', 'Exp1')
+        .replace('{METHOD}', 'simpleMethod')
+        .replace('{METRIC}', 'SELECTED_IMPL__Target'),
+      1,
+      MetricLoggerUnit.Count
+    )
+  })
+
+  it('switch traffic 0% should get result from control', async () => {
+    const controlImplentation = sinon.createStubInstance(SimpleTesterControl)
+    const treatmentImplementation = sinon.createStubInstance(SimpleTesterTreatment)
+    controlImplentation.simpleMethod.callsFake(methodReturn100)
+    treatmentImplementation.simpleMethod.callsFake(methodReturn200)
+
+    const trafficSwitchProvider = new TrafficSwitcherISimpleTester('Exp1', {
+      control: controlImplentation,
+      treatment: treatmentImplementation,
+      aliasControl: 'Current',
+      aliasTreatment: 'Target',
+      customization: {
+        pctEnabled: 0.0,
+        pctShadowSampling: 0.0,
+      },
+    })
+
+    const result = await trafficSwitchProvider.simpleMethod()
+
+    for (const key in result) {
+      expect(result[key]).to.equal(100)
+    }
+
+    sinon.assert.notCalled(treatmentImplementation.simpleMethod)
+    sinon.assert.calledOnce(controlImplentation.simpleMethod)
+    sinon.assert.calledWith(
+      spy,
+      TrafficSwitcher.METRIC_NAME_TEMPLATE.replace('{EXP}', 'Exp1')
+        .replace('{METHOD}', 'simpleMethod')
+        .replace('{METRIC}', 'SELECTED_IMPL__Current'),
+      1,
+      MetricLoggerUnit.Count
+    )
+  })
+
+  it('sampling traffic 100% should get results from both (Identical), and return control impl result', async () => {
+    const controlImplentation = sinon.createStubInstance(SimpleTesterControl)
+    const treatmentImplementation = sinon.createStubInstance(SimpleTesterTreatment)
+    controlImplentation.simpleMethod.callsFake(methodReturn100)
+    treatmentImplementation.simpleMethod.callsFake(methodReturn100)
+
+    const trafficSwitchProvider = new TrafficSwitcherISimpleTester('Exp1', {
+      control: controlImplentation,
+      treatment: treatmentImplementation,
+      aliasControl: 'Current',
+      aliasTreatment: 'Target',
+      customization: {
+        pctEnabled: 0.0,
+        pctShadowSampling: 1.0,
+      },
+    })
+
+    const result = await trafficSwitchProvider.simpleMethod()
+
+    for (const key in result) {
+      expect(result[key]).to.equal(100)
+    }
+
+    sinon.assert.calledOnce(controlImplentation.simpleMethod)
+    sinon.assert.calledOnce(treatmentImplementation.simpleMethod)
+    sinon.assert.calledWith(
+      spy,
+      TrafficSwitcher.METRIC_NAME_TEMPLATE.replace('{EXP}', 'Exp1')
+        .replace('{METHOD}', 'simpleMethod')
+        .replace('{METRIC}', 'COMPARISON_SAMPLE'),
+      1,
+      MetricLoggerUnit.Count
+    )
+    sinon.assert.calledWith(
+      spy,
+      TrafficSwitcher.METRIC_NAME_TEMPLATE.replace('{EXP}', 'Exp1')
+        .replace('{METHOD}', 'simpleMethod')
+        .replace('{METRIC}', 'COMPARISON__IDENTICAL__RESULT__YES'),
+      1,
+      MetricLoggerUnit.Count
+    )
+  })
+
+  it('sampling traffic 100% should get results from both (Different), and return Current impl result', async () => {
+    const controlImplentation = sinon.createStubInstance(SimpleTesterControl)
+    const treatmentImplementation = sinon.createStubInstance(SimpleTesterTreatment)
+    controlImplentation.simpleMethod.callsFake(methodReturn100)
+    treatmentImplementation.simpleMethod.callsFake(methodReturn200)
+
+    const trafficSwitchProvider = new TrafficSwitcherISimpleTester('Exp1', {
+      control: controlImplentation,
+      treatment: treatmentImplementation,
+      aliasControl: 'Current',
+      aliasTreatment: 'Target',
+      customization: {
+        pctEnabled: 0.0,
+        pctShadowSampling: 1.0,
+      },
+    })
+
+    const result = await trafficSwitchProvider.simpleMethod()
+
+    for (const key in result) {
+      expect(result[key]).to.equal(100)
+    }
+
+    sinon.assert.calledOnce(controlImplentation.simpleMethod)
+    sinon.assert.calledOnce(treatmentImplementation.simpleMethod)
+    sinon.assert.calledWith(
+      spy,
+      TrafficSwitcher.METRIC_NAME_TEMPLATE.replace('{EXP}', 'Exp1')
+        .replace('{METHOD}', 'simpleMethod')
+        .replace('{METRIC}', 'COMPARISON_SAMPLE'),
+      1,
+      MetricLoggerUnit.Count
+    )
+    sinon.assert.calledWith(
+      spy,
+      TrafficSwitcher.METRIC_NAME_TEMPLATE.replace('{EXP}', 'Exp1')
+        .replace('{METHOD}', 'simpleMethod')
+        .replace('{METRIC}', 'COMPARISON__IDENTICAL__RESULT__NO'),
+      1,
+      MetricLoggerUnit.Count
+    )
+    sinon.assert.calledWith(
+      spy,
+      TrafficSwitcher.METRIC_NAME_TEMPLATE.replace('{EXP}', 'Exp1')
+        .replace('{METHOD}', 'simpleMethod')
+        .replace('{METRIC}', 'COMPARISON__LENGTHS_MATCH__RESULT__YES'),
+      1,
+      MetricLoggerUnit.Count
+    )
+    sinon.assert.calledWith(
+      spy,
+      TrafficSwitcher.METRIC_NAME_TEMPLATE.replace('{EXP}', 'Exp1')
+        .replace('{METHOD}', 'simpleMethod')
+        .replace('{METRIC}', 'DIFFERENT_FEE_FOR__Address__0x1'),
+      1,
+      MetricLoggerUnit.Count
+    )
+    sinon.assert.calledWith(
+      spy,
+      TrafficSwitcher.METRIC_NAME_TEMPLATE.replace('{EXP}', 'Exp1')
+        .replace('{METHOD}', 'simpleMethod')
+        .replace('{METRIC}', 'DIFFERENT_FEE_FOR__Address__0x2'),
+      1,
+      MetricLoggerUnit.Count
+    )
+  })
+
+  it('sampling traffic 100% with target impl exception should still return Current impl result', async () => {
+    const controlImplentation = sinon.createStubInstance(SimpleTesterControl)
+    const treatmentImplementation = sinon.createStubInstance(SimpleTesterTreatment)
+    controlImplentation.simpleMethod.callsFake(methodReturn100)
+    treatmentImplementation.simpleMethod.callsFake(methodThrowsException)
+
+    const trafficSwitchProvider = new TrafficSwitcherISimpleTester('Exp1', {
+      control: controlImplentation,
+      treatment: treatmentImplementation,
+      aliasControl: 'Current',
+      aliasTreatment: 'Target',
+      customization: {
+        pctEnabled: 0.0,
+        pctShadowSampling: 1.0,
+      },
+    })
+
+    const result = await trafficSwitchProvider.simpleMethod()
+
+    for (const key in result) {
+      expect(result[key]).to.equal(100)
+    }
+
+    sinon.assert.calledOnce(controlImplentation.simpleMethod)
+    sinon.assert.calledOnce(treatmentImplementation.simpleMethod)
+    sinon.assert.calledWith(
+      spy,
+      TrafficSwitcher.METRIC_NAME_TEMPLATE.replace('{EXP}', 'Exp1')
+        .replace('{METHOD}', 'simpleMethod')
+        .replace('{METRIC}', 'COMPARISON_SAMPLE'),
+      1,
+      MetricLoggerUnit.Count
+    )
+    sinon.assert.calledWith(
+      spy,
+      TrafficSwitcher.METRIC_NAME_TEMPLATE.replace('{EXP}', 'Exp1')
+        .replace('{METHOD}', 'simpleMethod')
+        .replace('{METRIC}', 'Target_EXCEPTION'),
+      1,
+      MetricLoggerUnit.Count
+    )
+    sinon.assert.calledWith(
+      spy,
+      TrafficSwitcher.METRIC_NAME_TEMPLATE.replace('{EXP}', 'Exp1')
+        .replace('{METHOD}', 'simpleMethod')
+        .replace('{METRIC}', 'COMPARISON__Target_IS_UNDEFINED__RESULT__YES'),
+      1,
+      MetricLoggerUnit.Count
+    )
+  })
+})

--- a/test/mocha/unit/traffic-switch/traffic-switcher.test.ts
+++ b/test/mocha/unit/traffic-switch/traffic-switcher.test.ts
@@ -11,8 +11,8 @@ interface ISimpleTester {
 class SimpleTesterControl implements ISimpleTester {
   async simpleMethod(): Promise<Record<string, number>> {
     return {
-      "0x1": 1,
-      "0x2": 2
+      '0x1': 1,
+      '0x2': 2,
     }
   }
 }
@@ -20,8 +20,8 @@ class SimpleTesterControl implements ISimpleTester {
 class SimpleTesterTreatment implements ISimpleTester {
   async simpleMethod(): Promise<Record<string, number>> {
     return {
-      "0x1": 1,
-      "0x2": 2
+      '0x1': 1,
+      '0x2': 2,
     }
   }
 }
@@ -37,7 +37,10 @@ class TrafficSwitcherISimpleTester extends TrafficSwitcher<ISimpleTester> implem
     )
   }
 
-  private compareResults(resultA: Record<string, number> | undefined, resultB: Record<string, number> | undefined): void {
+  private compareResults(
+    resultA: Record<string, number> | undefined,
+    resultB: Record<string, number> | undefined
+  ): void {
     // Check if both results are undefined or only one of them is. If so, log and return
     if (!resultA && !resultB) {
       this.logComparisonResult(this.simpleMethod.name, 'IDENTICAL', true)
@@ -90,14 +93,14 @@ describe('TrafficSwitcher', () => {
 
   const methodReturn100 = async (): Promise<Record<string, number>> => {
     return {
-      "0x1": 100,
-      "0x2": 100
+      '0x1': 100,
+      '0x2': 100,
     }
   }
   const methodReturn200 = async (): Promise<Record<string, number>> => {
     return {
-      "0x1": 200,
-      "0x2": 200
+      '0x1': 200,
+      '0x2': 200,
     }
   }
   const methodThrowsException = async (): Promise<Record<string, number>> => {


### PR DESCRIPTION
Starting shadow sampling for `GraphQLTokenFeeFetcher` at `0.5%` of traffic.
This is only enabled on mainnet and, with recent caching changes, `0.5%` of traffic should be around `20 RPM` of sampling traffic (`avg 4k requests / min * 0.005 = 20 RPM`) (stats pulled from [here](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~'Uniswap~'TokenFeeFetcherFetchFeesSuccess~'Service~'RoutingAPI)~(~'.~'TokenFeeFetcherFetchFeesFailure~'.~'.)~(~'.~'TokenPropertiesProviderBatchGetCacheHit~'.~'.))~view~'timeSeries~stacked~false~region~'us-east-2~stat~'SampleCount~period~60)&query=~'*7bUniswap*2cService*7d*20TokenPropertiesProviderBatchGetCacheHit))

Also adding a generic `TrafficSwitcher<T>` to handle traffic switching/sampling on 2 implementations of any type `T`.