### PR TITLE
chore: bump sor to 3.43.2 - fix: ticks crossing gas estimate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.10.0",
         "@uniswap/sdk-core": "^5.3.0",
-        "@uniswap/smart-order-router": "3.43.1",
+        "@uniswap/smart-order-router": "3.43.2",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^2.2.4",
         "@uniswap/v2-sdk": "^4.3.2",
@@ -4749,9 +4749,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.43.1",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.43.1.tgz",
-      "integrity": "sha512-jo601ATVSrz8Hdeyp3ftyC6fsPRXgM+iFT+IoIaj8sVCFEp+xuXDlTnMR/PzXQYkGOemf/yyD00dpt1bMJ0atA==",
+      "version": "3.43.2",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.43.2.tgz",
+      "integrity": "sha512-UFBbm/NYL85AZoUpYIU0k8cehf8ldF3YhUR8cmcBhirBuWisLIJ1pgcECBPB2czZNdxbUO4YlBcldz8dWzUZeA==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -28422,9 +28422,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.43.1",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.43.1.tgz",
-      "integrity": "sha512-jo601ATVSrz8Hdeyp3ftyC6fsPRXgM+iFT+IoIaj8sVCFEp+xuXDlTnMR/PzXQYkGOemf/yyD00dpt1bMJ0atA==",
+      "version": "3.43.2",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.43.2.tgz",
+      "integrity": "sha512-UFBbm/NYL85AZoUpYIU0k8cehf8ldF3YhUR8cmcBhirBuWisLIJ1pgcECBPB2czZNdxbUO4YlBcldz8dWzUZeA==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@uniswap/router-sdk": "^1.10.0",
     "@uniswap/sdk-core": "^5.3.0",
     "@types/semver": "^7.5.8",
-    "@uniswap/smart-order-router": "3.43.1",
+    "@uniswap/smart-order-router": "3.43.2",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^2.2.4",
     "@uniswap/v2-sdk": "^4.3.2",


### PR DESCRIPTION
Release https://github.com/Uniswap/smart-order-router/pull/675