### PR TITLE
seperate quicknode geth vs. reth metrics via different provider naming

### DIFF
--- a/lib/handlers/evm/provider/ProviderName.ts
+++ b/lib/handlers/evm/provider/ProviderName.ts
@@ -1,6 +1,8 @@
 export enum ProviderName {
   INFURA = 'INFURA',
   QUIKNODE = 'QUIKNODE', // quicknode doesn't have letter c in the RPC endpoint
+  QUIKNODE_GETH = 'QUIKNODE_GETH',
+  QUIKNODE_RETH = 'QUIKNODE_RETH',
   FORNO = 'FORNO',
   ALCHEMY = 'ALCHEMY',
   NIRVANA = 'NIRVANA',
@@ -10,7 +12,17 @@ export enum ProviderName {
 export function deriveProviderName(url: string): ProviderName {
   for (const name in ProviderName) {
     if (url.toUpperCase().includes(name)) {
-      return ProviderName[name as keyof typeof ProviderName]
+      if (url.toUpperCase().includes(ProviderName.QUIKNODE)) {
+        if (url.toLowerCase().includes('solitary')) {
+          return ProviderName.QUIKNODE_GETH
+        } else if (url.toLowerCase().includes('ancient')) {
+          return ProviderName.QUIKNODE_RETH
+        } else {
+          return ProviderName.QUIKNODE
+        }
+      } else {
+        return ProviderName[name as keyof typeof ProviderName]
+      }
     }
   }
 


### PR DESCRIPTION
We want to differentiate the latency metrics between quicknode geth vs reth. We do so by differentiating the provider name, based on part of the url, which is a substring of the domain name:

![Screenshot 2024-07-15 at 8.03.13 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/5b88cd52-a7ad-43e3-96da-fde2abb2aaa0.png)

