### PR TITLE
fix: Fee sampling comparison metrics when both undefined or buy/sellFeeBps missing

### DIFF
--- a/lib/util/traffic-switch/traffic-switcher-i-token-fee-fetcher.ts
+++ b/lib/util/traffic-switch/traffic-switcher-i-token-fee-fetcher.ts
@@ -2,6 +2,7 @@ import { TrafficSwitcher } from './traffic-switcher'
 import { ITokenFeeFetcher, TokenFeeMap } from '@uniswap/smart-order-router/build/main/providers/token-fee-fetcher'
 import { ProviderConfig } from '@uniswap/smart-order-router/build/main/providers/provider'
 import { log } from '@uniswap/smart-order-router'
+import { BigNumber } from 'ethers'
 
 type Address = string
 
@@ -33,11 +34,23 @@ export class TrafficSwitcherITokenFeeFetcher extends TrafficSwitcher<ITokenFeeFe
 
     // We have results from both implementations, compare them as a whole.
     // Before comparison, do some cleaning and keep only entries with a fee != 0.
-    // This is needed as different implementations can return empty/null entry, or entry with 0 fees.
+    // This is needed as different implementations can return empty/null entry, or entry with 0 fees (buy/sellFeeBps or both).
     const cleanResult = (result: TokenFeeMap): TokenFeeMap =>
       Object.entries(result)
-        .filter(([_, v]) => !v.buyFeeBps?.eq(0) || !v.sellFeeBps?.eq(0))
-        .reduce((acc, [k, v]) => ({ ...acc, [k]: v }), {})
+        .filter(
+          ([_, v]) =>
+            (v.buyFeeBps !== undefined && !v.buyFeeBps.eq(0)) || (v.sellFeeBps !== undefined && !v.sellFeeBps.eq(0))
+        )
+        .reduce(
+          (acc, [k, v]) => ({
+            ...acc,
+            [k]: {
+              buyFeeBps: v.buyFeeBps || BigNumber.from(0),
+              sellFeeBps: v.sellFeeBps || BigNumber.from(0),
+            },
+          }),
+          {}
+        )
     const cleanedResultA = cleanResult(resultA)
     const cleanedResultB = cleanResult(resultB)
 

--- a/lib/util/traffic-switch/traffic-switcher-i-token-fee-fetcher.ts
+++ b/lib/util/traffic-switch/traffic-switcher-i-token-fee-fetcher.ts
@@ -45,8 +45,8 @@ export class TrafficSwitcherITokenFeeFetcher extends TrafficSwitcher<ITokenFeeFe
           (acc, [k, v]) => ({
             ...acc,
             [k]: {
-              buyFeeBps: v.buyFeeBps || BigNumber.from(0),
-              sellFeeBps: v.sellFeeBps || BigNumber.from(0),
+              buyFeeBps: v.buyFeeBps ?? BigNumber.from(0),
+              sellFeeBps: v.sellFeeBps ?? BigNumber.from(0),
             },
           }),
           {}

