### PR TITLE
chore: bump SOR to v3.55 - feat: upgrade v3-sdk version + support additional fee tiers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.11.2",
         "@uniswap/sdk-core": "^5.4.0",
-        "@uniswap/smart-order-router": "3.54.0",
+        "@uniswap/smart-order-router": "3.55.0",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^3.0.2",
         "@uniswap/v2-sdk": "^4.3.2",
@@ -4749,9 +4749,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.54.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.54.0.tgz",
-      "integrity": "sha512-ywPiebFlHRWaBisHMoN+SwSU1PnBI7AdUaoXLpk9ivnt8c3dpHbMEidRnJjFzHTkgm2sLJxrN+kxm7/oRSyzTA==",
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.55.0.tgz",
+      "integrity": "sha512-BA0e1pttUI1cr15iBrFMVOasvfB5T7SrFSeFjudeF+gAoGTnfspzC5DY5DA623dOuHISU4ECv6aG59MtCWSNKw==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -4764,7 +4764,7 @@
         "@uniswap/universal-router": "^1.6.0",
         "@uniswap/universal-router-sdk": "^3.0.2",
         "@uniswap/v2-sdk": "^4.3.2",
-        "@uniswap/v3-sdk": "^3.13.0",
+        "@uniswap/v3-sdk": "^3.14.0",
         "@uniswap/v4-sdk": "^1.0.0",
         "async-retry": "^1.3.1",
         "await-timeout": "^1.1.1",
@@ -4921,9 +4921,9 @@
       "integrity": "sha512-W6QmqgkADuFcTLzHL8vVoNBtkwjvQRpYIAom7KiUNoLKghyx3FgH0GBjt8NRvigV1ZmMOBllvE1By1C+bi8WpA=="
     },
     "node_modules/@uniswap/v3-sdk": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/@uniswap/v3-sdk/-/v3-sdk-3.13.1.tgz",
-      "integrity": "sha512-MCc96HrUZy17DINwrGnMtCvr+yXQlWUJJVaIiRRKe1DQzSuv97/G4lzM+zAaSymrxbR2qnHHWL5vMFjmwzCN9Q==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/v3-sdk/-/v3-sdk-3.14.0.tgz",
+      "integrity": "sha512-/fnHYnCpzp8Ruwn9/Tm2Xv2oSykNajwCRwgfdD0K/2euwdlKaNCMpGqCP1XZsugLbEEemCNjFpc3i6YAk2IdYg==",
       "dependencies": {
         "@ethersproject/abi": "^5.5.0",
         "@ethersproject/solidity": "^5.0.9",
@@ -28422,9 +28422,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.54.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.54.0.tgz",
-      "integrity": "sha512-ywPiebFlHRWaBisHMoN+SwSU1PnBI7AdUaoXLpk9ivnt8c3dpHbMEidRnJjFzHTkgm2sLJxrN+kxm7/oRSyzTA==",
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.55.0.tgz",
+      "integrity": "sha512-BA0e1pttUI1cr15iBrFMVOasvfB5T7SrFSeFjudeF+gAoGTnfspzC5DY5DA623dOuHISU4ECv6aG59MtCWSNKw==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -28437,7 +28437,7 @@
         "@uniswap/universal-router": "^1.6.0",
         "@uniswap/universal-router-sdk": "^3.0.2",
         "@uniswap/v2-sdk": "^4.3.2",
-        "@uniswap/v3-sdk": "^3.13.0",
+        "@uniswap/v3-sdk": "^3.14.0",
         "@uniswap/v4-sdk": "^1.0.0",
         "async-retry": "^1.3.1",
         "await-timeout": "^1.1.1",
@@ -28566,9 +28566,9 @@
       }
     },
     "@uniswap/v3-sdk": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/@uniswap/v3-sdk/-/v3-sdk-3.13.1.tgz",
-      "integrity": "sha512-MCc96HrUZy17DINwrGnMtCvr+yXQlWUJJVaIiRRKe1DQzSuv97/G4lzM+zAaSymrxbR2qnHHWL5vMFjmwzCN9Q==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/v3-sdk/-/v3-sdk-3.14.0.tgz",
+      "integrity": "sha512-/fnHYnCpzp8Ruwn9/Tm2Xv2oSykNajwCRwgfdD0K/2euwdlKaNCMpGqCP1XZsugLbEEemCNjFpc3i6YAk2IdYg==",
       "requires": {
         "@ethersproject/abi": "^5.5.0",
         "@ethersproject/solidity": "^5.0.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@uniswap/universal-router-sdk": "^3.0.2",
         "@uniswap/v2-sdk": "^4.3.2",
         "@uniswap/v3-periphery": "^1.4.4",
-        "@uniswap/v3-sdk": "^3.13.0",
+        "@uniswap/v3-sdk": "^3.14.0",
         "async-retry": "^1.3.1",
         "aws-cdk-lib": "^2.137.0",
         "aws-embedded-metrics": "^2.0.6",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "@uniswap/universal-router-sdk": "^3.0.2",
     "@uniswap/v2-sdk": "^4.3.2",
     "@uniswap/v3-periphery": "^1.4.4",
-    "@uniswap/v3-sdk": "^3.13.0",
+    "@uniswap/v3-sdk": "^3.14.0",
     "async-retry": "^1.3.1",
     "aws-cdk-lib": "^2.137.0",
     "aws-embedded-metrics": "^2.0.6",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@uniswap/router-sdk": "^1.11.2",
     "@uniswap/sdk-core": "^5.4.0",
     "@types/semver": "^7.5.8",
-    "@uniswap/smart-order-router": "3.54.0",
+    "@uniswap/smart-order-router": "3.55.0",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^3.0.2",
     "@uniswap/v2-sdk": "^4.3.2",


### PR DESCRIPTION
Bumps SOR to v3.55 (+ v3-sdk to v3.14)
Supports additional fee tiers
Related SOR PR: https://github.com/Uniswap/smart-order-router/pull/704