### PR TITLE
fix: manually include eth/wsteth with artificially high TVL

### DIFF
--- a/lib/cron/cache-pools.ts
+++ b/lib/cron/cache-pools.ts
@@ -207,6 +207,21 @@ const handler: ScheduledHandler = metricScope((metrics) => async (event: EventBr
       })
       filteredPools.forEach((pool) => pools.push(pool))
 
+      pools = (pools as Array<V3SubgraphPool>).filter((pool: V3SubgraphPool) => {
+        const shouldFilterOut =
+          // filter out AMPL-token pools from v3 subgraph, since they are not supported on v3
+          pool.token0.id.toLowerCase() === '0xd46ba6d942050d489dbd938a2c909a5d5039a161' ||
+          pool.token1.id.toLowerCase() === '0xd46ba6d942050d489dbd938a2c909a5d5039a161' ||
+          // also filter out WETH/wstETH pool, because later we want to re-add the pool with artificially high TVL
+          pool.id.toLowerCase() === '0x109830a1aaad605bbf02a9dfa7b0b92ec2fb7daa'
+
+        if (shouldFilterOut) {
+          log.info(`Filtering out pool ${pool.id} from ${protocol} on ${chainId}`)
+        }
+
+        return !shouldFilterOut
+      })
+
       const manuallyIncludedPools: V3SubgraphPool[] = [
         {
           id: '0x109830a1aaad605bbf02a9dfa7b0b92ec2fb7daa',

--- a/lib/cron/cache-pools.ts
+++ b/lib/cron/cache-pools.ts
@@ -207,6 +207,23 @@ const handler: ScheduledHandler = metricScope((metrics) => async (event: EventBr
       })
       filteredPools.forEach((pool) => pools.push(pool))
 
+      const manuallyIncludedPools: V3SubgraphPool[] = [
+        {
+          id: '0x109830a1aaad605bbf02a9dfa7b0b92ec2fb7daa',
+          feeTier: "100",
+          liquidity: "29225684102047357356897753",
+          token0: {
+            id: '0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0'
+          },
+          token1: {
+            id: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
+          },
+          tvlETH: 706196.651729130972764273,
+          tvlUSD: 140465485 // same as WETH/USDC 0.05%
+        } as V3SubgraphPool,
+      ]
+      manuallyIncludedPools.forEach((pool) => pools.push(pool))
+
       pools = (pools as Array<V3SubgraphPool>).filter((pool: V3SubgraphPool) => {
         const shouldFilterOut =
           // filter out AMPL-token pools from v3 subgraph, since they are not supported on v3

--- a/lib/cron/cache-pools.ts
+++ b/lib/cron/cache-pools.ts
@@ -225,16 +225,16 @@ const handler: ScheduledHandler = metricScope((metrics) => async (event: EventBr
       const manuallyIncludedPools: V3SubgraphPool[] = [
         {
           id: '0x109830a1aaad605bbf02a9dfa7b0b92ec2fb7daa',
-          feeTier: "100",
-          liquidity: "29225684102047357356897753",
+          feeTier: '100',
+          liquidity: '29225684102047357356897753',
           token0: {
-            id: '0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0'
+            id: '0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0',
           },
           token1: {
-            id: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
+            id: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
           },
           tvlETH: 706196.651729130972764273,
-          tvlUSD: 140465485 // same as WETH/USDC 0.05%
+          tvlUSD: 140465485, // same as WETH/USDC 0.05%
         } as V3SubgraphPool,
       ]
       manuallyIncludedPools.forEach((pool) => pools.push(pool))


### PR DESCRIPTION
Even though [ETH/wstETH](https://app.uniswap.org/explore/pools/ethereum/0x109830a1AAaD605BbF02a9dFA7B0B92EC2FB7dAa) is not a high TVL pool, because of both assets close pegging, their concentrated liquidity is high within the narrow price range. We don't want to aggressively modify the pools discovery heuristics in SOR (e.g. https://app.graphite.dev/github/pr/Uniswap/smart-order-router/641/feat-mixed-Add-Cross-Liquidity-Pools-to-Mixed-Candidate-Pools?utm_source=gt-slack-notif#), so the next best thing to do is to artificually inflate the [ETH/wstETH](https://app.uniswap.org/explore/pools/ethereum/0x109830a1AAaD605BbF02a9dFA7B0B92EC2FB7dAa) TVL during routing cron job.

I've tested locally, and now can see that 1 ETH -> DOG routes through wstETH: https://app.warp.dev/block/GnbbpKGa0e3jK2upANEQvm