### PR TITLE
chore: bump sor to 3.35.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.9.2",
         "@uniswap/sdk-core": "^5.3.0",
-        "@uniswap/smart-order-router": "3.35.10",
+        "@uniswap/smart-order-router": "3.35.11",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^2.2.0",
         "@uniswap/v2-sdk": "^4.3.2",
@@ -4748,9 +4748,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.35.10",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.35.10.tgz",
-      "integrity": "sha512-mjcTAX8IHonnpn0Lalktgugk5O3Xt99jWCQNQQAY8zfWvi9h944cfkJFpBMfehIaCRKjXC4Yo3LkmirbsVTwyw==",
+      "version": "3.35.11",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.35.11.tgz",
+      "integrity": "sha512-+4SQnZAr7ed7mIy+2WgpquuHR5zYE0xDjkCIvwN9STk3/Y751WnVgX1wmldoWRK9JObC89lRdWxBMqnTe+0kWg==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -28385,9 +28385,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.35.10",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.35.10.tgz",
-      "integrity": "sha512-mjcTAX8IHonnpn0Lalktgugk5O3Xt99jWCQNQQAY8zfWvi9h944cfkJFpBMfehIaCRKjXC4Yo3LkmirbsVTwyw==",
+      "version": "3.35.11",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.35.11.tgz",
+      "integrity": "sha512-+4SQnZAr7ed7mIy+2WgpquuHR5zYE0xDjkCIvwN9STk3/Y751WnVgX1wmldoWRK9JObC89lRdWxBMqnTe+0kWg==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@uniswap/router-sdk": "^1.9.2",
     "@uniswap/sdk-core": "^5.3.0",
     "@types/semver": "^7.5.8",
-    "@uniswap/smart-order-router": "3.35.10",
+    "@uniswap/smart-order-router": "3.35.11",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^2.2.0",
     "@uniswap/v2-sdk": "^4.3.2",


### PR DESCRIPTION
release https://github.com/Uniswap/smart-order-router/pull/628