### PR TITLE
chore(GQL): traffic switch 2% to graphql token fee fetch

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -246,8 +246,8 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
             aliasControl: 'onChainTokenFeeFetcher',
             aliasTreatment: 'graphQLTokenFeeFetcher',
             customization: {
-              pctEnabled: 0.0,
-              pctShadowSampling: 0.005,
+              pctEnabled: 0.02,
+              pctShadowSampling: 0.0,
             },
           })
 


### PR DESCRIPTION
Start traffic switch 2% to graphql token fee fetch, then we'll monitor and gradually increase.
2% should send ~3 req/sec to graphql endpoint

When we switch 100%, gql should expect around [~60 to 80 req/sec](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~'Uniswap~'GraphQLTokenFeeFetcherOnChainCallbackRequest~'Service~'RoutingAPI~(visible~false))~(~'.~'GraphQLTokenFeeFetcherFetchFeesSuccess~'.~'.~(visible~false))~(~'.~'TRAFFIC_SWITCHER__TokenFetcherExperiment__fetchFees__COMPARISON__IDENTICAL__RESULT__NO~'.~'.~(visible~false))~(~'.~'TRAFFIC_SWITCHER__TokenFetcherExperiment__fetchFees__COMPARISON__IDENTICAL__RESULT__YES~'.~'.~(visible~false))~(~'.~'TokenFeeFetcherFetchFeesSuccess~'.~'.~(period~60))~(~'.~'TokenFeeFetcherFetchFeesFailure~'.~'.~(period~60)))~view~'timeSeries~stacked~false~region~'us-east-2~stat~'SampleCount~period~900~start~'-PT3H~end~'P0D)&query=~'*7bUniswap*2cService*7d*20TokenFeeFetcherFetchFeesFailure) based on current onchain metrics.
cc @andysmith415 @robert-seitz-uniswap 