### PR TITLE
fix: hardcode gas on zksync

### DIFF
--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -457,7 +457,12 @@ export class QuoteHandler extends APIGLambdaHandler<
     } = swapRoute
 
     const estimatedGasUsed = this.adhocCorrectGasUsed(preProcessedEstimatedGasUsed, chainId, isMobileRequest)
-    const estimatedGasUsedUSD = this.adhocCorrectGasUsedUSD(preProcessedEstimatedGasUsed, preProcessedEstimatedGasUsedUSD, chainId, isMobileRequest)
+    const estimatedGasUsedUSD = this.adhocCorrectGasUsedUSD(
+      preProcessedEstimatedGasUsed,
+      preProcessedEstimatedGasUsedUSD,
+      chainId,
+      isMobileRequest
+    )
 
     if (simulationStatus == SimulationStatus.Failed) {
       metric.putMetric('SimulationFailed', 1, MetricLoggerUnit.Count)
@@ -814,7 +819,12 @@ export class QuoteHandler extends APIGLambdaHandler<
     }
   }
 
-  private adhocCorrectGasUsedUSD(estimatedGasUsed: BigNumber, estimatedGasUsedUSD: CurrencyAmount<Currency>, chainId: ChainId, isMobileRequest: boolean): CurrencyAmount<Currency> {
+  private adhocCorrectGasUsedUSD(
+    estimatedGasUsed: BigNumber,
+    estimatedGasUsedUSD: CurrencyAmount<Currency>,
+    chainId: ChainId,
+    isMobileRequest: boolean
+  ): CurrencyAmount<Currency> {
     if (!isMobileRequest) {
       return estimatedGasUsedUSD
     }
@@ -827,7 +837,10 @@ export class QuoteHandler extends APIGLambdaHandler<
           return estimatedGasUsedUSD
         }
 
-        const correctedEstimateGasUsedUSD = JSBI.divide(JSBI.multiply(estimatedGasUsedUSD.quotient, JSBI.BigInt(ZKSYNC_UPPER_SWAP_GAS_LIMIT)), JSBI.BigInt(estimatedGasUsed))
+        const correctedEstimateGasUsedUSD = JSBI.divide(
+          JSBI.multiply(estimatedGasUsedUSD.quotient, JSBI.BigInt(ZKSYNC_UPPER_SWAP_GAS_LIMIT)),
+          JSBI.BigInt(estimatedGasUsed)
+        )
         return CurrencyAmount.fromRawAmount(estimatedGasUsedUSD.currency, correctedEstimateGasUsedUSD)
       default:
         return estimatedGasUsedUSD

--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -34,6 +34,8 @@ import { CurrencyLookup } from '../CurrencyLookup'
 import { SwapOptionsFactory } from './SwapOptionsFactory'
 import { GlobalRpcProviders } from '../../rpc/GlobalRpcProviders'
 import semver from 'semver'
+import { BigNumber } from '@ethersproject/bignumber'
+import { ZKSYNC_UPPER_SWAP_GAS_LIMIT } from '../../util/gasLimit'
 
 export class QuoteHandler extends APIGLambdaHandler<
   ContainerInjected,
@@ -245,10 +247,11 @@ export class QuoteHandler extends APIGLambdaHandler<
     }
 
     const requestSource = requestSourceHeader ?? params.requestQueryParams.source ?? ''
+    const isMobileRequest = ['uniswap-ios', 'uniswap-android'].includes(requestSource)
     const protocols = QuoteHandler.protocolsFromRequest(
       chainId,
       protocolsStr,
-      requestSource,
+      isMobileRequest,
       appVersion,
       forceCrossProtocol
     )
@@ -441,9 +444,9 @@ export class QuoteHandler extends APIGLambdaHandler<
       quoteGasAdjusted,
       quoteGasAndPortionAdjusted,
       route,
-      estimatedGasUsed,
+      estimatedGasUsed: preProcessedEstimatedGasUsed,
       estimatedGasUsedQuoteToken,
