### PR TITLE
chore: bump sor to 3.54.0 - feat: support native currency in getting candidate pools from v4 subgraph

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.11.2",
         "@uniswap/sdk-core": "^5.4.0",
-        "@uniswap/smart-order-router": "3.53.0",
+        "@uniswap/smart-order-router": "3.54.0",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^3.0.2",
         "@uniswap/v2-sdk": "^4.3.2",
@@ -4749,9 +4749,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.53.0.tgz",
-      "integrity": "sha512-Plhtcik8kR8QAagrK8DsjraZA5xGK/W+PYHBobL65zkgDZKC0RvIxIBTc6DMncUEEsjmu9lEx0cbmt66TQPpUw==",
+      "version": "3.54.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.54.0.tgz",
+      "integrity": "sha512-ywPiebFlHRWaBisHMoN+SwSU1PnBI7AdUaoXLpk9ivnt8c3dpHbMEidRnJjFzHTkgm2sLJxrN+kxm7/oRSyzTA==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -28422,9 +28422,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.53.0.tgz",
-      "integrity": "sha512-Plhtcik8kR8QAagrK8DsjraZA5xGK/W+PYHBobL65zkgDZKC0RvIxIBTc6DMncUEEsjmu9lEx0cbmt66TQPpUw==",
+      "version": "3.54.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.54.0.tgz",
+      "integrity": "sha512-ywPiebFlHRWaBisHMoN+SwSU1PnBI7AdUaoXLpk9ivnt8c3dpHbMEidRnJjFzHTkgm2sLJxrN+kxm7/oRSyzTA==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@uniswap/router-sdk": "^1.11.2",
     "@uniswap/sdk-core": "^5.4.0",
     "@types/semver": "^7.5.8",
-    "@uniswap/smart-order-router": "3.53.0",
+    "@uniswap/smart-order-router": "3.54.0",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^3.0.2",
     "@uniswap/v2-sdk": "^4.3.2",


### PR DESCRIPTION
Release https://github.com/Uniswap/smart-order-router/pull/708