### PR TITLE
fix: partially exclude fot from fee

### DIFF
--- a/lib/graphql/graphql-queries.ts
+++ b/lib/graphql/graphql-queries.ts
@@ -11,6 +11,9 @@ query Token($chain: Chain!, $address: String!) {
             feeData {
                 buyFeeBps
                 sellFeeBps
+                feeTakenOnTransfer
+                externalTransferFailed
+                sellReverted
             }
         }
     }

--- a/lib/graphql/graphql-queries.ts
+++ b/lib/graphql/graphql-queries.ts
@@ -32,6 +32,9 @@ query Tokens($contracts: [ContractInput!]!) {
           feeData {
               buyFeeBps
               sellFeeBps
+              feeTakenOnTransfer
+              externalTransferFailed
+              sellReverted
           }
       }
     }

--- a/lib/graphql/graphql-schemas.ts
+++ b/lib/graphql/graphql-schemas.ts
@@ -21,5 +21,8 @@ export interface TokenInfo {
   feeData?: {
     buyFeeBps?: string
     sellFeeBps?: string
+    feeTakenOnTransfer?: boolean
+    externalTransferFailed?: boolean
+    sellReverted?: boolean
   }
 }

--- a/lib/graphql/graphql-token-fee-fetcher.ts
+++ b/lib/graphql/graphql-token-fee-fetcher.ts
@@ -49,9 +49,21 @@ export class GraphQLTokenFeeFetcher implements ITokenFeeFetcher {
             const feeTakenOnTransfer = token.feeData.feeTakenOnTransfer
             const externalTransferFailed = token.feeData.externalTransferFailed
             const sellReverted = token.feeData.sellReverted
-            tokenFeeMap[token.address] = { buyFeeBps, sellFeeBps, feeTakenOnTransfer, externalTransferFailed, sellReverted }
+            tokenFeeMap[token.address] = {
+              buyFeeBps,
+              sellFeeBps,
+              feeTakenOnTransfer,
+              externalTransferFailed,
+              sellReverted,
+            }
           } else {
-            tokenFeeMap[token.address] = { buyFeeBps: undefined, sellFeeBps: undefined, feeTakenOnTransfer: false, externalTransferFailed: false, sellReverted: false }
+            tokenFeeMap[token.address] = {
+              buyFeeBps: undefined,
+              sellFeeBps: undefined,
+              feeTakenOnTransfer: false,
+              externalTransferFailed: false,
+              sellReverted: false,
+            }
           }
         })
         metric.putMetric('GraphQLTokenFeeFetcherFetchFeesSuccess', 1, MetricLoggerUnit.Count)

--- a/lib/graphql/graphql-token-fee-fetcher.ts
+++ b/lib/graphql/graphql-token-fee-fetcher.ts
@@ -46,9 +46,12 @@ export class GraphQLTokenFeeFetcher implements ITokenFeeFetcher {
           if (token.feeData?.buyFeeBps || token.feeData?.sellFeeBps) {
             const buyFeeBps = token.feeData.buyFeeBps ? BigNumber.from(token.feeData.buyFeeBps) : undefined
             const sellFeeBps = token.feeData.sellFeeBps ? BigNumber.from(token.feeData.sellFeeBps) : undefined
-            tokenFeeMap[token.address] = { buyFeeBps, sellFeeBps }
+            const feeTakenOnTransfer = token.feeData.feeTakenOnTransfer
+            const externalTransferFailed = token.feeData.externalTransferFailed
+            const sellReverted = token.feeData.sellReverted
+            tokenFeeMap[token.address] = { buyFeeBps, sellFeeBps, feeTakenOnTransfer, externalTransferFailed, sellReverted }
           } else {
-            tokenFeeMap[token.address] = { buyFeeBps: undefined, sellFeeBps: undefined }
+            tokenFeeMap[token.address] = { buyFeeBps: undefined, sellFeeBps: undefined, feeTakenOnTransfer: false, externalTransferFailed: false, sellReverted: false }
           }
         })
         metric.putMetric('GraphQLTokenFeeFetcherFetchFeesSuccess', 1, MetricLoggerUnit.Count)

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.9.2",
         "@uniswap/sdk-core": "^5.3.0",
-        "@uniswap/smart-order-router": "3.36.2",
+        "@uniswap/smart-order-router": "3.37.0",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^2.2.0",
         "@uniswap/v2-sdk": "^4.3.2",
@@ -4748,9 +4748,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.36.2",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.36.2.tgz",
-      "integrity": "sha512-IJG36HLyI5h2vHKmIFxsMIHh4vS3TmgBF07xzM3uaWHzKN6yEUJqD5B/7x2WmC6C/t84o7NkyR6Rgr1tP5m6FA==",
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.37.0.tgz",
+      "integrity": "sha512-yxS21l4UqX5B1fM2y3pEsw8HxYQVJzPdRsplriLiwrqnyt21CsX0VdkxTHKVF8HeOa1/XFMao9DgCzmcM0soxw==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -28385,9 +28385,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.36.2",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.36.2.tgz",
-      "integrity": "sha512-IJG36HLyI5h2vHKmIFxsMIHh4vS3TmgBF07xzM3uaWHzKN6yEUJqD5B/7x2WmC6C/t84o7NkyR6Rgr1tP5m6FA==",
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.37.0.tgz",
+      "integrity": "sha512-yxS21l4UqX5B1fM2y3pEsw8HxYQVJzPdRsplriLiwrqnyt21CsX0VdkxTHKVF8HeOa1/XFMao9DgCzmcM0soxw==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@uniswap/router-sdk": "^1.9.2",
     "@uniswap/sdk-core": "^5.3.0",
     "@types/semver": "^7.5.8",
