### PR TITLE
feat: migrate to tenderly node endpoint at 50% on mainnet 

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -391,7 +391,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
             undefined,
             // The timeout for the underlying axios call to Tenderly, measured in milliseconds.
             2.5 * 1000,
-            10,
+            50,
             [ChainId.MAINNET]
           )
 


### PR DESCRIPTION
We migrated to tenderly node endpoint at 10%. latency wise overall we have not seen a big difference 
<img width="1606" alt="Screenshot 2024-07-31 at 21 09 28" src="https://github.com/user-attachments/assets/343fcea0-7ead-4ff8-991c-996b66e943fe">
