### PR TITLE
chore(GQL): traffic switch 70% to graphql token fee fetch

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -246,7 +246,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
             aliasControl: 'onChainTokenFeeFetcher',
             aliasTreatment: 'graphQLTokenFeeFetcher',
             customization: {
-              pctEnabled: 0.3,
+              pctEnabled: 0.7,
               pctShadowSampling: 0.0,
             },
           })


### PR DESCRIPTION
30% traffic (https://github.com/Uniswap/routing-api/pull/764) [looks good ](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~'Uniswap~'GraphQLTokenFeeFetcherOnChainCallbackRequest~'Service~'RoutingAPI)~(~'.~'GraphQLTokenFeeFetcherFetchFeesSuccess~'.~'.)~(~'.~'GraphQLTokenFeeFetcherFetchFeesFailure~'.~'.)~(~'.~'TRAFFIC_SWITCHER__TokenFetcherExperiment__fetchFees__COMPARISON__IDENTICAL__RESULT__NO~'.~'.~(visible~false))~(~'.~'TRAFFIC_SWITCHER__TokenFetcherExperiment__fetchFees__COMPARISON__IDENTICAL__RESULT__YES~'.~'.~(visible~false))~(~'.~'TokenFeeFetcherFetchFeesSuccess~'.~'.~(visible~false))~(~'.~'TokenFeeFetcherFetchFeesFailure~'.~'.~(visible~false)))~view~'timeSeries~stacked~false~region~'us-east-2~stat~'SampleCount~period~60~start~'-PT24H~end~'P0D)&query=~'*7bUniswap*2cService*7d*20GraphQLTokenFeeFetcherFetchFees) without issues after 5 hours

Moving to 70%