### PR TITLE
fix: graphql endpoint might return null feeData

### DIFF
--- a/lib/graphql/graphql-schemas.ts
+++ b/lib/graphql/graphql-schemas.ts
@@ -18,8 +18,8 @@ export interface TokenInfo {
   decimals: number
   symbol: string
   standard: string
-  feeData: {
-    buyFeeBps: string
-    sellFeeBps: string
+  feeData?: {
+    buyFeeBps?: string
+    sellFeeBps?: string
   }
 }

--- a/lib/graphql/graphql-token-fee-fetcher.ts
+++ b/lib/graphql/graphql-token-fee-fetcher.ts
@@ -36,10 +36,12 @@ export class GraphQLTokenFeeFetcher implements ITokenFeeFetcher {
     try {
       const tokenFeeResponse: TokensInfoResponse = await this.graphQLProvider.getTokensInfo(this.chainId, addresses)
       tokenFeeResponse.tokens.forEach((token) => {
-        if (token.feeData.buyFeeBps || token.feeData.sellFeeBps) {
+        if (token.feeData && (token.feeData.buyFeeBps || token.feeData.sellFeeBps)) {
           const buyFeeBps = token.feeData.buyFeeBps ? BigNumber.from(token.feeData.buyFeeBps) : undefined
           const sellFeeBps = token.feeData.sellFeeBps ? BigNumber.from(token.feeData.sellFeeBps) : undefined
           tokenFeeMap[token.address] = { buyFeeBps, sellFeeBps }
+        } else {
+          tokenFeeMap[token.address] = { buyFeeBps: undefined, sellFeeBps: undefined }
         }
       })
 

--- a/lib/graphql/graphql-token-fee-fetcher.ts
+++ b/lib/graphql/graphql-token-fee-fetcher.ts
@@ -36,7 +36,7 @@ export class GraphQLTokenFeeFetcher implements ITokenFeeFetcher {
     try {
       const tokenFeeResponse: TokensInfoResponse = await this.graphQLProvider.getTokensInfo(this.chainId, addresses)
       tokenFeeResponse.tokens.forEach((token) => {
-        if (token.feeData && (token.feeData.buyFeeBps || token.feeData.sellFeeBps)) {
+        if (token.feeData?.buyFeeBps || token.feeData?.sellFeeBps) {
           const buyFeeBps = token.feeData.buyFeeBps ? BigNumber.from(token.feeData.buyFeeBps) : undefined
           const sellFeeBps = token.feeData.sellFeeBps ? BigNumber.from(token.feeData.sellFeeBps) : undefined
           tokenFeeMap[token.address] = { buyFeeBps, sellFeeBps }

--- a/test/mocha/integ/graphql/graphql-token-fee-fetcher.test.ts
+++ b/test/mocha/integ/graphql/graphql-token-fee-fetcher.test.ts
@@ -47,7 +47,9 @@ describe('integration test for GraphQLTokenFeeFetcher', () => {
 
   it('Fetch WETH and BITBOY, should only return BITBOY', async () => {
     const tokenFeeMap = await tokenFeeFetcher.fetchFees([WETH9[ChainId.MAINNET]!.address, BITBOY.address])
-    expect(tokenFeeMap[WETH9[ChainId.MAINNET]!.address]).to.be.undefined
+    expect(tokenFeeMap[WETH9[ChainId.MAINNET]!.address]).to.not.be.undefined
+    expect(tokenFeeMap[WETH9[ChainId.MAINNET]!.address]?.buyFeeBps).to.be.undefined
+    expect(tokenFeeMap[WETH9[ChainId.MAINNET]!.address]?.sellFeeBps).to.be.undefined
     expect(tokenFeeMap[BITBOY.address]).to.not.be.undefined
     expect(tokenFeeMap[BITBOY.address]?.buyFeeBps?._hex).equals(BITBOY.buyFeeBps?._hex)
     expect(tokenFeeMap[BITBOY.address]?.sellFeeBps?._hex).equals(BITBOY.sellFeeBps?._hex)


### PR DESCRIPTION
From sampling traffic identified a small number of cases where graphql returns `feeData: null` and causing exception.
This was handled eventually with onChain fallback, but we want to handle correctly and keep sampling/comparing control and treatment.