-      estimatedGasUsedUSD,
+      estimatedGasUsedUSD: preProcessedEstimatedGasUsedUSD,
       estimatedGasUsedGasToken,
       gasPriceWei,
       methodParameters,
@@ -452,6 +455,9 @@ export class QuoteHandler extends APIGLambdaHandler<
       hitsCachedRoute,
       portionAmount: outputPortionAmount, // TODO: name it back to portionAmount
     } = swapRoute
+
+    const estimatedGasUsed = this.adhocCorrectGasUsed(preProcessedEstimatedGasUsed, chainId, isMobileRequest)
+    const estimatedGasUsedUSD = this.adhocCorrectGasUsedUSD(preProcessedEstimatedGasUsed, preProcessedEstimatedGasUsedUSD, chainId, isMobileRequest)
 
     if (simulationStatus == SimulationStatus.Failed) {
       metric.putMetric('SimulationFailed', 1, MetricLoggerUnit.Count)
@@ -640,11 +646,10 @@ export class QuoteHandler extends APIGLambdaHandler<
   static protocolsFromRequest(
     chainId: ChainId,
     requestedProtocols: string[] | string | undefined,
-    requestSource: string,
+    isMobileRequest: boolean,
     appVersion: string | undefined,
     forceCrossProtocol: boolean | undefined
   ): Protocol[] | undefined {
-    const isMobileRequest = ['uniswap-ios', 'uniswap-android'].includes(requestSource)
     // We will exclude V2 if isMobile and the appVersion is not present or is lower than 1.24
     const semverAppVersion = semver.coerce(appVersion)
     const fixVersion = semver.coerce('1.24')!
@@ -787,6 +792,45 @@ export class QuoteHandler extends APIGLambdaHandler<
         },
         `Tracked Route for pair [${tradingPair}/${tradeType.toUpperCase()}] on chain [${chainId}] with route hash [${routeStringHash}] for amount [${amount.toExact()}]`
       )
+    }
+  }
+
+  private adhocCorrectGasUsed(estimatedGasUsed: BigNumber, chainId: ChainId, isMobileRequest: boolean): BigNumber {
+    if (!isMobileRequest) {
+      return estimatedGasUsed
+    }
+
+    switch (chainId) {
+      case ChainId.ZKSYNC:
+        if (estimatedGasUsed.gt(ZKSYNC_UPPER_SWAP_GAS_LIMIT)) {
+          // this is a check to ensure that we don't return the gas used smaller than upper swap gas limit,
+          // although this is unlikely
+          return estimatedGasUsed
+        }
+
+        return ZKSYNC_UPPER_SWAP_GAS_LIMIT
+      default:
+        return estimatedGasUsed
+    }
+  }
+
+  private adhocCorrectGasUsedUSD(estimatedGasUsed: BigNumber, estimatedGasUsedUSD: CurrencyAmount<Currency>, chainId: ChainId, isMobileRequest: boolean): CurrencyAmount<Currency> {
+    if (!isMobileRequest) {
+      return estimatedGasUsedUSD
+    }
+
+    switch (chainId) {
+      case ChainId.ZKSYNC:
+        if (estimatedGasUsed.gt(ZKSYNC_UPPER_SWAP_GAS_LIMIT)) {
+          // this is a check to ensure that we don't return the gas used smaller than upper swap gas limit,
+          // although this is unlikely
+          return estimatedGasUsedUSD
+        }
+
+        const correctedEstimateGasUsedUSD = JSBI.divide(JSBI.multiply(estimatedGasUsedUSD.quotient, JSBI.BigInt(ZKSYNC_UPPER_SWAP_GAS_LIMIT)), JSBI.BigInt(estimatedGasUsed))
+        return CurrencyAmount.fromRawAmount(estimatedGasUsedUSD.currency, correctedEstimateGasUsedUSD)
+      default:
+        return estimatedGasUsedUSD
     }
   }
 

--- a/lib/util/gasLimit.ts
+++ b/lib/util/gasLimit.ts
@@ -1,0 +1,3 @@
+import { BigNumber } from '@ethersproject/bignumber'
+
+export const ZKSYNC_UPPER_SWAP_GAS_LIMIT = BigNumber.from(6000000)

