### PR TITLE
feat: remove mobile check

### DIFF
--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -33,7 +33,6 @@ import { MetricsLogger } from 'aws-embedded-metrics'
 import { CurrencyLookup } from '../CurrencyLookup'
 import { SwapOptionsFactory } from './SwapOptionsFactory'
 import { GlobalRpcProviders } from '../../rpc/GlobalRpcProviders'
-import semver from 'semver'
 import { adhocCorrectGasUsed } from '../../util/estimateGasUsed'
 import { adhocCorrectGasUsedUSD } from '../../util/estimateGasUsedUSD'
 
@@ -248,13 +247,7 @@ export class QuoteHandler extends APIGLambdaHandler<
 
     const requestSource = requestSourceHeader ?? params.requestQueryParams.source ?? ''
     const isMobileRequest = ['uniswap-ios', 'uniswap-android'].includes(requestSource)
-    const protocols = QuoteHandler.protocolsFromRequest(
-      chainId,
-      protocolsStr,
-      isMobileRequest,
-      appVersion,
-      forceCrossProtocol
-    )
+    const protocols = QuoteHandler.protocolsFromRequest(chainId, protocolsStr, isMobileRequest)
 
     if (protocols === undefined) {
       return {

--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -651,14 +651,9 @@ export class QuoteHandler extends APIGLambdaHandler<
   static protocolsFromRequest(
     chainId: ChainId,
     requestedProtocols: string[] | string | undefined,
-    isMobileRequest: boolean,
-    appVersion: string | undefined,
     forceCrossProtocol: boolean | undefined
   ): Protocol[] | undefined {
-    // We will exclude V2 if isMobile and the appVersion is not present or is lower than 1.24
-    const semverAppVersion = semver.coerce(appVersion)
-    const fixVersion = semver.coerce('1.24')!
-    const excludeV2 = isMobileRequest && (semverAppVersion === null || semver.lt(semverAppVersion, fixVersion))
+    const excludeV2 = false
 
     if (requestedProtocols) {
       let protocols: Protocol[] = []

--- a/test/jest/unit/handlers/quote.test.ts
+++ b/test/jest/unit/handlers/quote.test.ts
@@ -6,126 +6,49 @@ import { Protocol } from '@uniswap/router-sdk'
 describe('QuoteHandler', () => {
   describe('.protocolsFromRequest', () => {
     it('returns V3 when no protocols are requested', () => {
-      const isMobileRequest = ['uniswap-ios', 'uniswap-android'].includes('')
       expect(
-        QuoteHandler.protocolsFromRequest(ChainId.MAINNET, undefined, isMobileRequest, undefined, undefined)
+        QuoteHandler.protocolsFromRequest(ChainId.MAINNET, undefined, undefined)
       ).toEqual([Protocol.V3])
     })
 
-    it('returns V3 when forceCrossProtocols is false', () => {
-      const isMobileRequest = ['uniswap-ios', 'uniswap-android'].includes('')
-      expect(QuoteHandler.protocolsFromRequest(ChainId.MAINNET, undefined, isMobileRequest, undefined, false)).toEqual([
+    it('returns V3 when forceCrossProtocol is false', () => {
+      expect(QuoteHandler.protocolsFromRequest(ChainId.MAINNET, undefined, false)).toEqual([
         Protocol.V3,
       ])
     })
 
-    it('returns empty when forceCrossProtocols is true', () => {
-      const isMobileRequest = ['uniswap-ios', 'uniswap-android'].includes('')
-      expect(QuoteHandler.protocolsFromRequest(ChainId.MAINNET, undefined, isMobileRequest, undefined, true)).toEqual(
+    it('returns empty when forceCrossProtocol is true', () => {
+      expect(QuoteHandler.protocolsFromRequest(ChainId.MAINNET, undefined, true)).toEqual(
         []
       )
     })
 
     it('returns requested protocols', () => {
-      const isMobileRequest = ['uniswap-ios', 'uniswap-android'].includes('')
       expect(
-        QuoteHandler.protocolsFromRequest(ChainId.MAINNET, ['v2', 'v3', 'mixed'], isMobileRequest, undefined, undefined)
+        QuoteHandler.protocolsFromRequest(ChainId.MAINNET, ['v2', 'v3', 'mixed'], undefined)
       ).toEqual([Protocol.V2, Protocol.V3, Protocol.MIXED])
     })
 
     it('returns a different set of requested protocols', () => {
-      const isMobileRequest = ['uniswap-ios', 'uniswap-android'].includes('')
       expect(
-        QuoteHandler.protocolsFromRequest(ChainId.MAINNET, ['v3', 'mixed'], isMobileRequest, undefined, undefined)
+        QuoteHandler.protocolsFromRequest(ChainId.MAINNET, ['v3', 'mixed'], undefined)
       ).toEqual([Protocol.V3, Protocol.MIXED])
     })
 
     it('works with other chains', () => {
-      const isMobileRequest = ['uniswap-ios', 'uniswap-android'].includes('')
       expect(
-        QuoteHandler.protocolsFromRequest(ChainId.BASE, ['v2', 'v3', 'mixed'], isMobileRequest, undefined, undefined)
+        QuoteHandler.protocolsFromRequest(ChainId.BASE, ['v2', 'v3', 'mixed'], undefined)
       ).toEqual([Protocol.V2, Protocol.V3, Protocol.MIXED])
     })
 
     it('returns undefined when a requested protocol is invalid', () => {
-      const isMobileRequest = ['uniswap-ios', 'uniswap-android'].includes('')
       expect(
         QuoteHandler.protocolsFromRequest(
           ChainId.BASE,
           ['v2', 'v3', 'mixed', 'miguel'],
-          isMobileRequest,
-          undefined,
           undefined
         )
       ).toBeUndefined()
-    })
-
-    describe('for mobile request', () => {
-      it('removes v2 and mixed with other chains, when the requested source is mobile', () => {
-        ;['uniswap-ios', 'uniswap-android'].forEach((requestSource) => {
-          const isMobileRequest = ['uniswap-ios', 'uniswap-android'].includes(requestSource)
-          expect(
-            QuoteHandler.protocolsFromRequest(
-              ChainId.BASE,
-              ['v2', 'v3', 'mixed'],
-              isMobileRequest,
-              undefined,
-              undefined
-            )
-          ).toEqual([Protocol.V3])
-        })
-      })
-
-      it('removes v2 and mixed with other chains, when the requested source is mobile, and version 1.22, 1.22.5 or 1.23', () => {
-        ;['uniswap-ios', 'uniswap-android'].forEach((requestSource) => {
-          const isMobileRequest = ['uniswap-ios', 'uniswap-android'].includes(requestSource)
-          ;['1.22', '1.22.5', '1.23'].forEach((appVersion) => {
-            expect(
-              QuoteHandler.protocolsFromRequest(
-                ChainId.BASE,
-                ['v2', 'v3', 'mixed'],
-                isMobileRequest,
-                appVersion,
-                undefined
-              )
-            ).toEqual([Protocol.V3])
-          })
-        })
-      })
-
-      it('allows v2 and mixed with mainnet, even when the requested source is mobile, and version 1.22, 1.22.5 or 1.23', () => {
-        ;['uniswap-ios', 'uniswap-android'].forEach((requestSource) => {
-          const isMobileRequest = ['uniswap-ios', 'uniswap-android'].includes(requestSource)
-          ;['1.22', '1.22.5', '1.23', '1.23.build-0'].forEach((appVersion) => {
-            expect(
-              QuoteHandler.protocolsFromRequest(
-                ChainId.MAINNET,
-                ['v2', 'v3', 'mixed'],
-                isMobileRequest,
-                appVersion,
-                undefined
-              )
-            ).toEqual([Protocol.V2, Protocol.V3, Protocol.MIXED])
-          })
-        })
-      })
-
-      it('allows v2 and mixed with other chains, when the requested source is mobile, and version is 1.24 or greater', () => {
-        ;['uniswap-ios', 'uniswap-android'].forEach((requestSource) => {
-          const isMobileRequest = ['uniswap-ios', 'uniswap-android'].includes(requestSource)
-          ;['1.24', '1.25', '1.25.5', '1.26', '1.26.test'].forEach((appVersion) => {
-            expect(
-              QuoteHandler.protocolsFromRequest(
-                ChainId.BASE,
-                ['v2', 'v3', 'mixed'],
-                isMobileRequest,
-                appVersion,
-                undefined
-              )
-            ).toEqual([Protocol.V2, Protocol.V3, Protocol.MIXED])
-          })
-        })
-      })
     })
   })
 })

--- a/test/jest/unit/handlers/quote.test.ts
+++ b/test/jest/unit/handlers/quote.test.ts
@@ -6,48 +6,43 @@ import { Protocol } from '@uniswap/router-sdk'
 describe('QuoteHandler', () => {
   describe('.protocolsFromRequest', () => {
     it('returns V3 when no protocols are requested', () => {
-      expect(
-        QuoteHandler.protocolsFromRequest(ChainId.MAINNET, undefined, undefined)
-      ).toEqual([Protocol.V3])
+      expect(QuoteHandler.protocolsFromRequest(ChainId.MAINNET, undefined, undefined)).toEqual([Protocol.V3])
     })
 
     it('returns V3 when forceCrossProtocol is false', () => {
-      expect(QuoteHandler.protocolsFromRequest(ChainId.MAINNET, undefined, false)).toEqual([
-        Protocol.V3,
-      ])
+      expect(QuoteHandler.protocolsFromRequest(ChainId.MAINNET, undefined, false)).toEqual([Protocol.V3])
     })
 
     it('returns empty when forceCrossProtocol is true', () => {
-      expect(QuoteHandler.protocolsFromRequest(ChainId.MAINNET, undefined, true)).toEqual(
-        []
-      )
+      expect(QuoteHandler.protocolsFromRequest(ChainId.MAINNET, undefined, true)).toEqual([])
     })
 
     it('returns requested protocols', () => {
-      expect(
-        QuoteHandler.protocolsFromRequest(ChainId.MAINNET, ['v2', 'v3', 'mixed'], undefined)
-      ).toEqual([Protocol.V2, Protocol.V3, Protocol.MIXED])
+      expect(QuoteHandler.protocolsFromRequest(ChainId.MAINNET, ['v2', 'v3', 'mixed'], undefined)).toEqual([
+        Protocol.V2,
+        Protocol.V3,
+        Protocol.MIXED,
+      ])
     })
 
     it('returns a different set of requested protocols', () => {
-      expect(
-        QuoteHandler.protocolsFromRequest(ChainId.MAINNET, ['v3', 'mixed'], undefined)
-      ).toEqual([Protocol.V3, Protocol.MIXED])
+      expect(QuoteHandler.protocolsFromRequest(ChainId.MAINNET, ['v3', 'mixed'], undefined)).toEqual([
+        Protocol.V3,
+        Protocol.MIXED,
+      ])
     })
 
     it('works with other chains', () => {
-      expect(
-        QuoteHandler.protocolsFromRequest(ChainId.BASE, ['v2', 'v3', 'mixed'], undefined)
-      ).toEqual([Protocol.V2, Protocol.V3, Protocol.MIXED])
+      expect(QuoteHandler.protocolsFromRequest(ChainId.BASE, ['v2', 'v3', 'mixed'], undefined)).toEqual([
+        Protocol.V2,
+        Protocol.V3,
+        Protocol.MIXED,
+      ])
     })
 
     it('returns undefined when a requested protocol is invalid', () => {
       expect(
-        QuoteHandler.protocolsFromRequest(
-          ChainId.BASE,
-          ['v2', 'v3', 'mixed', 'miguel'],
-          undefined
-        )
+        QuoteHandler.protocolsFromRequest(ChainId.BASE, ['v2', 'v3', 'mixed', 'miguel'], undefined)
       ).toBeUndefined()
     })
   })


### PR DESCRIPTION
- This PR aims to remove the check for mobile, version < 1.24 to exclude V2 routing
- More context can be found in this [Slack](https://uniswapteam.slack.com/archives/C02GYG8TU12/p1720726497647639) thread