### PR TITLE
chore(GQL): traffic switch 100% to graphql token fee fetch + shadow sample at 0.5%

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -240,7 +240,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
             onChainTokenFeeFetcher,
             chainId
           )
-          const trafficSwitcherTokenFetcher = new TrafficSwitcherITokenFeeFetcher('TokenFetcherExperiment', {
+          const trafficSwitcherTokenFetcher = new TrafficSwitcherITokenFeeFetcher('TokenFetcherExperimentV2', {
             control: graphQLTokenFeeFetcher,
             treatment: onChainTokenFeeFetcher,
             aliasControl: 'graphQLTokenFeeFetcher',

--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -241,13 +241,13 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
             chainId
           )
           const trafficSwitcherTokenFetcher = new TrafficSwitcherITokenFeeFetcher('TokenFetcherExperiment', {
-            control: onChainTokenFeeFetcher,
-            treatment: graphQLTokenFeeFetcher,
-            aliasControl: 'onChainTokenFeeFetcher',
-            aliasTreatment: 'graphQLTokenFeeFetcher',
+            control: graphQLTokenFeeFetcher,
+            treatment: onChainTokenFeeFetcher,
+            aliasControl: 'graphQLTokenFeeFetcher',
+            aliasTreatment: 'onChainTokenFeeFetcher',
             customization: {
-              pctEnabled: 0.7,
-              pctShadowSampling: 0.0,
+              pctEnabled: 0.0,
+              pctShadowSampling: 0.005,
             },
           })
 


### PR DESCRIPTION
70% traffic [looks good ](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~'Uniswap~'GraphQLTokenFeeFetcherOnChainCallbackRequest~'Service~'RoutingAPI)~(~'.~'GraphQLTokenFeeFetcherFetchFeesSuccess~'.~'.)~(~'.~'GraphQLTokenFeeFetcherFetchFeesFailure~'.~'.)~(~'.~'TRAFFIC_SWITCHER__TokenFetcherExperiment__fetchFees__COMPARISON__IDENTICAL__RESULT__NO~'.~'.~(visible~false))~(~'.~'TRAFFIC_SWITCHER__TokenFetcherExperiment__fetchFees__COMPARISON__IDENTICAL__RESULT__YES~'.~'.~(visible~false))~(~'.~'TokenFeeFetcherFetchFeesSuccess~'.~'.~(visible~false))~(~'.~'TokenFeeFetcherFetchFeesFailure~'.~'.~(visible~false)))~view~'timeSeries~stacked~false~region~'us-east-2~stat~'SampleCount~period~60~start~'-PT24H~end~'P0D)&query=~'*7bUniswap*2cService*7d*20GraphQLTokenFeeFetcherFetchFees) without issues.

Preparing a PR to moving to 100% and also enable shadow sampling for onChain (plan to checkin on Monday)

Shadow sampling data will be used to update our dynamic FOT token list in the near future, until data-api exposes the `isDynamicFOT` field.