### PR TITLE
chore: bump sor to 3.58.0 - chore: update v4 quoter address and ABI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.11.2",
         "@uniswap/sdk-core": "^5.4.0",
-        "@uniswap/smart-order-router": "3.57.0",
+        "@uniswap/smart-order-router": "3.58.0",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^3.0.2",
         "@uniswap/v2-sdk": "^4.3.2",
@@ -4749,9 +4749,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.57.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.57.0.tgz",
-      "integrity": "sha512-agH9B2g2TWloXThvIQufDNwVpilGporf4v28RORZGzXcNmRoYWujyEBrsV1isiRkOnYtzsyfzURpvE78BCH3vA==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.58.0.tgz",
+      "integrity": "sha512-NhRV0vWVBjRl+7KuFxIarEGNPCmtJ808+XzMd4j7mJSOeF8lQaxfJtQjy31YrbkBinT1MJXluDWVXfVx3Cos0w==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -28422,9 +28422,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.57.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.57.0.tgz",
-      "integrity": "sha512-agH9B2g2TWloXThvIQufDNwVpilGporf4v28RORZGzXcNmRoYWujyEBrsV1isiRkOnYtzsyfzURpvE78BCH3vA==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.58.0.tgz",
+      "integrity": "sha512-NhRV0vWVBjRl+7KuFxIarEGNPCmtJ808+XzMd4j7mJSOeF8lQaxfJtQjy31YrbkBinT1MJXluDWVXfVx3Cos0w==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@uniswap/router-sdk": "^1.11.2",
     "@uniswap/sdk-core": "^5.4.0",
     "@types/semver": "^7.5.8",
-    "@uniswap/smart-order-router": "3.57.0",
+    "@uniswap/smart-order-router": "3.58.0",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^3.0.2",
     "@uniswap/v2-sdk": "^4.3.2",


### PR DESCRIPTION
release https://github.com/Uniswap/smart-order-router/pull/719