### PR TITLE
chore: add RPC requests logging for RETH calls slower than GETH

### DIFF
--- a/lib/rpc/SingleJsonRpcProvider.ts
+++ b/lib/rpc/SingleJsonRpcProvider.ts
@@ -183,18 +183,19 @@ export class SingleJsonRpcProvider extends StaticJsonRpcProvider {
     this.logEvaluateLatency()
     this.evaluatingLatency = true
     try {
-      if (methodName === 'call') {
-        const transaction: Deferrable<TransactionRequest> = args[0]
-        const blockTag: BlockTag | Promise<BlockTag> = args[1]
+      switch (methodName) {
+        case CALL_METHOD_NAME:
+          const transaction: Deferrable<TransactionRequest> = args[0]
+          const blockTag: BlockTag | Promise<BlockTag> = args[1]
 
-        return await this.call_EvaluateLatency(transaction, blockTag, latency)
-      } else if (methodName === 'send') {
-        const underlyingMethodName = args[0]
-        const params: Array<any> = args.splice(1)
+          return await this.call_EvaluateLatency(transaction, blockTag, latency)
+        case SEND_METHOD_NAME:
+          const underlyingMethodName = args[0]
+          const params: Array<any> = args.splice(1)
 
-        return await this.send_EvaluateLatency(underlyingMethodName, params, latency)
-      } else {
-        return await (this as any)[`${methodName}_EvaluateLatency`](...args)
+          return await this.send_EvaluateLatency(underlyingMethodName, params, latency)
+        default:
+          return await (this as any)[`${methodName}_EvaluateLatency`](...args)
       }
     } catch (error: any) {
       this.log.error({ error }, `Encounter error for shadow evaluate latency call: ${JSON.stringify(error)}`)
@@ -303,7 +304,9 @@ export class SingleJsonRpcProvider extends StaticJsonRpcProvider {
         const evaluatedLatency = perf.latencyInMs
         this.log.error(
           { latency, evaluatedLatency },
-          `Slower evaluated latency for provider ${this.providerName}. SingleJsonRpcProvider: wrappedFunctionCall: callType: ${callType}, provider: ${
+          `Slower evaluated latency for provider ${
+            this.providerName
+          }. SingleJsonRpcProvider: wrappedFunctionCall: callType: ${callType}, provider: ${
             this.url
           }, fnName: ${fnName}, fn: ${fn}, args: ${JSON.stringify([...args])}`
         )
@@ -371,7 +374,7 @@ export class SingleJsonRpcProvider extends StaticJsonRpcProvider {
   ///////////////////// Begin of override functions /////////////////////
 
   override getBlockNumber(): Promise<number> {
-    return this.wrappedFunctionCall(CallType.NORMAL, 'getBlockNumber', this._getBlockNumber.bind(this))
+    return this.wrappedFunctionCall(CallType.NORMAL, 'getBlockNumber', this._getBlockNumber.bind(this), undefined)
   }
 
   override getBlockWithTransactions(
@@ -387,11 +390,18 @@ export class SingleJsonRpcProvider extends StaticJsonRpcProvider {
   }
 
   override getCode(addressOrName: string | Promise<string>, blockTag?: BlockTag | Promise<BlockTag>): Promise<string> {
-    return this.wrappedFunctionCall(CallType.NORMAL, 'getCode', super.getCode.bind(this), undefined, addressOrName, blockTag)
+    return this.wrappedFunctionCall(
+      CallType.NORMAL,
+      'getCode',
+      super.getCode.bind(this),
+      undefined,
+      addressOrName,
+      blockTag
+    )
   }
 
   override getGasPrice(): Promise<BigNumber> {
-    return this.wrappedFunctionCall(CallType.NORMAL, 'getGasPrice', super.getGasPrice.bind(this))
+    return this.wrappedFunctionCall(CallType.NORMAL, 'getGasPrice', super.getGasPrice.bind(this), undefined)
   }
 
   override getLogs(filter: Filter): Promise<Array<Log>> {
@@ -415,7 +425,13 @@ export class SingleJsonRpcProvider extends StaticJsonRpcProvider {
   }
 
   override getTransaction(transactionHash: string | Promise<string>): Promise<TransactionResponse> {
-    return this.wrappedFunctionCall(CallType.NORMAL, 'getTransaction', super.getTransaction.bind(this), undefined, transactionHash)
+    return this.wrappedFunctionCall(
+      CallType.NORMAL,
+      'getTransaction',
+      super.getTransaction.bind(this),
+      undefined,
+      transactionHash
+    )
   }
 
   override getTransactionCount(
@@ -443,7 +459,13 @@ export class SingleJsonRpcProvider extends StaticJsonRpcProvider {
   }
 
   override lookupAddress(address: string | Promise<string>): Promise<string | null> {
-    return this.wrappedFunctionCall(CallType.NORMAL, 'lookupAddress', super.lookupAddress.bind(this), undefined, address)
+    return this.wrappedFunctionCall(
+      CallType.NORMAL,
+      'lookupAddress',
+      super.lookupAddress.bind(this),
+      undefined,
+      address
+    )
   }
 
   override resolveName(name: string | Promise<string>): Promise<string | null> {
@@ -494,12 +516,17 @@ export class SingleJsonRpcProvider extends StaticJsonRpcProvider {
   }
 
   private getBlockNumber_EvaluateHealthiness(): Promise<number> {
-    return this.wrappedFunctionCall(CallType.HEALTH_CHECK, 'getBlockNumber', this._getBlockNumber.bind(this))
+    return this.wrappedFunctionCall(CallType.HEALTH_CHECK, 'getBlockNumber', this._getBlockNumber.bind(this), undefined)
   }
 
   // @ts-ignore
   private getBlockNumber_EvaluateLatency(): Promise<number> {
-    return this.wrappedFunctionCall(CallType.LATENCY_EVALUATION, 'getBlockNumber', this._getBlockNumber.bind(this), undefined)
+    return this.wrappedFunctionCall(
+      CallType.LATENCY_EVALUATION,
+      'getBlockNumber',
+      this._getBlockNumber.bind(this),
+      undefined
+    )
   }
 
   // @ts-ignore
@@ -508,7 +535,14 @@ export class SingleJsonRpcProvider extends StaticJsonRpcProvider {
     blockTag?: BlockTag | Promise<BlockTag>,
     latency?: number
   ): Promise<string> {
-    return this.wrappedFunctionCall(CallType.LATENCY_EVALUATION, 'call', super.call.bind(this), latency, transaction, blockTag)
+    return this.wrappedFunctionCall(
+      CallType.LATENCY_EVALUATION,
+      'call',
+      super.call.bind(this),
+      latency,
+      transaction,
+      blockTag
+    )
   }
 
   // @ts-ignore

--- a/lib/rpc/SingleJsonRpcProvider.ts
+++ b/lib/rpc/SingleJsonRpcProvider.ts
@@ -178,12 +178,24 @@ export class SingleJsonRpcProvider extends StaticJsonRpcProvider {
     }
   }
 
-  async evaluateLatency(methodName: string, ...args: any[]) {
+  async evaluateLatency(latency: number, methodName: string, ...args: any[]) {
     this.log.debug(`${this.url}: Evaluate for latency... methodName: ${methodName}`)
     this.logEvaluateLatency()
     this.evaluatingLatency = true
     try {
-      return await (this as any)[`${methodName}_EvaluateLatency`](...args)
+      if (methodName === 'call') {
+        const transaction: Deferrable<TransactionRequest> = args[0]
+        const blockTag: BlockTag | Promise<BlockTag> = args[1]
+
+        return await this.call_EvaluateLatency(transaction, blockTag, latency)
+      } else if (methodName === 'send') {
+        const underlyingMethodName = args[0]
+        const params: Array<any> = args.splice(1)
+
+        return await this.send_EvaluateLatency(underlyingMethodName, params, latency)
+      } else {
+        return await (this as any)[`${methodName}_EvaluateLatency`](...args)
+      }
     } catch (error: any) {
       this.log.error({ error }, `Encounter error for shadow evaluate latency call: ${JSON.stringify(error)}`)
       // Swallow the error.
@@ -264,6 +276,7 @@ export class SingleJsonRpcProvider extends StaticJsonRpcProvider {
     callType: CallType,
     fnName: string,
     fn: (...args: any[]) => Promise<any>,
+    latency?: number,
     ...args: any[]
   ): Promise<any> {
     this.log.debug(
@@ -283,6 +296,18 @@ export class SingleJsonRpcProvider extends StaticJsonRpcProvider {
       perf.startTimestampInMs = Date.now()
       const result = await fn(...args)
       perf.latencyInMs = Date.now() - perf.startTimestampInMs
+
+      // The provider latency we evaluate against should always be faster than the provider we are using in prod currently.
+      // If that's not the case, we need to log the RPC request payload to help debugging.
+      if (latency && perf.latencyInMs > latency) {
+        const evaluatedLatency = perf.latencyInMs
+        this.log.error(
+          { latency, evaluatedLatency },
+          `Slower evaluated latency for provider ${this.providerName}. SingleJsonRpcProvider: wrappedFunctionCall: callType: ${callType}, provider: ${
+            this.url
+          }, fnName: ${fnName}, fn: ${fn}, args: ${JSON.stringify([...args])}`
+        )
+      }
 
       return result
     } catch (error: any) {
@@ -356,12 +381,13 @@ export class SingleJsonRpcProvider extends StaticJsonRpcProvider {
       CallType.NORMAL,
       'getBlockWithTransactions',
       super.getBlockWithTransactions.bind(this),
+      undefined,
       blockHashOrBlockTag
     )
   }
 
   override getCode(addressOrName: string | Promise<string>, blockTag?: BlockTag | Promise<BlockTag>): Promise<string> {
-    return this.wrappedFunctionCall(CallType.NORMAL, 'getCode', super.getCode.bind(this), addressOrName, blockTag)
+    return this.wrappedFunctionCall(CallType.NORMAL, 'getCode', super.getCode.bind(this), undefined, addressOrName, blockTag)
   }
 
   override getGasPrice(): Promise<BigNumber> {
@@ -369,7 +395,7 @@ export class SingleJsonRpcProvider extends StaticJsonRpcProvider {
   }
 
   override getLogs(filter: Filter): Promise<Array<Log>> {
-    return this.wrappedFunctionCall(CallType.NORMAL, 'getLogs', super.getLogs.bind(this), filter)
+    return this.wrappedFunctionCall(CallType.NORMAL, 'getLogs', super.getLogs.bind(this), undefined, filter)
   }
 
   override getStorageAt(
@@ -381,6 +407,7 @@ export class SingleJsonRpcProvider extends StaticJsonRpcProvider {
       CallType.NORMAL,
       'getStorageAt',
       super.getStorageAt.bind(this),
+      undefined,
       addressOrName,
       position,
       blockTag
@@ -388,7 +415,7 @@ export class SingleJsonRpcProvider extends StaticJsonRpcProvider {
   }
 
   override getTransaction(transactionHash: string | Promise<string>): Promise<TransactionResponse> {
-    return this.wrappedFunctionCall(CallType.NORMAL, 'getTransaction', super.getTransaction.bind(this), transactionHash)
+    return this.wrappedFunctionCall(CallType.NORMAL, 'getTransaction', super.getTransaction.bind(this), undefined, transactionHash)
   }
 
   override getTransactionCount(
@@ -399,6 +426,7 @@ export class SingleJsonRpcProvider extends StaticJsonRpcProvider {
       CallType.NORMAL,
       'getTransactionCount',
       super.getTransactionCount.bind(this),
+      undefined,
       addressOrName,
       blockTag
     )
@@ -409,16 +437,17 @@ export class SingleJsonRpcProvider extends StaticJsonRpcProvider {
       CallType.NORMAL,
       'getTransactionReceipt',
       super.getTransactionReceipt.bind(this),
+      undefined,
       transactionHash
     )
   }
 
   override lookupAddress(address: string | Promise<string>): Promise<string | null> {
-    return this.wrappedFunctionCall(CallType.NORMAL, 'lookupAddress', super.lookupAddress.bind(this), address)
+    return this.wrappedFunctionCall(CallType.NORMAL, 'lookupAddress', super.lookupAddress.bind(this), undefined, address)
   }
 
   override resolveName(name: string | Promise<string>): Promise<string | null> {
-    return this.wrappedFunctionCall(CallType.NORMAL, 'resolveName', super.resolveName.bind(this), name)
+    return this.wrappedFunctionCall(CallType.NORMAL, 'resolveName', super.resolveName.bind(this), undefined, name)
   }
 
   override sendTransaction(signedTransaction: string | Promise<string>): Promise<TransactionResponse> {
@@ -426,6 +455,7 @@ export class SingleJsonRpcProvider extends StaticJsonRpcProvider {
       CallType.NORMAL,
       'sendTransaction',
       super.sendTransaction.bind(this),
+      undefined,
       signedTransaction
     )
   }
@@ -439,6 +469,7 @@ export class SingleJsonRpcProvider extends StaticJsonRpcProvider {
       CallType.NORMAL,
       'waitForTransaction',
       super.waitForTransaction.bind(this),
+      undefined,
       transactionHash,
       confirmations,
       timeout
@@ -446,12 +477,12 @@ export class SingleJsonRpcProvider extends StaticJsonRpcProvider {
   }
 
   override call(transaction: Deferrable<TransactionRequest>, blockTag?: BlockTag | Promise<BlockTag>): Promise<string> {
-    return this.wrappedFunctionCall(CallType.NORMAL, 'call', super.call.bind(this), transaction, blockTag)
+    return this.wrappedFunctionCall(CallType.NORMAL, 'call', super.call.bind(this), undefined, transaction, blockTag)
   }
 
   override send(method: string, params: Array<any>): Promise<any> {
     this.logSendMetrod(method)
-    return this.wrappedFunctionCall(CallType.NORMAL, 'send', super.send.bind(this), method, params)
+    return this.wrappedFunctionCall(CallType.NORMAL, 'send', super.send.bind(this), undefined, method, params)
   }
 
   ///////////////////// Begin of special functions /////////////////////
@@ -468,19 +499,20 @@ export class SingleJsonRpcProvider extends StaticJsonRpcProvider {
 
   // @ts-ignore
   private getBlockNumber_EvaluateLatency(): Promise<number> {
-    return this.wrappedFunctionCall(CallType.LATENCY_EVALUATION, 'getBlockNumber', this._getBlockNumber.bind(this))
+    return this.wrappedFunctionCall(CallType.LATENCY_EVALUATION, 'getBlockNumber', this._getBlockNumber.bind(this), undefined)
   }
 
   // @ts-ignore
   private call_EvaluateLatency(
     transaction: Deferrable<TransactionRequest>,
-    blockTag?: BlockTag | Promise<BlockTag>
+    blockTag?: BlockTag | Promise<BlockTag>,
+    latency?: number
   ): Promise<string> {
-    return this.wrappedFunctionCall(CallType.LATENCY_EVALUATION, 'call', super.call.bind(this), transaction, blockTag)
+    return this.wrappedFunctionCall(CallType.LATENCY_EVALUATION, 'call', super.call.bind(this), latency, transaction, blockTag)
   }
 
   // @ts-ignore
-  private send_EvaluateLatency(method: string, params: Array<any>): Promise<any> {
-    return this.wrappedFunctionCall(CallType.LATENCY_EVALUATION, 'send', super.send.bind(this), method, params)
+  private send_EvaluateLatency(method: string, params: Array<any>, latency?: number): Promise<any> {
+    return this.wrappedFunctionCall(CallType.LATENCY_EVALUATION, 'send', super.send.bind(this), latency, method, params)
   }
 }

--- a/lib/rpc/UniJsonRpcProvider.ts
+++ b/lib/rpc/UniJsonRpcProvider.ts
@@ -239,7 +239,7 @@ export class UniJsonRpcProvider extends StaticJsonRpcProvider {
         // Within each provider latency shadow evaluation, we should do block I/O,
         // because NodeJS runs in single thread, so it's important to make sure
         // we benchmark the latencies correctly based on the single-threaded sequential evaluation.
-        const evaluatedProviderResponse = await provider[`evaluateLatency`](methodName, ...args)
+        const evaluatedProviderResponse = await provider[`evaluateLatency`](latency, methodName, ...args)
         // below invocation does not make the call/send RPC return the correct data
         // both call and send will return "0x" for some reason
         // I have to change to above invocation to make call/send return geniun RPC response

--- a/test/mocha/unit/rpc/UniJsonRpcProvider.test.ts
+++ b/test/mocha/unit/rpc/UniJsonRpcProvider.test.ts
@@ -704,9 +704,9 @@ describe('UniJsonRpcProvider', () => {
     // Shadow evaluate call should be made
     expect(spy0.callCount).to.equal(0)
     expect(spy1.callCount).to.equal(1)
-    expect(spy1.getCalls()[0].firstArg).to.equal('getBlockNumber')
+    expect(spy1.getCalls()[0].lastArg).to.equal('getBlockNumber')
     expect(spy2.callCount).to.equal(1)
-    expect(spy2.getCalls()[0].firstArg).to.equal('getBlockNumber')
+    expect(spy2.getCalls()[0].lastArg).to.equal('getBlockNumber')
 
     expect(uniProvider['providers'][1]['lastLatencyEvaluationTimestampInMs']).equals(timestamp)
     expect(uniProvider['providers'][2]['lastLatencyEvaluationTimestampInMs']).equals(timestamp)
@@ -746,9 +746,9 @@ describe('UniJsonRpcProvider', () => {
     // Shadow evaluate call should be made
     expect(spy0.callCount).to.equal(0)
     expect(spy1.callCount).to.equal(1)
-    expect(spy1.getCalls()[0].firstArg).to.equal('getBlockNumber')
+    expect(spy1.getCalls()[0].lastArg).to.equal('getBlockNumber')
     expect(spy2.callCount).to.equal(1)
-    expect(spy2.getCalls()[0].firstArg).to.equal('getBlockNumber')
+    expect(spy2.getCalls()[0].lastArg).to.equal('getBlockNumber')
 
     expect(uniProvider['providers'][1]['lastLatencyEvaluationTimestampInMs']).equals(timestamp)
     expect(uniProvider['providers'][2]['lastLatencyEvaluationTimestampInMs']).equals(timestamp)
@@ -774,10 +774,10 @@ describe('UniJsonRpcProvider', () => {
     await uniProvider.getBlockNumber('sessionId')
 
     expect(spy1.callCount).to.equal(1)
-    expect(spy1.getCalls()[0].firstArg).to.equal('getBlockNumber')
+    expect(spy1.getCalls()[0].lastArg).to.equal('getBlockNumber')
     expect(uniProvider['providers'][1]['lastLatencyEvaluationTimestampInMs']).equals(timestamp + 16000)
     expect(spy2.callCount).to.equal(1)
-    expect(spy2.getCalls()[0].firstArg).to.equal('getBlockNumber')
+    expect(spy2.getCalls()[0].lastArg).to.equal('getBlockNumber')
     expect(uniProvider['providers'][2]['lastLatencyEvaluationTimestampInMs']).equals(timestamp + 16000)
   })
 
@@ -822,9 +822,9 @@ describe('UniJsonRpcProvider', () => {
 
     expect(spy0.callCount).to.equal(0)
     expect(spy1.callCount).to.equal(5)
-    expect(spy1.getCalls()[0].firstArg).to.equal('getBlockNumber')
+    expect(spy1.getCalls()[0].lastArg).to.equal('getBlockNumber')
     expect(spy2.callCount).to.equal(5)
-    expect(spy2.getCalls()[0].firstArg).to.equal('getBlockNumber')
+    expect(spy2.getCalls()[0].lastArg).to.equal('getBlockNumber')
 
     expect(uniProvider['providers'][1]['lastLatencyEvaluationTimestampInMs']).equals(timestamp)
     expect(uniProvider['providers'][2]['lastLatencyEvaluationTimestampInMs']).equals(timestamp)
@@ -946,9 +946,9 @@ describe('UniJsonRpcProvider', () => {
     // 0.4 < 0.5, Shadow evaluate call should be made
     expect(spy0.callCount).to.equal(0)
     expect(spy1.callCount).to.equal(1)
-    expect(spy1.getCalls()[0].firstArg).to.equal('getBlockNumber')
+    expect(spy1.getCalls()[0].lastArg).to.equal('getBlockNumber')
     expect(spy2.callCount).to.equal(1)
-    expect(spy2.getCalls()[0].firstArg).to.equal('getBlockNumber')
+    expect(spy2.getCalls()[0].lastArg).to.equal('getBlockNumber')
   })
 
   it('Test use of healthCheckSampleProb', async () => {


### PR DESCRIPTION
I observe that RETH RPC calls are slower than GETH calls in Uniswap routing backend. My observation is based on two different time periods:

1. Between may 20th and may 21th, I had a [PR](https://github.com/Uniswap/routing-api/pull/701/files) that only samples quicknode reth and another [PR](https://github.com/Uniswap/routing-api/pull/704) that fail over from infura to quicknode geth. This means, before May 20th, I had the shadow sampling of mix of geth and reth, meanwhile between may 20th and may 21th, I had the shadow sampling of only reth.

request volume dropped in half on may 20th, because I changed from shadow sampling both quicknode geth and reth to shadow sampling only quicknode reth:

![Screenshot 2024-07-18 at 8.00.52 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/5bbc8317-0b8f-4fdc-a271-fe6a0a44229a.png)

If reth were to run faster than geth, then I expect P50 latency to go down, but instead it went up:

![Screenshot 2024-07-18 at 8.01.09 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/f4e2093d-58b4-4659-a421-1e19fed40f66.png)

2. Recently I created a [PR](https://github.com/Uniswap/routing-api/pull/781) to split geth vs reth latency metrics.

Sampling traffic volume are comparable between geth and reth, just to make sure the benchmarking is on the same traffic scale:

![Screenshot 2024-07-18 at 8.04.21 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/511d50e8-8900-4bbf-a16e-56a1dc8fa9e3.png)

I can see that P50 is also higher on reth than geth:

![Screenshot 2024-07-18 at 8.05.36 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/e7234138-271f-4504-b1fe-0de4578cdd01.png)

I do believe this is due to Uniswap specific RPC call pattern, since we make heavy multicall for quoting. e.g. this tenderly [simulation](https://www.tdly.co/shared/simulation/f53ad31e-02fc-4dc7-977d-6f821a63d747)  captures a heavy multicall with hundreds of routes. As mentioned in https://github.com/Uniswap/routing-api/pull/775, from Paradigm flood testing, we see quicknode reth is faster than quicknode geth, so this makes me believe it's uniswap specific RPC call pattern.

I think it makes sense to log the RPC requests when we observe the evaluated latencies are slower than the current provider latencies. This can help further debug why RETH for Uniswap is slower.