### PR TITLE
chore(gql): add sev3 alert

### DIFF
--- a/bin/stacks/routing-api-stack.ts
+++ b/bin/stacks/routing-api-stack.ts
@@ -359,6 +359,36 @@ export class RoutingAPIStack extends cdk.Stack {
       treatMissingData: aws_cloudwatch.TreatMissingData.NOT_BREACHING, // Missing data points are treated as "good" and within the threshold
     })
 
+    // Create an alarm for when GraphQLTokenFeeFetcherFetchFeesFailure rate goes above 15%.
+    // We do have on chain fallback in place of GQL failure, but we want to be alerted if the failure rate is high to take action.
+    // For this reason we only alert on SEV3.
+    const graphqlTokenFeeFetcherErrorRateSev3 = new aws_cloudwatch.Alarm(this, 'RoutingAPI-SEV3-GQLTokenFeeFetcherFailureRate', {
+      alarmName: 'RoutingAPI-SEV3-GQLTokenFeeFetcherFailureRate',
+      metric: new MathExpression({
+        expression: '100*(GraphQLTokenFeeFetcherFetchFeesFailure/(GraphQLTokenFeeFetcherFetchFeesSuccess+GraphQLTokenFeeFetcherFetchFeesFailure))',
+        period: Duration.minutes(5),
+        usingMetrics: {
+          GraphQLTokenFeeFetcherFetchFeesSuccess: new aws_cloudwatch.Metric({
+            namespace: 'Uniswap',
+            metricName: `GraphQLTokenFeeFetcherFetchFeesSuccess`,
+            dimensionsMap: { Service: 'RoutingAPI' },
+            unit: aws_cloudwatch.Unit.COUNT,
+            statistic: 'sum',
+          }),
+          GraphQLTokenFeeFetcherFetchFeesFailure: new aws_cloudwatch.Metric({
+            namespace: 'Uniswap',
+            metricName: `GraphQLTokenFeeFetcherFetchFeesFailure`,
+            dimensionsMap: { Service: 'RoutingAPI' },
+            unit: aws_cloudwatch.Unit.COUNT,
+            statistic: 'sum',
+          }),
+        },
+      }),
+      threshold: 15,
+      evaluationPeriods: 3,
+      treatMissingData: aws_cloudwatch.TreatMissingData.NOT_BREACHING, // Missing data points are treated as "good" and within the threshold
+    })
+
     // Alarms for high 400 error rate for each chain
     const percent4XXByChainAlarm: cdk.aws_cloudwatch.Alarm[] = []
     SUPPORTED_CHAINS.forEach((chainId) => {
@@ -538,6 +568,7 @@ export class RoutingAPIStack extends cdk.Stack {
       apiAlarm4xxSev3.addAlarmAction(new aws_cloudwatch_actions.SnsAction(chatBotTopic))
       apiAlarmLatencySev3.addAlarmAction(new aws_cloudwatch_actions.SnsAction(chatBotTopic))
       simulationAlarmSev3.addAlarmAction(new aws_cloudwatch_actions.SnsAction(chatBotTopic))
+      graphqlTokenFeeFetcherErrorRateSev3.addAlarmAction(new aws_cloudwatch_actions.SnsAction(chatBotTopic))
 
       percent4XXByChainAlarm.forEach((alarm) => {
         alarm.addAlarmAction(new aws_cloudwatch_actions.SnsAction(chatBotTopic))

--- a/bin/stacks/routing-api-stack.ts
+++ b/bin/stacks/routing-api-stack.ts
@@ -362,32 +362,37 @@ export class RoutingAPIStack extends cdk.Stack {
     // Create an alarm for when GraphQLTokenFeeFetcherFetchFeesFailure rate goes above 15%.
     // We do have on chain fallback in place of GQL failure, but we want to be alerted if the failure rate is high to take action.
     // For this reason we only alert on SEV3.
-    const graphqlTokenFeeFetcherErrorRateSev3 = new aws_cloudwatch.Alarm(this, 'RoutingAPI-SEV3-GQLTokenFeeFetcherFailureRate', {
-      alarmName: 'RoutingAPI-SEV3-GQLTokenFeeFetcherFailureRate',
-      metric: new MathExpression({
-        expression: '100*(GraphQLTokenFeeFetcherFetchFeesFailure/(GraphQLTokenFeeFetcherFetchFeesSuccess+GraphQLTokenFeeFetcherFetchFeesFailure))',
-        period: Duration.minutes(5),
-        usingMetrics: {
-          GraphQLTokenFeeFetcherFetchFeesSuccess: new aws_cloudwatch.Metric({
-            namespace: 'Uniswap',
-            metricName: `GraphQLTokenFeeFetcherFetchFeesSuccess`,
-            dimensionsMap: { Service: 'RoutingAPI' },
-            unit: aws_cloudwatch.Unit.COUNT,
-            statistic: 'sum',
-          }),
-          GraphQLTokenFeeFetcherFetchFeesFailure: new aws_cloudwatch.Metric({
-            namespace: 'Uniswap',
-            metricName: `GraphQLTokenFeeFetcherFetchFeesFailure`,
-            dimensionsMap: { Service: 'RoutingAPI' },
-            unit: aws_cloudwatch.Unit.COUNT,
-            statistic: 'sum',
-          }),
-        },
-      }),
-      threshold: 15,
-      evaluationPeriods: 3,
-      treatMissingData: aws_cloudwatch.TreatMissingData.NOT_BREACHING, // Missing data points are treated as "good" and within the threshold
-    })
+    const graphqlTokenFeeFetcherErrorRateSev3 = new aws_cloudwatch.Alarm(
+      this,
+      'RoutingAPI-SEV3-GQLTokenFeeFetcherFailureRate',
+      {
+        alarmName: 'RoutingAPI-SEV3-GQLTokenFeeFetcherFailureRate',
+        metric: new MathExpression({
+          expression:
+            '100*(GraphQLTokenFeeFetcherFetchFeesFailure/(GraphQLTokenFeeFetcherFetchFeesSuccess+GraphQLTokenFeeFetcherFetchFeesFailure))',
+          period: Duration.minutes(5),
+          usingMetrics: {
+            GraphQLTokenFeeFetcherFetchFeesSuccess: new aws_cloudwatch.Metric({
+              namespace: 'Uniswap',
+              metricName: `GraphQLTokenFeeFetcherFetchFeesSuccess`,
+              dimensionsMap: { Service: 'RoutingAPI' },
+              unit: aws_cloudwatch.Unit.COUNT,
+              statistic: 'sum',
+            }),
+            GraphQLTokenFeeFetcherFetchFeesFailure: new aws_cloudwatch.Metric({
+              namespace: 'Uniswap',
+              metricName: `GraphQLTokenFeeFetcherFetchFeesFailure`,
+              dimensionsMap: { Service: 'RoutingAPI' },
+              unit: aws_cloudwatch.Unit.COUNT,
+              statistic: 'sum',
+            }),
+          },
+        }),
+        threshold: 15,
+        evaluationPeriods: 3,
+        treatMissingData: aws_cloudwatch.TreatMissingData.NOT_BREACHING, // Missing data points are treated as "good" and within the threshold
+      }
+    )
 
     // Alarms for high 400 error rate for each chain
     const percent4XXByChainAlarm: cdk.aws_cloudwatch.Alarm[] = []


### PR DESCRIPTION
Create an alarm for when GraphQLTokenFeeFetcherFetchFeesFailure rate goes above 15%.
We do have on chain fallback in place of GQL failure, but we want to be alerted if the failure rate is high to take action.
For this reason we only alert on SEV3.