-    "@uniswap/smart-order-router": "3.36.2",
+    "@uniswap/smart-order-router": "3.37.0",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^2.2.0",
     "@uniswap/v2-sdk": "^4.3.2",

--- a/test/mocha/e2e/quote.test.ts
+++ b/test/mocha/e2e/quote.test.ts
@@ -1194,7 +1194,7 @@ describe('quote', function () {
                   expect(quoteWithFlagOn).not.to.be.undefined
 
                   // in case of FOT token that should not take a portion/fee, we assert that all portion fields are undefined
-                  if (tokenOut?.equals(DFNDR)) {
+                  if (!tokenOut?.equals(WETH9[ChainId.MAINNET])) {
                     expect(quoteWithFlagOn!.data.portionAmount).to.be.undefined
                     expect(quoteWithFlagOn!.data.portionBips).to.be.undefined
                     expect(quoteWithFlagOn!.data.portionRecipient).to.be.undefined

--- a/test/mocha/e2e/quote.test.ts
+++ b/test/mocha/e2e/quote.test.ts
@@ -1176,7 +1176,7 @@ describe('quote', function () {
                         // if fee-on-transfer flag is not enabled, most likely the simulation will fail due to quote not subtracting the tax
                         simulateFromAddress: enableFeeOnTransferFeeFetching ? simulateFromAddress : undefined,
                         portionBips: FLAT_PORTION.bips,
-                        portionRecipient: FLAT_PORTION.recipient
+                        portionRecipient: FLAT_PORTION.recipient,
                       }
 
                       const queryParams = qs.stringify(quoteReq)

--- a/test/mocha/e2e/quote.test.ts
+++ b/test/mocha/e2e/quote.test.ts
@@ -1192,6 +1192,18 @@ describe('quote', function () {
 
                   const quoteWithFlagOn = responses.find((r) => r.enableFeeOnTransferFeeFetching === true)
                   expect(quoteWithFlagOn).not.to.be.undefined
+
+                  // in case of FOT token that should not take a portion/fee, we assert that all portion fields are undefined
+                  if (tokenOut?.equals(DFNDR)) {
+                    expect(quoteWithFlagOn!.data.portionAmount).to.be.undefined
+                    expect(quoteWithFlagOn!.data.portionBips).to.be.undefined
+                    expect(quoteWithFlagOn!.data.portionRecipient).to.be.undefined
+                  } else {
+                    expect(quoteWithFlagOn!.data.portionAmount).to.be.not.undefined
+                    expect(quoteWithFlagOn!.data.portionBips).to.be.not.undefined
+                    expect(quoteWithFlagOn!.data.portionRecipient).to.be.not.undefined
+                  }
+
                   responses
                     .filter((r) => r.enableFeeOnTransferFeeFetching !== true)
                     .forEach((r) => {
@@ -1214,13 +1226,6 @@ describe('quote', function () {
                           expect(percentDiff.toFixed(3, undefined, Rounding.ROUND_HALF_UP)).equal(
                             new Fraction(BigNumber.from(BULLET_WHT_TAX.buyFeeBps ?? 0).toString(), 10_000).toFixed(3)
                           )
-                        }
-
-                        // in case of FOT token that should not take a portion/fee, we assert that all portion fields are undefined
-                        if (tokenOut?.equals(DFNDR)) {
-                          expect(r.data.portionAmount).to.be.undefined
-                          expect(r.data.portionBips).to.be.undefined
-                          expect(r.data.portionRecipient).to.be.undefined
                         }
                       }
                     })

--- a/test/mocha/integ/graphql/graphql-token-fee-fetcher.test.ts
+++ b/test/mocha/integ/graphql/graphql-token-fee-fetcher.test.ts
@@ -64,9 +64,15 @@ describe('integration test for GraphQLTokenFeeFetcher', () => {
     expect(tokenFeeMap[WETH9[ChainId.MAINNET]!.address]).to.not.be.undefined
     expect(tokenFeeMap[WETH9[ChainId.MAINNET]!.address]?.buyFeeBps).to.be.undefined
     expect(tokenFeeMap[WETH9[ChainId.MAINNET]!.address]?.sellFeeBps).to.be.undefined
+    expect(tokenFeeMap[WETH9[ChainId.MAINNET]!.address]?.feeTakenOnTransfer).to.not.be.undefined
+    expect(tokenFeeMap[WETH9[ChainId.MAINNET]!.address]?.externalTransferFailed).to.not.be.undefined
+    expect(tokenFeeMap[WETH9[ChainId.MAINNET]!.address]?.sellReverted).to.not.be.undefined
     expect(tokenFeeMap[BITBOY.address]).to.not.be.undefined
     expect(tokenFeeMap[BITBOY.address]?.buyFeeBps?._hex).equals(BITBOY.buyFeeBps?._hex)
     expect(tokenFeeMap[BITBOY.address]?.sellFeeBps?._hex).equals(BITBOY.sellFeeBps?._hex)
+    expect(tokenFeeMap[BITBOY.address]?.feeTakenOnTransfer).equals(false)
+    expect(tokenFeeMap[BITBOY.address]?.externalTransferFailed).equals(true)
+    expect(tokenFeeMap[BITBOY.address]?.sellReverted).equals(false)
   })
 
   it('Fetch BULLET and BITBOY, should return BOTH', async () => {
@@ -77,9 +83,16 @@ describe('integration test for GraphQLTokenFeeFetcher', () => {
     expect(tokenFeeMap[BULLET.address]).to.not.be.undefined
     expect(tokenFeeMap[BULLET.address]?.buyFeeBps?._hex).equals(BULLET.buyFeeBps?._hex)
     expect(tokenFeeMap[BULLET.address]?.sellFeeBps?._hex).equals(BULLET.sellFeeBps?._hex)
+    expect(tokenFeeMap[BULLET.address]?.feeTakenOnTransfer).equals(false)
+    expect(tokenFeeMap[BULLET.address]?.externalTransferFailed).equals(false)
+    expect(tokenFeeMap[BULLET.address]?.sellReverted).equals(false)
+
     expect(tokenFeeMap[BITBOY.address]).to.not.be.undefined
     expect(tokenFeeMap[BITBOY.address]?.buyFeeBps?._hex).equals(BITBOY.buyFeeBps?._hex)
     expect(tokenFeeMap[BITBOY.address]?.sellFeeBps?._hex).equals(BITBOY.sellFeeBps?._hex)
+    expect(tokenFeeMap[BITBOY.address]?.feeTakenOnTransfer).equals(false)
+    expect(tokenFeeMap[BITBOY.address]?.externalTransferFailed).equals(true)
+    expect(tokenFeeMap[BITBOY.address]?.sellReverted).equals(false)
 
     expect(spyGraphQLFetcher.calledOnce).to.be.true
     expect(spyOnChainFetcher.calledOnce).to.be.false
@@ -97,6 +110,9 @@ describe('integration test for GraphQLTokenFeeFetcher', () => {
     expect(tokenFeeMap[BITBOY.address]).to.not.be.undefined
     expect(tokenFeeMap[BITBOY.address]?.buyFeeBps?._hex).equals(BITBOY.buyFeeBps?._hex)
     expect(tokenFeeMap[BITBOY.address]?.sellFeeBps?._hex).equals(BITBOY.sellFeeBps?._hex)
+    expect(tokenFeeMap[BITBOY.address]?.feeTakenOnTransfer).equals(false)
+    expect(tokenFeeMap[BITBOY.address]?.externalTransferFailed).equals(true)
+    expect(tokenFeeMap[BITBOY.address]?.sellReverted).equals(false)
 
     expect(spyGraphQLFetcher.calledOnce).to.be.true
     expect(spyOnChainFetcher.calledOnce).to.be.true

--- a/test/mocha/integ/graphql/graphql-token-fee-fetcher.test.ts
+++ b/test/mocha/integ/graphql/graphql-token-fee-fetcher.test.ts
@@ -84,8 +84,8 @@ describe('integration test for GraphQLTokenFeeFetcher', () => {
     expect(tokenFeeMap[BULLET.address]?.buyFeeBps?._hex).equals(BULLET.buyFeeBps?._hex)
     expect(tokenFeeMap[BULLET.address]?.sellFeeBps?._hex).equals(BULLET.sellFeeBps?._hex)
     expect(tokenFeeMap[BULLET.address]?.feeTakenOnTransfer).equals(false)
-    expect(tokenFeeMap[BULLET.address]?.externalTransferFailed).equals(false)
-    expect(tokenFeeMap[BULLET.address]?.sellReverted).equals(false)
+    expect(tokenFeeMap[BULLET.address]?.externalTransferFailed).equals(true)
+    expect(tokenFeeMap[BULLET.address]?.sellReverted).equals(true)
 
     expect(tokenFeeMap[BITBOY.address]).to.not.be.undefined
     expect(tokenFeeMap[BITBOY.address]?.buyFeeBps?._hex).equals(BITBOY.buyFeeBps?._hex)


### PR DESCRIPTION
In routing-api, we primarily get FOT fee from graphql now. We need to update the graphql schema to include those new boolean flags.

I tested with [DFNDR](https://etherscan.io/address/0x3f57c35633cb29834bb7577ba8052eab90f52a02#code#L331), which has transfer delay. For this token, we make sure the portion related fields are not returned:
- without simulation - https://app.warp.dev/block/hIpmVZNmkfCXYOvCbmTTFZ
- with simulation - https://app.warp.dev/block/a2bpiaw4cPHfnzglscwGIU