### PR TITLE
feat: download v4 subgraph pools from s3 cache

### DIFF
--- a/lib/handlers/router-entities/aws-subgraph-provider.ts
+++ b/lib/handlers/router-entities/aws-subgraph-provider.ts
@@ -106,6 +106,18 @@ export const cachePoolsFromS3 = async <TSubgraphPool>(
   return pools
 }
 
+export class V4AWSSubgraphProvider extends AWSSubgraphProvider<V3SubgraphPool> implements IV3SubgraphProvider {
+  constructor(chainId: ChainId, bucket: string, baseKey: string) {
+    super(chainId, Protocol.V4, bucket, baseKey)
+  }
+
+  public static async EagerBuild(bucket: string, baseKey: string, chainId: ChainId): Promise<V3AWSSubgraphProvider> {
+    await cachePoolsFromS3<V3SubgraphPool>(s3, bucket, baseKey, chainId, Protocol.V4)
+
+    return new V4AWSSubgraphProvider(chainId, bucket, baseKey)
+  }
+}
+
 export class V3AWSSubgraphProvider extends AWSSubgraphProvider<V3SubgraphPool> implements IV3SubgraphProvider {
   constructor(chainId: ChainId, bucket: string, baseKey: string) {
     super(chainId, Protocol.V3, bucket, baseKey)

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.10.0",
         "@uniswap/sdk-core": "^5.3.0",
-        "@uniswap/smart-order-router": "3.40.0",
+        "@uniswap/smart-order-router": "3.41.0",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^2.2.4",
         "@uniswap/v2-sdk": "^4.3.2",
@@ -4749,9 +4749,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.40.0.tgz",
-      "integrity": "sha512-+Ffua7+neXz2w5Gyd8PKRB9NebEu+sZVQ9nxlaizsQuXo3KWU0yx79YiBubTqqrilI7foobtYYqTH+YAWyW+Dg==",
+      "version": "3.41.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.41.0.tgz",
+      "integrity": "sha512-j5FmHUaLE5kZ+3wF8gDuBfmFPlWCb9zNByJdNdiUEhnEfWXjgR1g94NPCEHWPG9OCAmlRfiUUzZpEJTnhqX2wg==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -28422,9 +28422,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.40.0.tgz",
-      "integrity": "sha512-+Ffua7+neXz2w5Gyd8PKRB9NebEu+sZVQ9nxlaizsQuXo3KWU0yx79YiBubTqqrilI7foobtYYqTH+YAWyW+Dg==",
+      "version": "3.41.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.41.0.tgz",
+      "integrity": "sha512-j5FmHUaLE5kZ+3wF8gDuBfmFPlWCb9zNByJdNdiUEhnEfWXjgR1g94NPCEHWPG9OCAmlRfiUUzZpEJTnhqX2wg==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@uniswap/router-sdk": "^1.10.0",
     "@uniswap/sdk-core": "^5.3.0",
     "@types/semver": "^7.5.8",
-    "@uniswap/smart-order-router": "3.40.0",
+    "@uniswap/smart-order-router": "3.41.0",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^2.2.4",
     "@uniswap/v2-sdk": "^4.3.2",


### PR DESCRIPTION
routing-api needs to download v4 subgraph pools from s3 cache during lambda instantiation time. Based on the metrics, I can see that happened:

![Screenshot 2024-08-15 at 1.38.00 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/dd60fcbe-75e4-44e9-a020-7d46e0a20c98.png)

![Screenshot 2024-08-15 at 2.26.12 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/90c1e8ac-91ce-4352-a0fd-5f47fbff14f5.png)

