### PR TITLE
chore: bump sor to 3.53.0 - feat: cached routes to support native currencies

### DIFF
--- a/lib/handlers/marshalling/cached-routes-marshaller.ts
+++ b/lib/handlers/marshalling/cached-routes-marshaller.ts
@@ -1,14 +1,14 @@
 import { CachedRoutes } from '@uniswap/smart-order-router'
 import { ChainId, TradeType } from '@uniswap/sdk-core'
 import { Protocol } from '@uniswap/router-sdk'
-import { MarshalledToken, TokenMarshaller } from './token-marshaller'
+import { MarshalledCurrency, TokenMarshaller } from './token-marshaller'
 import { CachedRouteMarshaller, MarshalledCachedRoute } from './cached-route-marshaller'
 
 export interface MarshalledCachedRoutes {
   routes: MarshalledCachedRoute[]
   chainId: ChainId
-  tokenIn: MarshalledToken
-  tokenOut: MarshalledToken
+  tokenIn: MarshalledCurrency
+  tokenOut: MarshalledCurrency
   protocolsCovered: Protocol[]
   blockNumber: number
   tradeType: TradeType
@@ -21,8 +21,8 @@ export class CachedRoutesMarshaller {
     return {
       routes: cachedRoutes.routes.map((route) => CachedRouteMarshaller.marshal(route)),
       chainId: cachedRoutes.chainId,
-      tokenIn: TokenMarshaller.marshal(cachedRoutes.tokenIn),
-      tokenOut: TokenMarshaller.marshal(cachedRoutes.tokenOut),
+      tokenIn: TokenMarshaller.marshal(cachedRoutes.currencyIn),
+      tokenOut: TokenMarshaller.marshal(cachedRoutes.currencyOut),
       protocolsCovered: cachedRoutes.protocolsCovered,
       blockNumber: cachedRoutes.blockNumber,
       tradeType: cachedRoutes.tradeType,
@@ -35,8 +35,8 @@ export class CachedRoutesMarshaller {
     return new CachedRoutes({
       routes: marshalledCachedRoutes.routes.map((route) => CachedRouteMarshaller.unmarshal(route)),
       chainId: marshalledCachedRoutes.chainId,
-      tokenIn: TokenMarshaller.unmarshal(marshalledCachedRoutes.tokenIn),
-      tokenOut: TokenMarshaller.unmarshal(marshalledCachedRoutes.tokenOut),
+      currencyIn: TokenMarshaller.unmarshal(marshalledCachedRoutes.tokenIn),
+      currencyOut: TokenMarshaller.unmarshal(marshalledCachedRoutes.tokenOut),
       protocolsCovered: marshalledCachedRoutes.protocolsCovered,
       blockNumber: marshalledCachedRoutes.blockNumber,
       tradeType: marshalledCachedRoutes.tradeType,

--- a/lib/handlers/marshalling/currency-amount-marshaller.ts
+++ b/lib/handlers/marshalling/currency-amount-marshaller.ts
@@ -1,8 +1,8 @@
 import { CurrencyAmount, Token } from '@uniswap/sdk-core'
-import { MarshalledToken, TokenMarshaller } from './token-marshaller'
+import { MarshalledCurrency, TokenMarshaller } from './token-marshaller'
 
 export interface MarshalledCurrencyAmount {
-  currency: MarshalledToken
+  currency: MarshalledCurrency
   numerator: string
   denominator: string
 }

--- a/lib/handlers/marshalling/route-marshaller.ts
+++ b/lib/handlers/marshalling/route-marshaller.ts
@@ -1,6 +1,6 @@
 import { MixedRoute, V2Route, V3Route, V4Route } from '@uniswap/smart-order-router/build/main/routers'
 import { Protocol } from '@uniswap/router-sdk'
-import { MarshalledToken, TokenMarshaller } from './token-marshaller'
+import { MarshalledCurrency, TokenMarshaller } from './token-marshaller'
 import { MarshalledPair, PairMarshaller } from './pair-marshaller'
 import { MarshalledPool as V3MarshalledPool, PoolMarshaller as V3PoolMarshaller } from './v3/pool-marshaller'
 import { MarshalledPool as V4MarshalledPool, PoolMarshaller as V4PoolMarshaller } from './v4/pool-marshaller'
@@ -11,29 +11,29 @@ import { Pair } from '@uniswap/v2-sdk'
 
 export interface MarshalledV2Route {
   protocol: Protocol
-  input: MarshalledToken
-  output: MarshalledToken
+  input: MarshalledCurrency
+  output: MarshalledCurrency
   pairs: MarshalledPair[]
 }
 
 export interface MarshalledV3Route {
   protocol: Protocol
-  input: MarshalledToken
-  output: MarshalledToken
+  input: MarshalledCurrency
+  output: MarshalledCurrency
   pools: V3MarshalledPool[]
 }
 
 export interface MarshalledV4Route {
   protocol: Protocol
-  input: MarshalledToken
-  output: MarshalledToken
+  input: MarshalledCurrency
+  output: MarshalledCurrency
   pools: V4MarshalledPool[]
 }
 
 export interface MarshalledMixedRoute {
   protocol: Protocol
-  input: MarshalledToken
-  output: MarshalledToken
+  input: MarshalledCurrency
+  output: MarshalledCurrency
   pools: (V4MarshalledPool | V3MarshalledPool | MarshalledPair)[]
 }
 

--- a/lib/handlers/marshalling/token-marshaller.ts
+++ b/lib/handlers/marshalling/token-marshaller.ts
@@ -1,7 +1,8 @@
-import { Token } from '@uniswap/sdk-core'
+import { Currency, Token } from '@uniswap/sdk-core'
 import { BigNumber } from 'ethers'
+import { getAddress } from '@uniswap/smart-order-router'
 
-export interface MarshalledToken {
+export interface MarshalledCurrency {
   chainId: number
   address: string
   decimals: number
@@ -12,28 +13,28 @@ export interface MarshalledToken {
 }
 
 export class TokenMarshaller {
-  public static marshal(token: Token): MarshalledToken {
+  public static marshal(currency: Currency): MarshalledCurrency {
     return {
-      chainId: token.chainId,
-      address: token.address,
-      decimals: token.decimals,
-      symbol: token.symbol,
-      name: token.name,
-      buyFeeBps: token.buyFeeBps?.toString(),
-      sellFeeBps: token.sellFeeBps?.toString(),
+      chainId: currency.chainId,
+      address: getAddress(currency),
+      decimals: currency.decimals,
+      symbol: currency.symbol,
+      name: currency.name,
+      buyFeeBps: currency.isToken ? currency.buyFeeBps?.toString() : undefined,
+      sellFeeBps: currency.isToken ? currency.sellFeeBps?.toString() : undefined,
     }
   }
 
-  public static unmarshal(marshalledToken: MarshalledToken): Token {
+  public static unmarshal(marshalledCurrency: MarshalledCurrency): Token {
     return new Token(
-      marshalledToken.chainId,
-      marshalledToken.address,
-      marshalledToken.decimals,
-      marshalledToken.symbol,
-      marshalledToken.name,
+      marshalledCurrency.chainId,
+      marshalledCurrency.address,
+      marshalledCurrency.decimals,
+      marshalledCurrency.symbol,
+      marshalledCurrency.name,
       true, // at this point we know it's valid token address
-      marshalledToken.buyFeeBps ? BigNumber.from(marshalledToken.buyFeeBps) : undefined,
-      marshalledToken.sellFeeBps ? BigNumber.from(marshalledToken.sellFeeBps) : undefined
+      marshalledCurrency.buyFeeBps ? BigNumber.from(marshalledCurrency.buyFeeBps) : undefined,
+      marshalledCurrency.sellFeeBps ? BigNumber.from(marshalledCurrency.sellFeeBps) : undefined
     )
   }
 }

--- a/lib/handlers/marshalling/v3/pool-marshaller.ts
+++ b/lib/handlers/marshalling/v3/pool-marshaller.ts
@@ -1,12 +1,12 @@
 import { Pool } from '@uniswap/v3-sdk'
 import { FeeAmount } from '@uniswap/v3-sdk/dist/constants'
-import { MarshalledToken, TokenMarshaller } from '../token-marshaller'
+import { MarshalledCurrency, TokenMarshaller } from '../token-marshaller'
 import { Protocol } from '@uniswap/router-sdk'
 
 export interface MarshalledPool {
   protocol: Protocol
-  token0: MarshalledToken
-  token1: MarshalledToken
+  token0: MarshalledCurrency
+  token1: MarshalledCurrency
   fee: FeeAmount
   sqrtRatioX96: string
   liquidity: string

--- a/lib/handlers/marshalling/v4/pool-marshaller.ts
+++ b/lib/handlers/marshalling/v4/pool-marshaller.ts
@@ -1,12 +1,12 @@
 import { Pool } from '@uniswap/v4-sdk'
 import { FeeAmount } from '@uniswap/v3-sdk/dist/constants'
-import { MarshalledToken, TokenMarshaller } from '../token-marshaller'
+import { MarshalledCurrency, TokenMarshaller } from '../token-marshaller'
 import { Protocol } from '@uniswap/router-sdk'
 
 export interface MarshalledPool {
   protocol: Protocol
-  token0: MarshalledToken
-  token1: MarshalledToken
+  token0: MarshalledCurrency
+  token1: MarshalledCurrency
   fee: FeeAmount
   tickSpacing: number
   hooks: string

--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -140,8 +140,8 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
     const { tokenIn, tokenOut } = this.determineTokenInOut(amount, quoteToken, tradeType)
 
     const partitionKey = new PairTradeTypeChainId({
-      tokenIn: tokenIn.address,
-      tokenOut: tokenOut.address,
+      currencyIn: tokenIn.address,
+      currencyOut: tokenOut.address,
       tradeType,
       chainId,
     })
@@ -239,8 +239,8 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
     const cachedRoutes = new CachedRoutes({
       routes: Array.from(routesMap.values()),
       chainId: first.chainId,
-      tokenIn: first.tokenIn,
-      tokenOut: first.tokenOut,
+      currencyIn: first.currencyIn,
+      currencyOut: first.currencyOut,
       protocolsCovered: first.protocolsCovered,
       blockNumber,
       tradeType: first.tradeType,
@@ -331,9 +331,9 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
   ): void {
     const payload = {
       queryStringParameters: {
-        tokenInAddress: partitionKey.tokenIn,
+        tokenInAddress: partitionKey.currencyIn,
         tokenInChainId: partitionKey.chainId.toString(),
-        tokenOutAddress: partitionKey.tokenOut,
+        tokenOutAddress: partitionKey.currencyOut,
         tokenOutChainId: partitionKey.chainId.toString(),
         amount: amount.quotient.toString(),
         type: partitionKey.tradeType === 0 ? 'exactIn' : 'exactOut',
@@ -384,8 +384,8 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
       const individualCachedRoutes = new CachedRoutes({
         routes: [route],
         chainId: cachedRoutes.chainId,
-        tokenIn: cachedRoutes.tokenIn,
-        tokenOut: cachedRoutes.tokenOut,
+        currencyIn: cachedRoutes.currencyIn,
+        currencyOut: cachedRoutes.currencyOut,
         protocolsCovered: cachedRoutes.protocolsCovered,
         blockNumber: cachedRoutes.blockNumber,
         tradeType: cachedRoutes.tradeType,

--- a/lib/handlers/router-entities/route-caching/model/pair-trade-type-chain-id.ts
+++ b/lib/handlers/router-entities/route-caching/model/pair-trade-type-chain-id.ts
@@ -1,9 +1,9 @@
 import { ChainId, TradeType } from '@uniswap/sdk-core'
-import { CachedRoutes } from '@uniswap/smart-order-router'
+import { CachedRoutes, getAddress } from '@uniswap/smart-order-router'
 
 interface PairTradeTypeChainIdArgs {
-  tokenIn: string
-  tokenOut: string
+  currencyIn: string
+  currencyOut: string
   tradeType: TradeType
   chainId: ChainId
 }
@@ -12,26 +12,26 @@ interface PairTradeTypeChainIdArgs {
  * Class used to model the partition key of the CachedRoutes cache database and configuration.
  */
 export class PairTradeTypeChainId {
-  public readonly tokenIn: string
-  public readonly tokenOut: string
+  public readonly currencyIn: string
+  public readonly currencyOut: string
   public readonly tradeType: TradeType
   public readonly chainId: ChainId
 
-  constructor({ tokenIn, tokenOut, tradeType, chainId }: PairTradeTypeChainIdArgs) {
-    this.tokenIn = tokenIn.toLowerCase() // All token addresses should be lower case for normalization.
-    this.tokenOut = tokenOut.toLowerCase() // All token addresses should be lower case for normalization.
+  constructor({ currencyIn, currencyOut, tradeType, chainId }: PairTradeTypeChainIdArgs) {
+    this.currencyIn = currencyIn.toLowerCase() // All currency addresses should be lower case for normalization.
+    this.currencyOut = currencyOut.toLowerCase() // All currency addresses should be lower case for normalization.
     this.tradeType = tradeType
     this.chainId = chainId
   }
 
   public toString(): string {
-    return `${this.tokenIn}/${this.tokenOut}/${this.tradeType}/${this.chainId}`
+    return `${this.currencyIn}/${this.currencyOut}/${this.tradeType}/${this.chainId}`
   }
 
   public static fromCachedRoutes(cachedRoutes: CachedRoutes): PairTradeTypeChainId {
     return new PairTradeTypeChainId({
-      tokenIn: cachedRoutes.tokenIn.address,
-      tokenOut: cachedRoutes.tokenOut.address,
+      currencyIn: getAddress(cachedRoutes.currencyIn),
+      currencyOut: getAddress(cachedRoutes.currencyOut),
       tradeType: cachedRoutes.tradeType,
       chainId: cachedRoutes.chainId,
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.11.2",
         "@uniswap/sdk-core": "^5.4.0",
-        "@uniswap/smart-order-router": "3.52.0",
+        "@uniswap/smart-order-router": "3.53.0",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^3.0.2",
         "@uniswap/v2-sdk": "^4.3.2",
@@ -4749,9 +4749,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.52.0.tgz",
-      "integrity": "sha512-ghhAEqUflVigJ7YE9G3Ru6wtae5wdxMse5uNZbXW0pMYuepfIFpAUtDeBFISF36bQAtIutRQABFRv+upoAiFqA==",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.53.0.tgz",
+      "integrity": "sha512-Plhtcik8kR8QAagrK8DsjraZA5xGK/W+PYHBobL65zkgDZKC0RvIxIBTc6DMncUEEsjmu9lEx0cbmt66TQPpUw==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -28422,9 +28422,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.52.0.tgz",
-      "integrity": "sha512-ghhAEqUflVigJ7YE9G3Ru6wtae5wdxMse5uNZbXW0pMYuepfIFpAUtDeBFISF36bQAtIutRQABFRv+upoAiFqA==",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.53.0.tgz",
+      "integrity": "sha512-Plhtcik8kR8QAagrK8DsjraZA5xGK/W+PYHBobL65zkgDZKC0RvIxIBTc6DMncUEEsjmu9lEx0cbmt66TQPpUw==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@uniswap/router-sdk": "^1.11.2",
     "@uniswap/sdk-core": "^5.4.0",
     "@types/semver": "^7.5.8",
-    "@uniswap/smart-order-router": "3.52.0",
+    "@uniswap/smart-order-router": "3.53.0",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^3.0.2",
     "@uniswap/v2-sdk": "^4.3.2",

--- a/test/jest/unit/handlers/router-entities/route-caching/model/pair-trade-type-chain-id.test.ts
+++ b/test/jest/unit/handlers/router-entities/route-caching/model/pair-trade-type-chain-id.test.ts
@@ -9,8 +9,8 @@ describe('PairTradeTypeChainId', () => {
   describe('toString', () => {
     it('returns a stringified version of the object', () => {
       const pairTradeTypeChainId = new PairTradeTypeChainId({
-        tokenIn: WETH,
-        tokenOut: USDC,
+        currencyIn: WETH,
+        currencyOut: USDC,
         tradeType: TradeType.EXACT_INPUT,
         chainId: ChainId.MAINNET,
       })
@@ -22,8 +22,8 @@ describe('PairTradeTypeChainId', () => {
 
     it('token addresses are converted to lowercase', () => {
       const pairTradeTypeChainId = new PairTradeTypeChainId({
-        tokenIn: WETH.toUpperCase(),
-        tokenOut: USDC.toUpperCase(),
+        currencyIn: WETH.toUpperCase(),
+        currencyOut: USDC.toUpperCase(),
         tradeType: TradeType.EXACT_INPUT,
         chainId: ChainId.MAINNET,
       })
@@ -35,8 +35,8 @@ describe('PairTradeTypeChainId', () => {
 
     it('works with ExactOutput too', () => {
       const pairTradeTypeChainId = new PairTradeTypeChainId({
-        tokenIn: WETH.toUpperCase(),
-        tokenOut: USDC.toUpperCase(),
+        currencyIn: WETH.toUpperCase(),
+        currencyOut: USDC.toUpperCase(),
         tradeType: TradeType.EXACT_OUTPUT,
         chainId: ChainId.MAINNET,
       })
@@ -48,8 +48,8 @@ describe('PairTradeTypeChainId', () => {
 
     it('works with other chains', () => {
       const pairTradeTypeChainId = new PairTradeTypeChainId({
-        tokenIn: WETH.toUpperCase(),
-        tokenOut: USDC.toUpperCase(),
+        currencyIn: WETH.toUpperCase(),
+        currencyOut: USDC.toUpperCase(),
         tradeType: TradeType.EXACT_OUTPUT,
         chainId: ChainId.ARBITRUM_ONE,
       })

--- a/test/mocha/integ/handlers/router-entities/route-caching/dynamo-route-caching-provider.test.ts
+++ b/test/mocha/integ/handlers/router-entities/route-caching/dynamo-route-caching-provider.test.ts
@@ -96,8 +96,8 @@ const TEST_CACHED_ROUTE = new CachedRoute({ route: TEST_WETH_USDC_V3_ROUTE, perc
 const TEST_CACHED_ROUTES = new CachedRoutes({
   routes: [TEST_CACHED_ROUTE],
   chainId: TEST_CACHED_ROUTE.route.chainId,
-  tokenIn: WETH,
-  tokenOut: USDC_MAINNET,
+  currencyIn: WETH,
+  currencyOut: USDC_MAINNET,
   protocolsCovered: [TEST_CACHED_ROUTE.protocol],
   blockNumber: 0,
   tradeType: TradeType.EXACT_INPUT,
@@ -109,8 +109,8 @@ const TEST_UNCACHED_ROUTE = new CachedRoute({ route: TEST_UNI_USDC_ROUTE, percen
 const TEST_UNCACHED_ROUTES = new CachedRoutes({
   routes: [TEST_UNCACHED_ROUTE],
   chainId: TEST_UNCACHED_ROUTE.route.chainId,
-  tokenIn: UNI_MAINNET,
-  tokenOut: USDC_MAINNET,
+  currencyIn: UNI_MAINNET,
+  currencyOut: USDC_MAINNET,
   protocolsCovered: [TEST_UNCACHED_ROUTE.protocol],
   blockNumber: 0,
   tradeType: TradeType.EXACT_INPUT,


### PR DESCRIPTION
cached routes need to support native currency routing. This is important for v4 routing.