### PR TITLE
chore(sor): Bump SOR version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.9.2",
         "@uniswap/sdk-core": "^5.3.0",
-        "@uniswap/smart-order-router": "3.35.12",
+        "@uniswap/smart-order-router": "3.35.13",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^2.2.0",
         "@uniswap/v2-sdk": "^4.3.2",
@@ -4748,9 +4748,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.35.12",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.35.12.tgz",
-      "integrity": "sha512-1Z4zT/uzCMHMDeP+A1CbgvkjhOHPZuw7hQ4986+/yI9rY5ioITd0MUJ2iQrdJjLVaBlpKQQSL3djttiKw8AvTg==",
+      "version": "3.35.13",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.35.13.tgz",
+      "integrity": "sha512-7TX1RpIf8477iqRQsS8DdXOjVtcxGyFhOQBoeMcmXTccVMhbOQgxXA4mGQpoGGOxEo6kcFQggp8jm4DbwPDjWQ==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -28385,9 +28385,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.35.12",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.35.12.tgz",
-      "integrity": "sha512-1Z4zT/uzCMHMDeP+A1CbgvkjhOHPZuw7hQ4986+/yI9rY5ioITd0MUJ2iQrdJjLVaBlpKQQSL3djttiKw8AvTg==",
+      "version": "3.35.13",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.35.13.tgz",
+      "integrity": "sha512-7TX1RpIf8477iqRQsS8DdXOjVtcxGyFhOQBoeMcmXTccVMhbOQgxXA4mGQpoGGOxEo6kcFQggp8jm4DbwPDjWQ==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@uniswap/router-sdk": "^1.9.2",
     "@uniswap/sdk-core": "^5.3.0",
     "@types/semver": "^7.5.8",
-    "@uniswap/smart-order-router": "3.35.12",
+    "@uniswap/smart-order-router": "3.35.13",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^2.2.0",
     "@uniswap/v2-sdk": "^4.3.2",


### PR DESCRIPTION
Updates SOR to the version that contains error logs for the subgraph class that is used in the cache cron.
