### PR TITLE
chore(GQL): traffic switch 8% to graphql token fee fetch

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -246,7 +246,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
             aliasControl: 'onChainTokenFeeFetcher',
             aliasTreatment: 'graphQLTokenFeeFetcher',
             customization: {
-              pctEnabled: 0.02,
+              pctEnabled: 0.08,
               pctShadowSampling: 0.0,
             },
           })


### PR DESCRIPTION
2% traffic ([PR](https://github.com/Uniswap/routing-api/pull/762)) [looks good ](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~'Uniswap~'GraphQLTokenFeeFetcherOnChainCallbackRequest~'Service~'RoutingAPI)~(~'.~'GraphQLTokenFeeFetcherFetchFeesSuccess~'.~'.)~(~'.~'TRAFFIC_SWITCHER__TokenFetcherExperiment__fetchFees__COMPARISON__IDENTICAL__RESULT__NO~'.~'.~(visible~false))~(~'.~'TRAFFIC_SWITCHER__TokenFetcherExperiment__fetchFees__COMPARISON__IDENTICAL__RESULT__YES~'.~'.~(visible~false))~(~'.~'TokenFeeFetcherFetchFeesSuccess~'.~'.~(visible~false))~(~'.~'TokenFeeFetcherFetchFeesFailure~'.~'.~(visible~false)))~view~'timeSeries~stacked~false~region~'us-east-2~stat~'SampleCount~period~60~start~'-PT12H~end~'P0D)&query=~'*7bUniswap*2cService*7d*20TokenFeeFetcherFetchFeesFailure) without issues after 3 hours

Moving to 8% for the rest of the day