--- a/test/jest/unit/handlers/quote.test.ts
+++ b/test/jest/unit/handlers/quote.test.ts
@@ -6,34 +6,40 @@ import { Protocol } from '@uniswap/router-sdk'
 describe('QuoteHandler', () => {
   describe('.protocolsFromRequest', () => {
     it('returns V3 when no protocols are requested', () => {
-      expect(QuoteHandler.protocolsFromRequest(ChainId.MAINNET, undefined, '', undefined, undefined)).toEqual([
+      const isMobileRequest = ['uniswap-ios', 'uniswap-android'].includes('')
+      expect(QuoteHandler.protocolsFromRequest(ChainId.MAINNET, undefined, isMobileRequest, undefined, undefined)).toEqual([
         Protocol.V3,
       ])
     })
 
     it('returns V3 when forceCrossProtocols is false', () => {
-      expect(QuoteHandler.protocolsFromRequest(ChainId.MAINNET, undefined, '', undefined, false)).toEqual([Protocol.V3])
+      const isMobileRequest = ['uniswap-ios', 'uniswap-android'].includes('')
+      expect(QuoteHandler.protocolsFromRequest(ChainId.MAINNET, undefined, isMobileRequest, undefined, false)).toEqual([Protocol.V3])
     })
 
     it('returns empty when forceCrossProtocols is true', () => {
-      expect(QuoteHandler.protocolsFromRequest(ChainId.MAINNET, undefined, '', undefined, true)).toEqual([])
+      const isMobileRequest = ['uniswap-ios', 'uniswap-android'].includes('')
+      expect(QuoteHandler.protocolsFromRequest(ChainId.MAINNET, undefined, isMobileRequest, undefined, true)).toEqual([])
     })
 
     it('returns requested protocols', () => {
+      const isMobileRequest = ['uniswap-ios', 'uniswap-android'].includes('')
       expect(
-        QuoteHandler.protocolsFromRequest(ChainId.MAINNET, ['v2', 'v3', 'mixed'], '', undefined, undefined)
+        QuoteHandler.protocolsFromRequest(ChainId.MAINNET, ['v2', 'v3', 'mixed'], isMobileRequest, undefined, undefined)
       ).toEqual([Protocol.V2, Protocol.V3, Protocol.MIXED])
     })
 
     it('returns a different set of requested protocols', () => {
-      expect(QuoteHandler.protocolsFromRequest(ChainId.MAINNET, ['v3', 'mixed'], '', undefined, undefined)).toEqual([
+      const isMobileRequest = ['uniswap-ios', 'uniswap-android'].includes('')
+      expect(QuoteHandler.protocolsFromRequest(ChainId.MAINNET, ['v3', 'mixed'], isMobileRequest, undefined, undefined)).toEqual([
         Protocol.V3,
         Protocol.MIXED,
       ])
     })
 
     it('works with other chains', () => {
-      expect(QuoteHandler.protocolsFromRequest(ChainId.BASE, ['v2', 'v3', 'mixed'], '', undefined, undefined)).toEqual([
+      const isMobileRequest = ['uniswap-ios', 'uniswap-android'].includes('')
+      expect(QuoteHandler.protocolsFromRequest(ChainId.BASE, ['v2', 'v3', 'mixed'], isMobileRequest, undefined, undefined)).toEqual([
         Protocol.V2,
         Protocol.V3,
         Protocol.MIXED,
@@ -41,28 +47,31 @@ describe('QuoteHandler', () => {
     })
 
     it('returns undefined when a requested protocol is invalid', () => {
+      const isMobileRequest = ['uniswap-ios', 'uniswap-android'].includes('')
       expect(
-        QuoteHandler.protocolsFromRequest(ChainId.BASE, ['v2', 'v3', 'mixed', 'miguel'], '', undefined, undefined)
+        QuoteHandler.protocolsFromRequest(ChainId.BASE, ['v2', 'v3', 'mixed', 'miguel'], isMobileRequest, undefined, undefined)
       ).toBeUndefined()
     })
 
     describe('for mobile request', () => {
       it('removes v2 and mixed with other chains, when the requested source is mobile', () => {
         ;['uniswap-ios', 'uniswap-android'].forEach((requestSource) => {
+          const isMobileRequest = ['uniswap-ios', 'uniswap-android'].includes(requestSource)
           expect(
-            QuoteHandler.protocolsFromRequest(ChainId.BASE, ['v2', 'v3', 'mixed'], requestSource, undefined, undefined)
+            QuoteHandler.protocolsFromRequest(ChainId.BASE, ['v2', 'v3', 'mixed'], isMobileRequest, undefined, undefined)
           ).toEqual([Protocol.V3])
         })
       })
 
       it('removes v2 and mixed with other chains, when the requested source is mobile, and version 1.22, 1.22.5 or 1.23', () => {
         ;['uniswap-ios', 'uniswap-android'].forEach((requestSource) => {
+          const isMobileRequest = ['uniswap-ios', 'uniswap-android'].includes(requestSource)
           ;['1.22', '1.22.5', '1.23'].forEach((appVersion) => {
             expect(
               QuoteHandler.protocolsFromRequest(
                 ChainId.BASE,
                 ['v2', 'v3', 'mixed'],
-                requestSource,
+                isMobileRequest,
                 appVersion,
                 undefined
               )
@@ -73,12 +82,13 @@ describe('QuoteHandler', () => {
 
       it('allows v2 and mixed with mainnet, even when the requested source is mobile, and version 1.22, 1.22.5 or 1.23', () => {
         ;['uniswap-ios', 'uniswap-android'].forEach((requestSource) => {
+          const isMobileRequest = ['uniswap-ios', 'uniswap-android'].includes(requestSource)
           ;['1.22', '1.22.5', '1.23', '1.23.build-0'].forEach((appVersion) => {
             expect(
               QuoteHandler.protocolsFromRequest(
                 ChainId.MAINNET,
                 ['v2', 'v3', 'mixed'],
-                requestSource,
+                isMobileRequest,
                 appVersion,
                 undefined
               )
@@ -89,12 +99,13 @@ describe('QuoteHandler', () => {
 
       it('allows v2 and mixed with other chains, when the requested source is mobile, and version is 1.24 or greater', () => {
         ;['uniswap-ios', 'uniswap-android'].forEach((requestSource) => {
+          const isMobileRequest = ['uniswap-ios', 'uniswap-android'].includes(requestSource)
           ;['1.24', '1.25', '1.25.5', '1.26', '1.26.test'].forEach((appVersion) => {
             expect(
               QuoteHandler.protocolsFromRequest(
                 ChainId.BASE,
                 ['v2', 'v3', 'mixed'],
-                requestSource,
+                isMobileRequest,
                 appVersion,
                 undefined
               )

--- a/test/jest/unit/handlers/quote.test.ts
+++ b/test/jest/unit/handlers/quote.test.ts
@@ -7,19 +7,23 @@ describe('QuoteHandler', () => {
   describe('.protocolsFromRequest', () => {
     it('returns V3 when no protocols are requested', () => {
       const isMobileRequest = ['uniswap-ios', 'uniswap-android'].includes('')
-      expect(QuoteHandler.protocolsFromRequest(ChainId.MAINNET, undefined, isMobileRequest, undefined, undefined)).toEqual([
-        Protocol.V3,
-      ])
+      expect(
+        QuoteHandler.protocolsFromRequest(ChainId.MAINNET, undefined, isMobileRequest, undefined, undefined)
+      ).toEqual([Protocol.V3])
     })
 
     it('returns V3 when forceCrossProtocols is false', () => {
       const isMobileRequest = ['uniswap-ios', 'uniswap-android'].includes('')
-      expect(QuoteHandler.protocolsFromRequest(ChainId.MAINNET, undefined, isMobileRequest, undefined, false)).toEqual([Protocol.V3])
+      expect(QuoteHandler.protocolsFromRequest(ChainId.MAINNET, undefined, isMobileRequest, undefined, false)).toEqual([
+        Protocol.V3,
+      ])
     })
 
     it('returns empty when forceCrossProtocols is true', () => {
       const isMobileRequest = ['uniswap-ios', 'uniswap-android'].includes('')
-      expect(QuoteHandler.protocolsFromRequest(ChainId.MAINNET, undefined, isMobileRequest, undefined, true)).toEqual([])
+      expect(QuoteHandler.protocolsFromRequest(ChainId.MAINNET, undefined, isMobileRequest, undefined, true)).toEqual(
+        []
+      )
     })
 
     it('returns requested protocols', () => {
@@ -31,25 +35,28 @@ describe('QuoteHandler', () => {
 
     it('returns a different set of requested protocols', () => {
       const isMobileRequest = ['uniswap-ios', 'uniswap-android'].includes('')
-      expect(QuoteHandler.protocolsFromRequest(ChainId.MAINNET, ['v3', 'mixed'], isMobileRequest, undefined, undefined)).toEqual([
-        Protocol.V3,
-        Protocol.MIXED,
-      ])
+      expect(
+        QuoteHandler.protocolsFromRequest(ChainId.MAINNET, ['v3', 'mixed'], isMobileRequest, undefined, undefined)
+      ).toEqual([Protocol.V3, Protocol.MIXED])
     })
 
     it('works with other chains', () => {
       const isMobileRequest = ['uniswap-ios', 'uniswap-android'].includes('')
-      expect(QuoteHandler.protocolsFromRequest(ChainId.BASE, ['v2', 'v3', 'mixed'], isMobileRequest, undefined, undefined)).toEqual([
-        Protocol.V2,
-        Protocol.V3,
-        Protocol.MIXED,
-      ])
+      expect(
+        QuoteHandler.protocolsFromRequest(ChainId.BASE, ['v2', 'v3', 'mixed'], isMobileRequest, undefined, undefined)
+      ).toEqual([Protocol.V2, Protocol.V3, Protocol.MIXED])
     })
 
     it('returns undefined when a requested protocol is invalid', () => {
       const isMobileRequest = ['uniswap-ios', 'uniswap-android'].includes('')
       expect(
-        QuoteHandler.protocolsFromRequest(ChainId.BASE, ['v2', 'v3', 'mixed', 'miguel'], isMobileRequest, undefined, undefined)
+        QuoteHandler.protocolsFromRequest(
+          ChainId.BASE,
+          ['v2', 'v3', 'mixed', 'miguel'],
+          isMobileRequest,
+          undefined,
+          undefined
+        )
       ).toBeUndefined()
     })
 
@@ -58,7 +65,13 @@ describe('QuoteHandler', () => {
         ;['uniswap-ios', 'uniswap-android'].forEach((requestSource) => {
           const isMobileRequest = ['uniswap-ios', 'uniswap-android'].includes(requestSource)
           expect(
-            QuoteHandler.protocolsFromRequest(ChainId.BASE, ['v2', 'v3', 'mixed'], isMobileRequest, undefined, undefined)
+            QuoteHandler.protocolsFromRequest(
+              ChainId.BASE,
+              ['v2', 'v3', 'mixed'],
+              isMobileRequest,
+              undefined,
+              undefined
+            )
           ).toEqual([Protocol.V3])
         })
       })


### PR DESCRIPTION
the gas used proprietary SOR algorithm is too low on zksync, but tenderly cannot simulate on zksync yet to support accurate gas estimate. mobile launch on zksync requires a gas used, that will not result in mass onchain swap failure. We determined that routing-api returns a hardcoded 6 million gas used on zksync would avoid large onchain swap failures on mobile.

- tested locally with uniswap-web source, gas estimate doesn't change: https://app.warp.dev/block/dSlawsa6TBSS4MYWWSoSqj
- tested locally with uniswap-ios source, gas estimate changed to 6000000: https://app.warp.dev/block/th0bZOQCC3wUpgD1aVYkhI