### PR TITLE
feat: migrate to tenderly node endpoint at 1% on mainnet

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -391,7 +391,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
             undefined,
             // The timeout for the underlying axios call to Tenderly, measured in milliseconds.
             2.5 * 1000,
-            20,
+            1,
             [ChainId.MAINNET]
           )
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.9.2",
         "@uniswap/sdk-core": "^5.3.0",
-        "@uniswap/smart-order-router": "3.38.0",
+        "@uniswap/smart-order-router": "3.39.0",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^2.2.0",
         "@uniswap/v2-sdk": "^4.3.2",
@@ -4748,9 +4748,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.38.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.38.0.tgz",
-      "integrity": "sha512-qZaTIrORRBWHyZV5M03H1a3L11eoFb+JI21A2NohtTZSETiEh6h+x7KlZiNClWXT6VKzPq5SDYCj+YiBI6Ml8w==",
+      "version": "3.39.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.39.0.tgz",
+      "integrity": "sha512-6PHMeJvXp7lpJvX4rE66ofHIJa/OB0s+TSQ802qu7cljj7E0SRDG/QAi3WBXIX3QlTyn1pp4Yvkqk7crtMRkgw==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -28385,9 +28385,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.38.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.38.0.tgz",
-      "integrity": "sha512-qZaTIrORRBWHyZV5M03H1a3L11eoFb+JI21A2NohtTZSETiEh6h+x7KlZiNClWXT6VKzPq5SDYCj+YiBI6Ml8w==",
+      "version": "3.39.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.39.0.tgz",
+      "integrity": "sha512-6PHMeJvXp7lpJvX4rE66ofHIJa/OB0s+TSQ802qu7cljj7E0SRDG/QAi3WBXIX3QlTyn1pp4Yvkqk7crtMRkgw==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@uniswap/router-sdk": "^1.9.2",
     "@uniswap/sdk-core": "^5.3.0",
     "@types/semver": "^7.5.8",
-    "@uniswap/smart-order-router": "3.38.0",
+    "@uniswap/smart-order-router": "3.39.0",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^2.2.0",
     "@uniswap/v2-sdk": "^4.3.2",


### PR DESCRIPTION
We see no mismatch between tenderly api and tenderly node gas estimate on mainnet. We want to migrate from api to node at 1% of the live traffic first.