### PR TITLE
chore: bump sor to 3.46.1 - fix(sor): catch div zero + log but don't throw

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.10.0",
         "@uniswap/sdk-core": "^5.3.0",
-        "@uniswap/smart-order-router": "3.46.0",
+        "@uniswap/smart-order-router": "3.46.1",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^2.2.4",
         "@uniswap/v2-sdk": "^4.3.2",
@@ -4749,9 +4749,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.46.0.tgz",
-      "integrity": "sha512-mXCAmYSHkQhT2kusHuSRdwDtz2gsig5G2tS0AsCGx0X1sxfp9QP76ztYXWUJCf6NQgc8zuCT7fAiBxngRKfcMA==",
+      "version": "3.46.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.46.1.tgz",
+      "integrity": "sha512-M6MD9wWMUblD4y4nxxd0WWFCPfsEpX13ARoWa2Rx9tIfCLEDfJklODfzjZVOCbd4lthmMowKnTQ20lV0mlK3ig==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -28422,9 +28422,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.46.0.tgz",
-      "integrity": "sha512-mXCAmYSHkQhT2kusHuSRdwDtz2gsig5G2tS0AsCGx0X1sxfp9QP76ztYXWUJCf6NQgc8zuCT7fAiBxngRKfcMA==",
+      "version": "3.46.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.46.1.tgz",
+      "integrity": "sha512-M6MD9wWMUblD4y4nxxd0WWFCPfsEpX13ARoWa2Rx9tIfCLEDfJklODfzjZVOCbd4lthmMowKnTQ20lV0mlK3ig==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@uniswap/router-sdk": "^1.10.0",
     "@uniswap/sdk-core": "^5.3.0",
     "@types/semver": "^7.5.8",
-    "@uniswap/smart-order-router": "3.46.0",
+    "@uniswap/smart-order-router": "3.46.1",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^2.2.4",
     "@uniswap/v2-sdk": "^4.3.2",


### PR DESCRIPTION
Release https://github.com/Uniswap/smart-order-router/pull/683