### PR TITLE
bump(sor): Update SOR version 3.38.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.9.2",
         "@uniswap/sdk-core": "^5.3.0",
-        "@uniswap/smart-order-router": "3.37.2",
+        "@uniswap/smart-order-router": "3.38.0",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^2.2.0",
         "@uniswap/v2-sdk": "^4.3.2",
@@ -4748,9 +4748,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.37.2",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.37.2.tgz",
-      "integrity": "sha512-Ulj8+uu6BhCJNPVuUJMla48bbeLFsBEsLwukZwHBx0sSFxITP61IumzCBSgnTqlJsaI5Zbi7gF5qjgH/LMTm8Q==",
+      "version": "3.38.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.38.0.tgz",
+      "integrity": "sha512-qZaTIrORRBWHyZV5M03H1a3L11eoFb+JI21A2NohtTZSETiEh6h+x7KlZiNClWXT6VKzPq5SDYCj+YiBI6Ml8w==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -28385,9 +28385,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.37.2",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.37.2.tgz",
-      "integrity": "sha512-Ulj8+uu6BhCJNPVuUJMla48bbeLFsBEsLwukZwHBx0sSFxITP61IumzCBSgnTqlJsaI5Zbi7gF5qjgH/LMTm8Q==",
+      "version": "3.38.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.38.0.tgz",
+      "integrity": "sha512-qZaTIrORRBWHyZV5M03H1a3L11eoFb+JI21A2NohtTZSETiEh6h+x7KlZiNClWXT6VKzPq5SDYCj+YiBI6Ml8w==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@uniswap/router-sdk": "^1.9.2",
     "@uniswap/sdk-core": "^5.3.0",
     "@types/semver": "^7.5.8",
-    "@uniswap/smart-order-router": "3.37.2",
+    "@uniswap/smart-order-router": "3.38.0",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^2.2.0",
     "@uniswap/v2-sdk": "^4.3.2",


### PR DESCRIPTION
# Bumps SOR to 3.38.0

Includes cross protocol liquidity pools.
