### PR TITLE
fix(alarm): exclude very low volume chains from 4xx alarm (no route)

### DIFF
--- a/bin/stacks/routing-api-stack.ts
+++ b/bin/stacks/routing-api-stack.ts
@@ -401,8 +401,10 @@ export class RoutingAPIStack extends cdk.Stack {
         return
       }
       const alarmName = `RoutingAPI-SEV3-4XXAlarm-ChainId: ${chainId.toString()}`
+      // We only want to alert if the volume is high enough over default period (5m) for 4xx errors (no route).
+      const invocationsThreshold = 500;
       const metric = new MathExpression({
-        expression: '100*(response400/invocations)',
+        expression: `IF(invocations > ${invocationsThreshold}, 100*(response400/invocations), 0)`,
         usingMetrics: {
           invocations: new aws_cloudwatch.Metric({
             namespace: 'Uniswap',

--- a/bin/stacks/routing-api-stack.ts
+++ b/bin/stacks/routing-api-stack.ts
@@ -402,7 +402,7 @@ export class RoutingAPIStack extends cdk.Stack {
       }
       const alarmName = `RoutingAPI-SEV3-4XXAlarm-ChainId: ${chainId.toString()}`
       // We only want to alert if the volume is high enough over default period (5m) for 4xx errors (no route).
-      const invocationsThreshold = 500;
+      const invocationsThreshold = 500
       const metric = new MathExpression({
         expression: `IF(invocations > ${invocationsThreshold}, 100*(response400/invocations), 0)`,
         usingMetrics: {


### PR DESCRIPTION
Exclude very low volume chains from 4xx alarm (no route).
Those alarms are very noisy due to low traffic and no liquidity.
[example](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#alarmsV2:alarm/RoutingAPI-SEV3-4XXAlarm-ChainId:%20324)