### PR TITLE
fix: blast integ-test due to insufficient liquidity

### DIFF
--- a/test/mocha/e2e/quote.test.ts
+++ b/test/mocha/e2e/quote.test.ts
@@ -2564,7 +2564,7 @@ describe('quote', function () {
 
         it(`${wrappedNative.symbol} -> erc20`, async () => {
           // Current WETH/USDB pool (https://blastscan.io/address/0xf52b4b69123cbcf07798ae8265642793b2e8990c) has low WETH amount
-          const amount = (chain === ChainId.BLAST ? (type === 'exactOut' ? '0.002' : '0.01') : '1')
+          const amount = chain === ChainId.BLAST ? (type === 'exactOut' ? '0.002' : '0.01') : '1'
 
           const quoteReq: QuoteQueryParams = {
             tokenInAddress: wrappedNative.address,

--- a/test/mocha/e2e/quote.test.ts
+++ b/test/mocha/e2e/quote.test.ts
@@ -2564,7 +2564,7 @@ describe('quote', function () {
 
         it(`${wrappedNative.symbol} -> erc20`, async () => {
           // Current WETH/USDB pool (https://blastscan.io/address/0xf52b4b69123cbcf07798ae8265642793b2e8990c) has low WETH amount
-          const amount = type === 'exactOut' && chain === ChainId.BLAST ? '0.002' : '1'
+          const amount = (chain === ChainId.BLAST ? (type === 'exactOut' ? '0.002' : '0.01') : '1')
 
           const quoteReq: QuoteQueryParams = {
             tokenInAddress: wrappedNative.address,


### PR DESCRIPTION
One blast integ-test with 1 weth trading amount keeps failing. It's due to blast pool's low liquidity. We lowered the trading amount from 1 weth to 0.01 weth and now the blast integ-test can all pass https://app.warp.dev/block/eHpCe18E8ywz63W6Z1Bz3q.