### PR TITLE
feat: accept universal router version request param from URA header 'x-universal-router-version'

### DIFF
--- a/lib/handlers/quote/SwapOptionsFactory.ts
+++ b/lib/handlers/quote/SwapOptionsFactory.ts
@@ -4,7 +4,7 @@ import JSBI from 'jsbi'
 import { TradeTypeParam } from './schema/quote-schema'
 import { computePortionAmount, parseDeadline, parseSlippageTolerance, populateFeeOptions } from '../shared'
 import { PermitSingle } from '@uniswap/permit2-sdk'
-import { UNIVERSAL_ROUTER_ADDRESS } from '@uniswap/universal-router-sdk'
+import { UNIVERSAL_ROUTER_ADDRESS, UniversalRouterVersion } from '@uniswap/universal-router-sdk'
 import { utils } from 'ethers'
 
 export type SwapOptionsUniversalRouterInput = {
@@ -12,6 +12,7 @@ export type SwapOptionsUniversalRouterInput = {
   currencyIn: Currency
   currencyOut: Currency
   tradeType: TradeTypeParam
+  universalRouterVersion: UniversalRouterVersion
   amountRaw: string
   slippageTolerance?: string
   enableUniversalRouter?: boolean
@@ -48,6 +49,7 @@ export class SwapOptionsFactory {
     currencyIn,
     currencyOut,
     tradeType,
+    universalRouterVersion,
     amountRaw,
     slippageTolerance,
     enableUniversalRouter,
@@ -69,6 +71,7 @@ export class SwapOptionsFactory {
         currencyIn,
         currencyOut,
         tradeType,
+        universalRouterVersion,
         slippageTolerance,
         portionBips,
         portionRecipient,
@@ -103,6 +106,7 @@ export class SwapOptionsFactory {
     currencyIn,
     currencyOut,
     tradeType,
+    universalRouterVersion,
     slippageTolerance,
     portionBips,
     portionRecipient,
@@ -145,7 +149,7 @@ export class SwapOptionsFactory {
           expiration: permitExpiration,
           nonce: permitNonce,
         },
-        spender: UNIVERSAL_ROUTER_ADDRESS(chainId),
+        spender: UNIVERSAL_ROUTER_ADDRESS(universalRouterVersion, chainId),
         sigDeadline: permitSigDeadline,
       }
 

--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -258,7 +258,7 @@ export class QuoteHandler extends APIGLambdaHandler<
     const requestSourceHeader = params.event.headers && params.event.headers['x-request-source']
     const appVersion = params.event.headers && params.event.headers['x-app-version']
     const universalRouterVersion = convertStringRouterVersionToEnum(
-      params.event.headers && params.event.headers['x-universal-router-version']
+      params.event.headers?.['x-universal-router-version']
     )
     const excludedProtocolsFromMixed = protocolVersionsToBeExcludedFromMixed(universalRouterVersion)
 

--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -366,6 +366,7 @@ export class QuoteHandler extends APIGLambdaHandler<
       currencyIn,
       currencyOut,
       tradeType: type,
+      universalRouterVersion,
       slippageTolerance,
       enableUniversalRouter,
       portionBips,

--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -42,7 +42,7 @@ import {
   convertStringRouterVersionToEnum,
   protocolVersionsToBeExcludedFromMixed,
   URVersionsToProtocolVersions,
-} from '../../util/SupportedProtocolVersions'
+} from '../../util/supportedProtocolVersions'
 
 export class QuoteHandler extends APIGLambdaHandler<
   ContainerInjected,

--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -10,7 +10,7 @@ import {
   routeAmountsToString,
   SimulationStatus,
   SwapOptions,
-  SwapRoute
+  SwapRoute,
 } from '@uniswap/smart-order-router'
 import { Pool as V3Pool } from '@uniswap/v3-sdk'
 import { Pool as V4Pool } from '@uniswap/v4-sdk'
@@ -23,7 +23,7 @@ import {
   DEFAULT_ROUTING_CONFIG_BY_CHAIN,
   FEE_ON_TRANSFER_SPECIFIC_CONFIG,
   INTENT_SPECIFIC_CONFIG,
-  QUOTE_SPEED_CONFIG
+  QUOTE_SPEED_CONFIG,
 } from '../shared'
 import { QuoteQueryParams, QuoteQueryParamsJoi, TradeTypeParam } from './schema/quote-schema'
 import { simulationStatusTranslation } from './util/simulation'
@@ -41,7 +41,7 @@ import { UniversalRouterVersion } from '@uniswap/universal-router-sdk'
 import {
   convertStringRouterVersionToEnum,
   protocolVersionsToBeExcludedFromMixed,
-  URVersionsToProtocolVersions
+  URVersionsToProtocolVersions,
 } from '../../util/SupportedProtocolVersions'
 
 export class QuoteHandler extends APIGLambdaHandler<
@@ -259,7 +259,7 @@ export class QuoteHandler extends APIGLambdaHandler<
     const appVersion = params.event.headers && params.event.headers['x-app-version']
     const universalRouterVersion = convertStringRouterVersionToEnum(
       params.event.headers && params.event.headers['x-universal-router-version']
-    );
+    )
     const excludedProtocolsFromMixed = protocolVersionsToBeExcludedFromMixed(universalRouterVersion)
 
     if (requestSourceHeader) {
@@ -271,7 +271,12 @@ export class QuoteHandler extends APIGLambdaHandler<
     }
 
     const requestSource = requestSourceHeader ?? params.requestQueryParams.source ?? ''
-    const protocols = QuoteHandler.protocolsFromRequest(chainId, universalRouterVersion, protocolsStr, forceCrossProtocol)
+    const protocols = QuoteHandler.protocolsFromRequest(
+      chainId,
+      universalRouterVersion,
+      protocolsStr,
+      forceCrossProtocol
+    )
 
     if (protocols === undefined) {
       return {

--- a/lib/util/SupportedProtocolVersions.ts
+++ b/lib/util/SupportedProtocolVersions.ts
@@ -1,0 +1,30 @@
+import { Protocol } from '@uniswap/router-sdk'
+import { UniversalRouterVersion } from '@uniswap/universal-router-sdk'
+
+export const SUPPORTED_PROTOCOL_VERSIONS = [Protocol.V2, Protocol.V3, Protocol.V4];
+
+export function convertStringRouterVersionToEnum(routerVersion?: string): UniversalRouterVersion {
+  switch (routerVersion) {
+    case '1.2':
+      return UniversalRouterVersion.V1_2;
+    case '2.0':
+      return UniversalRouterVersion.V2_0;
+    default:
+      return UniversalRouterVersion.V1_2;
+  }
+}
+
+export type URVersionsToProtocolVersionsMapping = {
+  readonly [universalRouterVersion in UniversalRouterVersion]: Array<Protocol>;
+};
+
+export const URVersionsToProtocolVersions: URVersionsToProtocolVersionsMapping = {
+  [UniversalRouterVersion.V1_2]: [Protocol.V2, Protocol.V3],
+  [UniversalRouterVersion.V2_0]: [Protocol.V2, Protocol.V3, Protocol.V4],
+};
+
+export function protocolVersionsToBeExcludedFromMixed(universalRouterVersion: UniversalRouterVersion): Protocol[] {
+  return URVersionsToProtocolVersions[universalRouterVersion].filter(
+    (protocol) => !SUPPORTED_PROTOCOL_VERSIONS.includes(protocol)
+  );
+}

--- a/lib/util/SupportedProtocolVersions.ts
+++ b/lib/util/SupportedProtocolVersions.ts
@@ -1,30 +1,30 @@
 import { Protocol } from '@uniswap/router-sdk'
 import { UniversalRouterVersion } from '@uniswap/universal-router-sdk'
 
-export const SUPPORTED_PROTOCOL_VERSIONS = [Protocol.V2, Protocol.V3, Protocol.V4];
+export const SUPPORTED_PROTOCOL_VERSIONS = [Protocol.V2, Protocol.V3, Protocol.V4]
 
 export function convertStringRouterVersionToEnum(routerVersion?: string): UniversalRouterVersion {
   switch (routerVersion) {
     case '1.2':
-      return UniversalRouterVersion.V1_2;
+      return UniversalRouterVersion.V1_2
     case '2.0':
-      return UniversalRouterVersion.V2_0;
+      return UniversalRouterVersion.V2_0
     default:
-      return UniversalRouterVersion.V1_2;
+      return UniversalRouterVersion.V1_2
   }
 }
 
 export type URVersionsToProtocolVersionsMapping = {
-  readonly [universalRouterVersion in UniversalRouterVersion]: Array<Protocol>;
-};
+  readonly [universalRouterVersion in UniversalRouterVersion]: Array<Protocol>
+}
 
 export const URVersionsToProtocolVersions: URVersionsToProtocolVersionsMapping = {
   [UniversalRouterVersion.V1_2]: [Protocol.V2, Protocol.V3],
   [UniversalRouterVersion.V2_0]: [Protocol.V2, Protocol.V3, Protocol.V4],
-};
+}
 
 export function protocolVersionsToBeExcludedFromMixed(universalRouterVersion: UniversalRouterVersion): Protocol[] {
-  return URVersionsToProtocolVersions[universalRouterVersion].filter(
-    (protocol) => !SUPPORTED_PROTOCOL_VERSIONS.includes(protocol)
-  );
+  return SUPPORTED_PROTOCOL_VERSIONS.filter((protocol) =>
+    URVersionsToProtocolVersions[universalRouterVersion].includes(protocol)
+  )
 }

--- a/lib/util/supportedProtocolVersions.ts
+++ b/lib/util/supportedProtocolVersions.ts
@@ -4,14 +4,8 @@ import { UniversalRouterVersion } from '@uniswap/universal-router-sdk'
 export const SUPPORTED_PROTOCOL_VERSIONS = [Protocol.V2, Protocol.V3, Protocol.V4]
 
 export function convertStringRouterVersionToEnum(routerVersion?: string): UniversalRouterVersion {
-  switch (routerVersion) {
-    case UniversalRouterVersion.V1_2:
-      return UniversalRouterVersion.V1_2
-    case UniversalRouterVersion.V2_0:
-      return UniversalRouterVersion.V2_0
-    default:
-      return UniversalRouterVersion.V1_2
-  }
+  const validVersions = Object.values(UniversalRouterVersion)
+  return validVersions.find((v) => v === routerVersion) || UniversalRouterVersion.V1_2
 }
 
 export type URVersionsToProtocolVersionsMapping = {

--- a/lib/util/supportedProtocolVersions.ts
+++ b/lib/util/supportedProtocolVersions.ts
@@ -24,7 +24,7 @@ export const URVersionsToProtocolVersions: URVersionsToProtocolVersionsMapping =
 }
 
 export function protocolVersionsToBeExcludedFromMixed(universalRouterVersion: UniversalRouterVersion): Protocol[] {
-  return SUPPORTED_PROTOCOL_VERSIONS.filter((protocol) =>
-    URVersionsToProtocolVersions[universalRouterVersion].includes(protocol)
+  return SUPPORTED_PROTOCOL_VERSIONS.filter(
+    (protocol) => !URVersionsToProtocolVersions[universalRouterVersion].includes(protocol)
   )
 }

--- a/lib/util/supportedProtocolVersions.ts
+++ b/lib/util/supportedProtocolVersions.ts
@@ -5,9 +5,9 @@ export const SUPPORTED_PROTOCOL_VERSIONS = [Protocol.V2, Protocol.V3, Protocol.V
 
 export function convertStringRouterVersionToEnum(routerVersion?: string): UniversalRouterVersion {
   switch (routerVersion) {
-    case '1.2':
+    case UniversalRouterVersion.V1_2:
       return UniversalRouterVersion.V1_2
-    case '2.0':
+    case UniversalRouterVersion.V2_0:
       return UniversalRouterVersion.V2_0
     default:
       return UniversalRouterVersion.V1_2

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@uniswap/sdk-core": "^5.3.0",
         "@uniswap/smart-order-router": "3.46.2",
         "@uniswap/token-lists": "^1.0.0-beta.33",
-        "@uniswap/universal-router-sdk": "^2.2.4",
+        "@uniswap/universal-router-sdk": "^3.0.1",
         "@uniswap/v2-sdk": "^4.3.2",
         "@uniswap/v3-periphery": "^1.4.4",
         "@uniswap/v3-sdk": "^3.13.0",
@@ -4787,6 +4787,25 @@
         "jsbi": "^3.2.0"
       }
     },
+    "node_modules/@uniswap/smart-order-router/node_modules/@uniswap/universal-router-sdk": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@uniswap/universal-router-sdk/-/universal-router-sdk-2.2.4.tgz",
+      "integrity": "sha512-6+ErgDDtCJLM2ro/krCKtu6ucUpcaQEEPRrAPuJiMTWbR0UyR+6Otp+KdBcT9LmyzSoXuSHhIRr+6s25no1J6A==",
+      "dependencies": {
+        "@uniswap/permit2-sdk": "^1.3.0",
+        "@uniswap/router-sdk": "^1.10.0",
+        "@uniswap/sdk-core": "^5.3.1",
+        "@uniswap/universal-router": "1.6.0",
+        "@uniswap/v2-sdk": "^4.4.1",
+        "@uniswap/v3-sdk": "^3.13.1",
+        "@uniswap/v4-sdk": "^1.0.0",
+        "bignumber.js": "^9.0.2",
+        "ethers": "^5.7.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@uniswap/smart-order-router/node_modules/graphql": {
       "version": "15.8.0",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
@@ -4846,9 +4865,9 @@
       }
     },
     "node_modules/@uniswap/universal-router-sdk": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@uniswap/universal-router-sdk/-/universal-router-sdk-2.2.4.tgz",
-      "integrity": "sha512-6+ErgDDtCJLM2ro/krCKtu6ucUpcaQEEPRrAPuJiMTWbR0UyR+6Otp+KdBcT9LmyzSoXuSHhIRr+6s25no1J6A==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/universal-router-sdk/-/universal-router-sdk-3.0.1.tgz",
+      "integrity": "sha512-8Yzso/rD+T0EoWYJ1uMtc/a0aPLk+YuBPPpeB1xleT+qW+i+vSg6ueSmuKtvvivd8Ns/sq/rhhv0eWk/+tDhlw==",
       "dependencies": {
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.10.0",
@@ -28454,6 +28473,22 @@
         "stats-lite": "^2.2.0"
       },
       "dependencies": {
+        "@uniswap/universal-router-sdk": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/@uniswap/universal-router-sdk/-/universal-router-sdk-2.2.4.tgz",
+          "integrity": "sha512-6+ErgDDtCJLM2ro/krCKtu6ucUpcaQEEPRrAPuJiMTWbR0UyR+6Otp+KdBcT9LmyzSoXuSHhIRr+6s25no1J6A==",
+          "requires": {
+            "@uniswap/permit2-sdk": "^1.3.0",
+            "@uniswap/router-sdk": "^1.10.0",
+            "@uniswap/sdk-core": "^5.3.1",
+            "@uniswap/universal-router": "1.6.0",
+            "@uniswap/v2-sdk": "^4.4.1",
+            "@uniswap/v3-sdk": "^3.13.1",
+            "@uniswap/v4-sdk": "^1.0.0",
+            "bignumber.js": "^9.0.2",
+            "ethers": "^5.7.0"
+          }
+        },
         "graphql": {
           "version": "15.8.0",
           "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
@@ -28509,9 +28544,9 @@
       }
     },
     "@uniswap/universal-router-sdk": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@uniswap/universal-router-sdk/-/universal-router-sdk-2.2.4.tgz",
-      "integrity": "sha512-6+ErgDDtCJLM2ro/krCKtu6ucUpcaQEEPRrAPuJiMTWbR0UyR+6Otp+KdBcT9LmyzSoXuSHhIRr+6s25no1J6A==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/universal-router-sdk/-/universal-router-sdk-3.0.1.tgz",
+      "integrity": "sha512-8Yzso/rD+T0EoWYJ1uMtc/a0aPLk+YuBPPpeB1xleT+qW+i+vSg6ueSmuKtvvivd8Ns/sq/rhhv0eWk/+tDhlw==",
       "requires": {
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.10.0",
         "@uniswap/sdk-core": "^5.3.0",
-        "@uniswap/smart-order-router": "3.46.2",
+        "@uniswap/smart-order-router": "3.47.0",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^3.0.1",
         "@uniswap/v2-sdk": "^4.3.2",
@@ -4749,9 +4749,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.46.2",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.46.2.tgz",
-      "integrity": "sha512-4UoQ3r6dlVaZc+RQzRBk9smzeUqqAbUUO8IafrW0wlZGNazhvZw/yJS0STu5exheDZ+YNwqewnmUAukKG2XB1Q==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.47.0.tgz",
+      "integrity": "sha512-olJWl8e3RGFE9Bj+0sCinCoxE8XDgei2zJg62qnlvUcikh+CVCYjTDZJ7DUU1qDnzz2G9gar4PuG3tAScAALhg==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -28441,9 +28441,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.46.2",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.46.2.tgz",
-      "integrity": "sha512-4UoQ3r6dlVaZc+RQzRBk9smzeUqqAbUUO8IafrW0wlZGNazhvZw/yJS0STu5exheDZ+YNwqewnmUAukKG2XB1Q==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.47.0.tgz",
+      "integrity": "sha512-olJWl8e3RGFE9Bj+0sCinCoxE8XDgei2zJg62qnlvUcikh+CVCYjTDZJ7DUU1qDnzz2G9gar4PuG3tAScAALhg==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@uniswap/sdk-core": "^5.3.0",
         "@uniswap/smart-order-router": "3.47.0",
         "@uniswap/token-lists": "^1.0.0-beta.33",
-        "@uniswap/universal-router-sdk": "^3.0.1",
+        "@uniswap/universal-router-sdk": "^3.0.2",
         "@uniswap/v2-sdk": "^4.3.2",
         "@uniswap/v3-periphery": "^1.4.4",
         "@uniswap/v3-sdk": "^3.13.0",
@@ -4865,9 +4865,9 @@
       }
     },
     "node_modules/@uniswap/universal-router-sdk": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@uniswap/universal-router-sdk/-/universal-router-sdk-3.0.1.tgz",
-      "integrity": "sha512-8Yzso/rD+T0EoWYJ1uMtc/a0aPLk+YuBPPpeB1xleT+qW+i+vSg6ueSmuKtvvivd8Ns/sq/rhhv0eWk/+tDhlw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@uniswap/universal-router-sdk/-/universal-router-sdk-3.0.2.tgz",
+      "integrity": "sha512-DRmUybl/XsN6buUNwpLGLdRnlEaIlrP3o3I1471YlKXhXF9Mb4m+HQqC3VSzBfyIiMBZn7SxL8M3VZIO+ofg5w==",
       "dependencies": {
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.10.0",
@@ -28544,9 +28544,9 @@
       }
     },
     "@uniswap/universal-router-sdk": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@uniswap/universal-router-sdk/-/universal-router-sdk-3.0.1.tgz",
-      "integrity": "sha512-8Yzso/rD+T0EoWYJ1uMtc/a0aPLk+YuBPPpeB1xleT+qW+i+vSg6ueSmuKtvvivd8Ns/sq/rhhv0eWk/+tDhlw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@uniswap/universal-router-sdk/-/universal-router-sdk-3.0.2.tgz",
+      "integrity": "sha512-DRmUybl/XsN6buUNwpLGLdRnlEaIlrP3o3I1471YlKXhXF9Mb4m+HQqC3VSzBfyIiMBZn7SxL8M3VZIO+ofg5w==",
       "requires": {
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@uniswap/router-sdk": "^1.10.0",
     "@uniswap/sdk-core": "^5.3.0",
     "@types/semver": "^7.5.8",
-    "@uniswap/smart-order-router": "3.46.2",
+    "@uniswap/smart-order-router": "3.47.0",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^3.0.1",
     "@uniswap/v2-sdk": "^4.3.2",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@types/semver": "^7.5.8",
     "@uniswap/smart-order-router": "3.46.2",
     "@uniswap/token-lists": "^1.0.0-beta.33",
-    "@uniswap/universal-router-sdk": "^2.2.4",
+    "@uniswap/universal-router-sdk": "^3.0.1",
     "@uniswap/v2-sdk": "^4.3.2",
     "@uniswap/v3-periphery": "^1.4.4",
     "@uniswap/v3-sdk": "^3.13.0",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@types/semver": "^7.5.8",
     "@uniswap/smart-order-router": "3.47.0",
     "@uniswap/token-lists": "^1.0.0-beta.33",
-    "@uniswap/universal-router-sdk": "^3.0.1",
+    "@uniswap/universal-router-sdk": "^3.0.2",
     "@uniswap/v2-sdk": "^4.3.2",
     "@uniswap/v3-periphery": "^1.4.4",
     "@uniswap/v3-sdk": "^3.13.0",

--- a/test/jest/unit/handlers/SwapOptionsFactory.test.ts
+++ b/test/jest/unit/handlers/SwapOptionsFactory.test.ts
@@ -5,15 +5,15 @@ import { TradeTypeParam } from '../../../../lib/handlers/quote/schema/quote-sche
 import { expect, jest } from '@jest/globals'
 import { SwapType } from '@uniswap/smart-order-router'
 import { utils } from 'ethers'
-import { UNIVERSAL_ROUTER_ADDRESS } from '@uniswap/universal-router-sdk'
+import { UNIVERSAL_ROUTER_ADDRESS, UniversalRouterVersion } from '@uniswap/universal-router-sdk'
 
 import {
   SwapOptionsFactory,
   SwapOptionsSwapRouter02Input,
-  SwapOptionsUniversalRouterInput,
+  SwapOptionsUniversalRouterInput
 } from '../../../../lib/handlers/quote/SwapOptionsFactory'
 
-const MAINNET_UNIVERSAL_ROUTER_ADDRESS = UNIVERSAL_ROUTER_ADDRESS(ChainId.MAINNET)
+const MAINNET_UNIVERSAL_ROUTER_ADDRESS = UNIVERSAL_ROUTER_ADDRESS(UniversalRouterVersion.V1_2, ChainId.MAINNET)
 
 class universalRouterInputFactory extends Factory<SwapOptionsUniversalRouterInput> {
   withFees() {
@@ -48,6 +48,7 @@ const UniversalRouterInputFactory = universalRouterInputFactory.define(() => ({
   currencyIn: new Token(ChainId.MAINNET, '0x0000000000000000000000000000000000000001', 18, 'FOO', 'Foo'),
   currencyOut: new Token(ChainId.MAINNET, '0x0000000000000000000000000000000000000002', 18, 'BAR', 'Bar'),
   tradeType: 'exactIn' as TradeTypeParam,
+  universalRouterVersion: UniversalRouterVersion.V1_2,
   slippageTolerance: '0.5',
   amountRaw: '100000000000000000',
   deadline: '60',

--- a/test/jest/unit/handlers/SwapOptionsFactory.test.ts
+++ b/test/jest/unit/handlers/SwapOptionsFactory.test.ts
@@ -10,7 +10,7 @@ import { UNIVERSAL_ROUTER_ADDRESS, UniversalRouterVersion } from '@uniswap/unive
 import {
   SwapOptionsFactory,
   SwapOptionsSwapRouter02Input,
-  SwapOptionsUniversalRouterInput
+  SwapOptionsUniversalRouterInput,
 } from '../../../../lib/handlers/quote/SwapOptionsFactory'
 
 const MAINNET_UNIVERSAL_ROUTER_ADDRESS = UNIVERSAL_ROUTER_ADDRESS(UniversalRouterVersion.V1_2, ChainId.MAINNET)

--- a/test/jest/unit/handlers/quote.test.ts
+++ b/test/jest/unit/handlers/quote.test.ts
@@ -2,48 +2,82 @@ import { expect } from '@jest/globals'
 import { QuoteHandler } from '../../../../lib/handlers/quote/quote'
 import { ChainId } from '@uniswap/sdk-core'
 import { Protocol } from '@uniswap/router-sdk'
+import { UniversalRouterVersion } from '@uniswap/universal-router-sdk'
 
 describe('QuoteHandler', () => {
   describe('.protocolsFromRequest', () => {
     it('returns V3 when no protocols are requested', () => {
-      expect(QuoteHandler.protocolsFromRequest(ChainId.MAINNET, undefined, undefined)).toEqual([Protocol.V3])
+      expect(
+        QuoteHandler.protocolsFromRequest(ChainId.MAINNET, UniversalRouterVersion.V1_2, undefined, undefined)
+      ).toEqual([Protocol.V3])
     })
 
     it('returns V3 when forceCrossProtocol is false', () => {
-      expect(QuoteHandler.protocolsFromRequest(ChainId.MAINNET, undefined, false)).toEqual([Protocol.V3])
+      expect(QuoteHandler.protocolsFromRequest(ChainId.MAINNET, UniversalRouterVersion.V1_2, undefined, false)).toEqual(
+        [Protocol.V3]
+      )
     })
 
     it('returns empty when forceCrossProtocol is true', () => {
-      expect(QuoteHandler.protocolsFromRequest(ChainId.MAINNET, undefined, true)).toEqual([])
+      expect(QuoteHandler.protocolsFromRequest(ChainId.MAINNET, UniversalRouterVersion.V1_2, undefined, true)).toEqual(
+        []
+      )
     })
 
     it('returns requested protocols', () => {
-      expect(QuoteHandler.protocolsFromRequest(ChainId.MAINNET, ['v2', 'v3', 'mixed'], undefined)).toEqual([
-        Protocol.V2,
-        Protocol.V3,
-        Protocol.MIXED,
-      ])
+      expect(
+        QuoteHandler.protocolsFromRequest(
+          ChainId.MAINNET,
+          UniversalRouterVersion.V1_2,
+          ['v2', 'v3', 'mixed'],
+          undefined
+        )
+      ).toEqual([Protocol.V2, Protocol.V3, Protocol.MIXED])
     })
 
     it('returns a different set of requested protocols', () => {
-      expect(QuoteHandler.protocolsFromRequest(ChainId.MAINNET, ['v3', 'mixed'], undefined)).toEqual([
-        Protocol.V3,
-        Protocol.MIXED,
-      ])
+      expect(
+        QuoteHandler.protocolsFromRequest(ChainId.MAINNET, UniversalRouterVersion.V1_2, ['v3', 'mixed'], undefined)
+      ).toEqual([Protocol.V3, Protocol.MIXED])
     })
 
     it('works with other chains', () => {
-      expect(QuoteHandler.protocolsFromRequest(ChainId.BASE, ['v2', 'v3', 'mixed'], undefined)).toEqual([
-        Protocol.V2,
-        Protocol.V3,
-        Protocol.MIXED,
-      ])
+      expect(
+        QuoteHandler.protocolsFromRequest(ChainId.BASE, UniversalRouterVersion.V1_2, ['v2', 'v3', 'mixed'], undefined)
+      ).toEqual([Protocol.V2, Protocol.V3, Protocol.MIXED])
     })
 
     it('returns undefined when a requested protocol is invalid', () => {
       expect(
-        QuoteHandler.protocolsFromRequest(ChainId.BASE, ['v2', 'v3', 'mixed', 'miguel'], undefined)
+        QuoteHandler.protocolsFromRequest(
+          ChainId.BASE,
+          UniversalRouterVersion.V1_2,
+          ['v2', 'v3', 'mixed', 'miguel'],
+          undefined
+        )
       ).toBeUndefined()
+    })
+
+    it('returns v2, v3, mixed when universal router version is v1.2', () => {
+      expect(
+        QuoteHandler.protocolsFromRequest(
+          ChainId.MAINNET,
+          UniversalRouterVersion.V1_2,
+          ['v2', 'v3', 'v4', 'mixed'],
+          undefined
+        )
+      ).toEqual([Protocol.V2, Protocol.V3, Protocol.MIXED])
+    })
+
+    it('returns v2, v3, v4, mixed when universal router version is v2.0', () => {
+      expect(
+        QuoteHandler.protocolsFromRequest(
+          ChainId.MAINNET,
+          UniversalRouterVersion.V2_0,
+          ['v2', 'v3', 'v4', 'mixed'],
+          undefined
+        )
+      ).toEqual([Protocol.V2, Protocol.V3, Protocol.V4, Protocol.MIXED])
     })
   })
 })

--- a/test/mocha/e2e/quote.test.ts
+++ b/test/mocha/e2e/quote.test.ts
@@ -8,6 +8,7 @@ import {
   CUSD_CELO_ALFAJORES,
   DAI_MAINNET,
   ID_TO_NETWORK_NAME,
+  MethodParameters,
   NATIVE_CURRENCY,
   parseAmount,
   SWAP_ROUTER_02_ADDRESSES,
@@ -27,8 +28,8 @@ import {
 import {
   PERMIT2_ADDRESS,
   UNIVERSAL_ROUTER_ADDRESS as UNIVERSAL_ROUTER_ADDRESS_BY_CHAIN,
+  UniversalRouterVersion,
 } from '@uniswap/universal-router-sdk'
-import { MethodParameters } from '@uniswap/smart-order-router'
 import { fail } from 'assert'
 import axiosStatic, { AxiosResponse } from 'axios'
 import axiosRetry from 'axios-retry'
@@ -54,7 +55,7 @@ const { ethers } = hre
 chai.use(chaiAsPromised)
 chai.use(chaiSubset)
 
-const UNIVERSAL_ROUTER_ADDRESS = UNIVERSAL_ROUTER_ADDRESS_BY_CHAIN(1)
+const UNIVERSAL_ROUTER_ADDRESS = UNIVERSAL_ROUTER_ADDRESS_BY_CHAIN(UniversalRouterVersion.V1_2, 1)
 
 if (!process.env.UNISWAP_ROUTING_API || !process.env.ARCHIVE_NODE_RPC) {
   throw new Error('Must set UNISWAP_ROUTING_API and ARCHIVE_NODE_RPC env variables for integ tests. See README')
@@ -2650,8 +2651,14 @@ describe('quote', function () {
 
           const queryParams = qs.stringify(quoteReq)
 
+          const headers = {
+            'x-universal-router-version': '2.0',
+          }
+
           try {
-            const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(`${API}?${queryParams}`)
+            const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(`${API}?${queryParams}`, {
+              headers: headers,
+            })
             const { status } = response
 
             expect(status).to.equal(200)

--- a/test/mocha/unit/util/supportedProtocolVersions.test.ts
+++ b/test/mocha/unit/util/supportedProtocolVersions.test.ts
@@ -11,6 +11,7 @@ describe('supported protocol versions', () => {
     expect(convertStringRouterVersionToEnum('1.2')).to.eq(UniversalRouterVersion.V1_2)
     expect(convertStringRouterVersionToEnum('2.0')).to.eq(UniversalRouterVersion.V2_0)
     expect(convertStringRouterVersionToEnum('3.0')).to.eq(UniversalRouterVersion.V1_2)
+    expect(convertStringRouterVersionToEnum(undefined)).to.eq(UniversalRouterVersion.V1_2)
   })
 
   it('should return protocol versions to be excluded from mixed', async () => {

--- a/test/mocha/unit/util/supportedProtocolVersions.test.ts
+++ b/test/mocha/unit/util/supportedProtocolVersions.test.ts
@@ -1,0 +1,20 @@
+import { UniversalRouterVersion } from '@uniswap/universal-router-sdk'
+import {
+  convertStringRouterVersionToEnum,
+  protocolVersionsToBeExcludedFromMixed,
+} from '../../../../lib/util/supportedProtocolVersions'
+import { Protocol } from '@uniswap/router-sdk'
+import { expect } from 'chai'
+
+describe('supported protocol versions', () => {
+  it('should convert string router version to enum', async () => {
+    expect(convertStringRouterVersionToEnum('1.2')).to.eq(UniversalRouterVersion.V1_2)
+    expect(convertStringRouterVersionToEnum('2.0')).to.eq(UniversalRouterVersion.V2_0)
+    expect(convertStringRouterVersionToEnum('3.0')).to.eq(UniversalRouterVersion.V1_2)
+  })
+
+  it('should return protocol versions to be excluded from mixed', async () => {
+    expect(protocolVersionsToBeExcludedFromMixed(UniversalRouterVersion.V1_2)).to.deep.eq([Protocol.V4])
+    expect(protocolVersionsToBeExcludedFromMixed(UniversalRouterVersion.V2_0)).to.deep.eq([])
+  })
+})


### PR DESCRIPTION
routing-api also accepts the 'x-universal-router-version' request header passed through from URA.

One way to validate the change is working, is that the existing v4 pool routing quote e2e test will fail without passing 'universal-router-version' header, as it defaults to universal router 1.2 in case of absent header: https://app.warp.dev/block/gUssmXhFujGDxGqywxEfOH

Then another local test, that adds 'universal-router-version' header with 2.0 will succeed, as that's the universal router version that will support v4 commands and v4 route planner: https://app.warp.dev/block/a1NCxqXzfuFPRAxZSUJJfm