--- a/test/mocha/unit/traffic-switch/traffic-switcher-i-token-fee-fetcher.test.ts
+++ b/test/mocha/unit/traffic-switch/traffic-switcher-i-token-fee-fetcher.test.ts
@@ -23,6 +23,31 @@ describe('TrafficSwitcherITokenFeeFetcher', () => {
     return tokenFeeMap
   }
 
+  const methodFetchFeesReturnFee100AndUndefined = async (
+    addresses: string[],
+    _?: ProviderConfig
+  ): Promise<TokenFeeMap> => {
+    const tokenFeeMap: TokenFeeMap = {}
+    addresses.map((address) => {
+      tokenFeeMap[address] = {
+        buyFeeBps: BigNumber.from(100),
+        sellFeeBps: undefined,
+      }
+    })
+    return tokenFeeMap
+  }
+
+  const methodFetchFeesReturnFee100AndZero = async (addresses: string[], _?: ProviderConfig): Promise<TokenFeeMap> => {
+    const tokenFeeMap: TokenFeeMap = {}
+    addresses.map((address) => {
+      tokenFeeMap[address] = {
+        buyFeeBps: BigNumber.from(100),
+        sellFeeBps: BigNumber.from(0),
+      }
+    })
+    return tokenFeeMap
+  }
+
   const methodFetchFeesReturnFee200 = async (addresses: string[], _?: ProviderConfig): Promise<TokenFeeMap> => {
     const tokenFeeMap: TokenFeeMap = {}
     addresses.map((address) => {
@@ -332,6 +357,52 @@ describe('TrafficSwitcherITokenFeeFetcher', () => {
     for (const address in tokenFeeMap) {
       expect(tokenFeeMap[address]).to.deep.equal({
         buyFeeBps: BigNumber.from(0),
+        sellFeeBps: BigNumber.from(0),
+      })
+    }
+
+    sinon.assert.calledOnce(targetFeeFetcher.fetchFees)
+    sinon.assert.calledOnce(currentFeeFetcher.fetchFees)
+    sinon.assert.calledWith(
+      spy,
+      TrafficSwitcher.METRIC_NAME_TEMPLATE.replace('{EXP}', 'Exp1')
+        .replace('{METHOD}', 'fetchFees')
+        .replace('{METRIC}', 'COMPARISON_SAMPLE'),
+      1,
+      MetricLoggerUnit.Count
+    )
+    sinon.assert.calledWith(
+      spy,
+      TrafficSwitcher.METRIC_NAME_TEMPLATE.replace('{EXP}', 'Exp1')
+        .replace('{METHOD}', 'fetchFees')
+        .replace('{METRIC}', 'COMPARISON__IDENTICAL__RESULT__YES'),
+      1,
+      MetricLoggerUnit.Count
+    )
+  })
+
+  it('sampling traffic 100% should get results from both (Identical 100+undefined/0 fee), and return Current impl result', async () => {
+    const currentFeeFetcher = sinon.createStubInstance(OnChainTokenFeeFetcher)
+    const targetFeeFetcher = sinon.createStubInstance(GraphQLTokenFeeFetcher)
+    currentFeeFetcher.fetchFees.callsFake(methodFetchFeesReturnFee100AndZero)
+    targetFeeFetcher.fetchFees.callsFake(methodFetchFeesReturnFee100AndUndefined)
+
+    const trafficSwitchProvider = new TrafficSwitcherITokenFeeFetcher('Exp1', {
+      control: currentFeeFetcher,
+      treatment: targetFeeFetcher,
+      aliasControl: 'Current',
+      aliasTreatment: 'Target',
+      customization: {
+        pctEnabled: 0.0,
+        pctShadowSampling: 1.0,
+      },
+    })
+
+    const tokenFeeMap = await trafficSwitchProvider.fetchFees(['0x1', '0x2'], undefined)
+
+    for (const address in tokenFeeMap) {
+      expect(tokenFeeMap[address]).to.deep.equal({
+        buyFeeBps: BigNumber.from(100),
         sellFeeBps: BigNumber.from(0),
       })
     }

--- a/test/mocha/unit/traffic-switch/traffic-switcher-i-token-fee-fetcher.test.ts
+++ b/test/mocha/unit/traffic-switch/traffic-switcher-i-token-fee-fetcher.test.ts
@@ -74,6 +74,17 @@ describe('TrafficSwitcherITokenFeeFetcher', () => {
     return tokenFeeMap
   }
 
+  const methodFetchFeesReturnFeeEmpty = async (addresses: string[], _?: ProviderConfig): Promise<TokenFeeMap> => {
+    const tokenFeeMap: TokenFeeMap = {}
+    addresses.map((address) => {
+      tokenFeeMap[address] = {
+        buyFeeBps: undefined,
+        sellFeeBps: undefined,
+      }
+    })
+    return tokenFeeMap
+  }
+
   const methodFetchFeesThrowsException = async (
     _addresses: string[],
     _providerConfig?: ProviderConfig
@@ -340,6 +351,52 @@ describe('TrafficSwitcherITokenFeeFetcher', () => {
     const targetFeeFetcher = sinon.createStubInstance(GraphQLTokenFeeFetcher)
     currentFeeFetcher.fetchFees.callsFake(methodFetchFeesReturnFee0)
     targetFeeFetcher.fetchFees.callsFake(methodFetchFeesReturnEmpty)
+
+    const trafficSwitchProvider = new TrafficSwitcherITokenFeeFetcher('Exp1', {
+      control: currentFeeFetcher,
+      treatment: targetFeeFetcher,
+      aliasControl: 'Current',
+      aliasTreatment: 'Target',
+      customization: {
+        pctEnabled: 0.0,
+        pctShadowSampling: 1.0,
+      },
+    })
+
+    const tokenFeeMap = await trafficSwitchProvider.fetchFees(['0x1', '0x2'], undefined)
+
+    for (const address in tokenFeeMap) {
+      expect(tokenFeeMap[address]).to.deep.equal({
+        buyFeeBps: BigNumber.from(0),
+        sellFeeBps: BigNumber.from(0),
+      })
+    }
+
+    sinon.assert.calledOnce(targetFeeFetcher.fetchFees)
+    sinon.assert.calledOnce(currentFeeFetcher.fetchFees)
+    sinon.assert.calledWith(
+      spy,
+      TrafficSwitcher.METRIC_NAME_TEMPLATE.replace('{EXP}', 'Exp1')
+        .replace('{METHOD}', 'fetchFees')
+        .replace('{METRIC}', 'COMPARISON_SAMPLE'),
+      1,
+      MetricLoggerUnit.Count
+    )
+    sinon.assert.calledWith(
+      spy,
+      TrafficSwitcher.METRIC_NAME_TEMPLATE.replace('{EXP}', 'Exp1')
+        .replace('{METHOD}', 'fetchFees')
+        .replace('{METRIC}', 'COMPARISON__IDENTICAL__RESULT__YES'),
+      1,
+      MetricLoggerUnit.Count
+    )
+  })
+
+  it('sampling traffic 100% should get results from both (Identical fee_empty/fee_zero), and return Current impl result', async () => {
+    const currentFeeFetcher = sinon.createStubInstance(OnChainTokenFeeFetcher)
+    const targetFeeFetcher = sinon.createStubInstance(GraphQLTokenFeeFetcher)
+    currentFeeFetcher.fetchFees.callsFake(methodFetchFeesReturnFee0)
+    targetFeeFetcher.fetchFees.callsFake(methodFetchFeesReturnFeeEmpty)
 
     const trafficSwitchProvider = new TrafficSwitcherITokenFeeFetcher('Exp1', {
       control: currentFeeFetcher,


### PR DESCRIPTION
One more minor fix when comparing partially populated fees between the 2 implementations.
Populate with 0 so that we can have correct comparison.