### PR TITLE
fix: can not apply cdk when in region ap-southeast-1

### DIFF
--- a/bin/stacks/rpc-gateway-fallback-stack.ts
+++ b/bin/stacks/rpc-gateway-fallback-stack.ts
@@ -93,7 +93,7 @@ export class RpcGatewayFallbackStack extends cdk.NestedStack {
           evaluationPeriods: 1,
         })
 
-        const lambdaAliasName = `ErrorRate-${chainId}-${providerNameFix}`
+        const lambdaAliasName = `ErrRate-${chainId}-${providerNameFix}`
         const lambdaAlias = new aws_lambda.Alias(this, lambdaAliasName, {
           aliasName: lambdaAliasName,
           version: providerFallbackLambda.currentVersion,


### PR DESCRIPTION
I encountered a small issue when trying to run your CDK stack to test the Swap API in region **ap-southeast-1**.
![errr](https://github.com/user-attachments/assets/1889b9d3-f7a9-4ce9-9d23-845e639187a5)

The problem was caused by the AWS::Lambda::Permission resource. I believe the issue was due to the Lambda alias name being too long. I made a slight adjustment, and now it works as expected.

![Complete](https://github.com/user-attachments/assets/d3183e8c-a166-43a5-9d70-0d188cf63616)
