### PR TITLE
feat: migrate to tenderly node endpoint at 10% on mainnet

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -391,7 +391,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
             undefined,
             // The timeout for the underlying axios call to Tenderly, measured in milliseconds.
             2.5 * 1000,
-            1,
+            10,
             [ChainId.MAINNET]
           )
 


### PR DESCRIPTION
We migrated to tenderly node endpoint at 1%. P50 latency wise, the improvement is very noticeable between tenderly api and tenderly node:

![Screenshot 2024-07-31 at 6.50.58 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/5ce2d10c-88b8-413b-a1c6-63ca663453e9.png)

response volume wise, we see slight increase in node 200 response, and no other http status:
![Screenshot 2024-07-31 at 6.51.40 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/399dbcf3-2bb4-4918-96ad-a880807af32a.png)

But the absolute tenderly node traffic volume is not high enough, so we don't see overall quote endpoint latency improvement. We are ramping up to 10% tenderly node volume to see if the quote endpoint latency has noticeable improvements.