### PR TITLE
feat: update subgraph and pool manager address

### DIFF
--- a/lib/cron/cache-config.ts
+++ b/lib/cron/cache-config.ts
@@ -9,7 +9,7 @@ import { ChainId } from '@uniswap/sdk-core'
 export const v4SubgraphUrlOverride = (chainId: ChainId) => {
   switch (chainId) {
     case ChainId.SEPOLIA:
-      return `https://subgraph.satsuma-prod.com/${process.env.ALCHEMY_QUERY_KEY}/uniswap/uniswap-v4-sepolia-test/api`
+      return `https://subgraph.satsuma-prod.com/${process.env.ALCHEMY_QUERY_KEY}/uniswap/uniswap-v4-sepolia-test/version/v0.0.16/api`
     default:
       return undefined
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.10.0",
         "@uniswap/sdk-core": "^5.3.0",
-        "@uniswap/smart-order-router": "3.48.0",
+        "@uniswap/smart-order-router": "3.49.0",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^3.0.2",
         "@uniswap/v2-sdk": "^4.3.2",
@@ -4749,9 +4749,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.48.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.48.0.tgz",
-      "integrity": "sha512-yoXTsMcWXQk0OLJyxSDr+IkAi9wp7fI4Ioq4dvyY5azClzL7UMYtt1PneZaYVy5SeLokh4Eq3tIBUebGLOuO/Q==",
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.49.0.tgz",
+      "integrity": "sha512-yco6C/C0fNfc5cGiWlCIbSqgD2qdpIrRabikPVAsKAyTcIsn076c6EFCyCNfAtHLjWWG0N/JhRle5Eec2c0zdA==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -28422,9 +28422,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.48.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.48.0.tgz",
-      "integrity": "sha512-yoXTsMcWXQk0OLJyxSDr+IkAi9wp7fI4Ioq4dvyY5azClzL7UMYtt1PneZaYVy5SeLokh4Eq3tIBUebGLOuO/Q==",
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.49.0.tgz",
+      "integrity": "sha512-yco6C/C0fNfc5cGiWlCIbSqgD2qdpIrRabikPVAsKAyTcIsn076c6EFCyCNfAtHLjWWG0N/JhRle5Eec2c0zdA==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@uniswap/router-sdk": "^1.10.0",
     "@uniswap/sdk-core": "^5.3.0",
     "@types/semver": "^7.5.8",
-    "@uniswap/smart-order-router": "3.48.0",
+    "@uniswap/smart-order-router": "3.49.0",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^3.0.2",
     "@uniswap/v2-sdk": "^4.3.2",

--- a/test/mocha/e2e/quote.test.ts
+++ b/test/mocha/e2e/quote.test.ts
@@ -21,8 +21,8 @@ import {
   USDC_NATIVE_OPTIMISM,
   USDC_NATIVE_POLYGON,
   USDT_MAINNET,
-  V4_SEPOLIA_TEST_OP,
-  V4_SEPOLIA_TEST_USDC,
+  V4_SEPOLIA_TEST_A,
+  V4_SEPOLIA_TEST_B,
   WBTC_MAINNET,
 } from '@uniswap/smart-order-router'
 import {
@@ -2485,7 +2485,7 @@ describe('quote', function () {
     [ChainId.MAINNET]: () => USDC_ON(1),
     [ChainId.GOERLI]: () => USDC_ON(ChainId.GOERLI),
     [ChainId.SEPOLIA]: () => USDC_ON(ChainId.SEPOLIA),
-    [ChainId.SEPOLIA]: () => V4_SEPOLIA_TEST_OP,
+    [ChainId.SEPOLIA]: () => V4_SEPOLIA_TEST_A,
     [ChainId.OPTIMISM]: () => USDC_ON(ChainId.OPTIMISM),
     [ChainId.OPTIMISM]: () => USDC_NATIVE_OPTIMISM,
     [ChainId.OPTIMISM_GOERLI]: () => USDC_ON(ChainId.OPTIMISM_GOERLI),
@@ -2518,7 +2518,7 @@ describe('quote', function () {
     [ChainId.MAINNET]: () => DAI_ON(1),
     [ChainId.GOERLI]: () => DAI_ON(ChainId.GOERLI),
     [ChainId.SEPOLIA]: () => DAI_ON(ChainId.SEPOLIA),
-    [ChainId.SEPOLIA]: () => V4_SEPOLIA_TEST_USDC,
+    [ChainId.SEPOLIA]: () => V4_SEPOLIA_TEST_B,
     [ChainId.OPTIMISM]: () => DAI_ON(ChainId.OPTIMISM),
     [ChainId.OPTIMISM_GOERLI]: () => DAI_ON(ChainId.OPTIMISM_GOERLI),
     [ChainId.OPTIMISM_SEPOLIA]: () => USDC_ON(ChainId.OPTIMISM_SEPOLIA),
@@ -2568,7 +2568,7 @@ describe('quote', function () {
         const wrappedNative = WNATIVE_ON(chain)
 
         it(`${wrappedNative.symbol} -> erc20`, async () => {
-          if (chain === ChainId.SEPOLIA && erc1.equals(V4_SEPOLIA_TEST_OP)) {
+          if (chain === ChainId.SEPOLIA && erc1.equals(V4_SEPOLIA_TEST_A)) {
             // there's no WETH/USDC v4 pool on Sepolia
             return
           }
@@ -2707,7 +2707,7 @@ describe('quote', function () {
           }
         })
         it(`has quoteGasAdjusted values`, async () => {
-          if (chain === ChainId.SEPOLIA) {
+          if (chain === ChainId.SEPOLIA && !erc1.equals(V4_SEPOLIA_TEST_A)) {
             // Sepolia doesn't have sufficient liquidity on DAI pools yet
             return
           }
@@ -2725,10 +2725,16 @@ describe('quote', function () {
             type,
           }
 
+          const headers = {
+            'x-universal-router-version': '2.0',
+          }
+
           const queryParams = qs.stringify(quoteReq)
 
           try {
-            const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(`${API}?${queryParams}`)
+            const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(`${API}?${queryParams}`, {
+              headers: headers,
+            })
             const {
               data: { quoteDecimals, quoteGasAdjustedDecimals },
               status,


### PR DESCRIPTION
Release https://github.com/Uniswap/smart-order-router/pull/696

Also, we should update the subgraph API url accordingly, because SOR now points to a newer deployed pool manager address.

Now we can unblock the sepolia v4 quote e2e test, that pool manager address is updated.