### PR TITLE
chore: bump sor to 3.37.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.9.2",
         "@uniswap/sdk-core": "^5.3.0",
-        "@uniswap/smart-order-router": "3.37.0",
+        "@uniswap/smart-order-router": "3.37.1",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^2.2.0",
         "@uniswap/v2-sdk": "^4.3.2",
@@ -4748,9 +4748,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.37.0.tgz",
-      "integrity": "sha512-yxS21l4UqX5B1fM2y3pEsw8HxYQVJzPdRsplriLiwrqnyt21CsX0VdkxTHKVF8HeOa1/XFMao9DgCzmcM0soxw==",
+      "version": "3.37.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.37.1.tgz",
+      "integrity": "sha512-IyriGXoMp1IKil0Pb6itgK2RRKF24tv6QlXfceZfu4kntEfPVjjyHqQ8TpuYmffCVdYr4FiGtcJqdpaMrwrDwA==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -28385,9 +28385,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.37.0.tgz",
-      "integrity": "sha512-yxS21l4UqX5B1fM2y3pEsw8HxYQVJzPdRsplriLiwrqnyt21CsX0VdkxTHKVF8HeOa1/XFMao9DgCzmcM0soxw==",
+      "version": "3.37.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.37.1.tgz",
+      "integrity": "sha512-IyriGXoMp1IKil0Pb6itgK2RRKF24tv6QlXfceZfu4kntEfPVjjyHqQ8TpuYmffCVdYr4FiGtcJqdpaMrwrDwA==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@uniswap/router-sdk": "^1.9.2",
     "@uniswap/sdk-core": "^5.3.0",
     "@types/semver": "^7.5.8",
-    "@uniswap/smart-order-router": "3.37.0",
+    "@uniswap/smart-order-router": "3.37.1",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^2.2.0",
     "@uniswap/v2-sdk": "^4.3.2",


### PR DESCRIPTION
Release https://github.com/Uniswap/smart-order-router/pull/647