### PR TITLE
chore: bump sor to 4.0.0 - feat(breaking): top-level alpha router native currencyIn, currencyIn, quoteCurrency support

### DIFF
--- a/lib/cron/cache-config.ts
+++ b/lib/cron/cache-config.ts
@@ -1,6 +1,9 @@
 import { Protocol } from '@uniswap/router-sdk'
 import { V2SubgraphProvider, V3SubgraphProvider, V4SubgraphProvider } from '@uniswap/smart-order-router'
 import { ChainId } from '@uniswap/sdk-core'
+import dotenv from 'dotenv'
+
+dotenv.config()
 
 // during local cdk stack update, the env vars are not populated
 // make sure to fill in the env vars below

--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -12,7 +12,7 @@ import {
   SupportedRoutes,
 } from '@uniswap/smart-order-router'
 import { AWSError, DynamoDB, Lambda } from 'aws-sdk'
-import { ChainId, Currency, CurrencyAmount, Fraction, Token, TradeType } from '@uniswap/sdk-core'
+import { ChainId, Currency, CurrencyAmount, Fraction, TradeType } from '@uniswap/sdk-core'
 import { Protocol } from '@uniswap/router-sdk'
 import { PairTradeTypeChainId } from './model/pair-trade-type-chain-id'
 import { CachedRoutesMarshaller } from '../../marshalling/cached-routes-marshaller'
@@ -449,14 +449,14 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
    *
    * @param _chainId
    * @param _amount
-   * @param _quoteToken
+   * @param _quoteCurrency
    * @param _tradeType
    * @param _protocols
    */
   public async getCacheMode(
     _chainId: ChainId,
     _amount: CurrencyAmount<Currency>,
-    _quoteToken: Token,
+    _quoteCurrency: Currency,
     _tradeType: TradeType,
     _protocols: Protocol[]
   ): Promise<CacheMode> {
@@ -481,7 +481,7 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
   }
 
   /**
-   * Helper function to determine the tokenIn and tokenOut given the tradeType, quoteToken and amount.currency
+   * Helper function to determine the tokenIn and tokenOut given the tradeType, quoteCurrency and amount.currency
    *
    * @param amount
    * @param quoteCurrency

--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -2,13 +2,14 @@ import {
   CachedRoute,
   CachedRoutes,
   CacheMode,
+  getAddress,
   ID_TO_NETWORK_NAME,
   IRouteCachingProvider,
   log,
   metric,
   MetricLoggerUnit,
   routeToString,
-  SupportedRoutes,
+  SupportedRoutes
 } from '@uniswap/smart-order-router'
 import { AWSError, DynamoDB, Lambda } from 'aws-sdk'
 import { ChainId, Currency, CurrencyAmount, Fraction, Token, TradeType } from '@uniswap/sdk-core'
@@ -123,7 +124,7 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
    *
    * @param chainId
    * @param amount
-   * @param quoteToken
+   * @param quoteCurrency
    * @param tradeType
    * @param _protocols
    * @protected
@@ -131,17 +132,22 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
   protected async _getCachedRoute(
     chainId: ChainId,
     amount: CurrencyAmount<Currency>,
-    quoteToken: Token,
+    quoteCurrency: Currency,
     tradeType: TradeType,
     protocols: Protocol[],
     currentBlockNumber: number,
     optimistic: boolean
   ): Promise<CachedRoutes | undefined> {
-    const { tokenIn, tokenOut } = this.determineTokenInOut(amount, quoteToken, tradeType)
+    const { currencyIn, currencyOut } = this.determineCurrencyInOut(amount, quoteCurrency, tradeType)
+    // This is for backward compatibility with the existing cached routes, that doesn't include V4, i.e.. doesn't support native currency routing
+    // If we are changing to use native currency address that doesn't have V4, we will have a temporary period of cached routes miss
+    // because frontend can still send in native currency as tokenIn/tokenOut, and we are not caching the wrapped addresses.
+    const currencyInAddress = protocols.includes(Protocol.V4) ? getAddress(currencyIn) : currencyIn.wrapped.address
+    const currencyOutAddress = protocols.includes(Protocol.V4) ? getAddress(currencyOut) : currencyOut.wrapped.address
 
     const partitionKey = new PairTradeTypeChainId({
-      currencyIn: tokenIn.address,
-      currencyOut: tokenOut.address,
+      currencyIn: currencyInAddress,
+      currencyOut: currencyOutAddress,
       tradeType,
       chainId,
     })
@@ -478,19 +484,19 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
    * Helper function to determine the tokenIn and tokenOut given the tradeType, quoteToken and amount.currency
    *
    * @param amount
-   * @param quoteToken
+   * @param quoteCurrency
    * @param tradeType
    * @private
    */
-  private determineTokenInOut(
+  private determineCurrencyInOut(
     amount: CurrencyAmount<Currency>,
-    quoteToken: Token,
+    quoteCurrency: Currency,
     tradeType: TradeType
-  ): { tokenIn: Token; tokenOut: Token } {
+  ): { currencyIn: Currency; currencyOut: Currency } {
     if (tradeType == TradeType.EXACT_INPUT) {
-      return { tokenIn: amount.currency.wrapped, tokenOut: quoteToken }
+      return { currencyIn: amount.currency, currencyOut: quoteCurrency }
     } else {
-      return { tokenIn: quoteToken, tokenOut: amount.currency.wrapped }
+      return { currencyIn: quoteCurrency, currencyOut: amount.currency }
     }
   }
 }

--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -9,7 +9,7 @@ import {
   metric,
   MetricLoggerUnit,
   routeToString,
-  SupportedRoutes
+  SupportedRoutes,
 } from '@uniswap/smart-order-router'
 import { AWSError, DynamoDB, Lambda } from 'aws-sdk'
 import { ChainId, Currency, CurrencyAmount, Fraction, Token, TradeType } from '@uniswap/sdk-core'

--- a/lib/handlers/router-entities/route-caching/model/pair-trade-type-chain-id.ts
+++ b/lib/handlers/router-entities/route-caching/model/pair-trade-type-chain-id.ts
@@ -33,8 +33,12 @@ export class PairTradeTypeChainId {
     // This is for backward compatibility with the existing cached routes, that doesn't include V4, i.e.. doesn't support native currency routing
     // If we are changing to use native currency address that doesn't have V4, we will have a temporary period of cached routes miss
     // because frontend can still send in native currency as tokenIn/tokenOut, and we are not caching the wrapped addresses.
-    const currencyInAddress = cachedRoutes.protocolsCovered.includes(Protocol.V4) ? getAddress(cachedRoutes.currencyIn) : cachedRoutes.currencyIn.wrapped.address
-    const currencyOutAddress = cachedRoutes.protocolsCovered.includes(Protocol.V4) ? getAddress(cachedRoutes.currencyIn) : cachedRoutes.currencyIn.wrapped.address
+    const currencyInAddress = cachedRoutes.protocolsCovered.includes(Protocol.V4)
+      ? getAddress(cachedRoutes.currencyIn)
+      : cachedRoutes.currencyIn.wrapped.address
+    const currencyOutAddress = cachedRoutes.protocolsCovered.includes(Protocol.V4)
+      ? getAddress(cachedRoutes.currencyIn)
+      : cachedRoutes.currencyIn.wrapped.address
 
     return new PairTradeTypeChainId({
       currencyIn: currencyInAddress,

--- a/lib/handlers/router-entities/route-caching/model/pair-trade-type-chain-id.ts
+++ b/lib/handlers/router-entities/route-caching/model/pair-trade-type-chain-id.ts
@@ -1,5 +1,6 @@
 import { ChainId, TradeType } from '@uniswap/sdk-core'
 import { CachedRoutes, getAddress } from '@uniswap/smart-order-router'
+import { Protocol } from '@uniswap/router-sdk'
 
 interface PairTradeTypeChainIdArgs {
   currencyIn: string
@@ -29,9 +30,15 @@ export class PairTradeTypeChainId {
   }
 
   public static fromCachedRoutes(cachedRoutes: CachedRoutes): PairTradeTypeChainId {
+    // This is for backward compatibility with the existing cached routes, that doesn't include V4, i.e.. doesn't support native currency routing
+    // If we are changing to use native currency address that doesn't have V4, we will have a temporary period of cached routes miss
+    // because frontend can still send in native currency as tokenIn/tokenOut, and we are not caching the wrapped addresses.
+    const currencyInAddress = cachedRoutes.protocolsCovered.includes(Protocol.V4) ? getAddress(cachedRoutes.currencyIn) : cachedRoutes.currencyIn.wrapped.address
+    const currencyOutAddress = cachedRoutes.protocolsCovered.includes(Protocol.V4) ? getAddress(cachedRoutes.currencyIn) : cachedRoutes.currencyIn.wrapped.address
+
     return new PairTradeTypeChainId({
-      currencyIn: getAddress(cachedRoutes.currencyIn),
-      currencyOut: getAddress(cachedRoutes.currencyOut),
+      currencyIn: currencyInAddress,
+      currencyOut: currencyOutAddress,
       tradeType: cachedRoutes.tradeType,
       chainId: cachedRoutes.chainId,
     })

--- a/lib/handlers/router-entities/route-caching/model/pair-trade-type-chain-id.ts
+++ b/lib/handlers/router-entities/route-caching/model/pair-trade-type-chain-id.ts
@@ -37,8 +37,8 @@ export class PairTradeTypeChainId {
       ? getAddress(cachedRoutes.currencyIn)
       : cachedRoutes.currencyIn.wrapped.address
     const currencyOutAddress = cachedRoutes.protocolsCovered.includes(Protocol.V4)
-      ? getAddress(cachedRoutes.currencyIn)
-      : cachedRoutes.currencyIn.wrapped.address
+      ? getAddress(cachedRoutes.currencyOut)
+      : cachedRoutes.currencyOut.wrapped.address
 
     return new PairTradeTypeChainId({
       currencyIn: currencyInAddress,

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.11.2",
         "@uniswap/sdk-core": "^5.4.0",
-        "@uniswap/smart-order-router": "/tmp/uniswap-smart-order-router-3.59.0-native-1.tgz",
+        "@uniswap/smart-order-router": "4.0.0",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^3.0.2",
         "@uniswap/v2-sdk": "^4.3.2",
@@ -4749,10 +4749,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.59.0-native-1",
-      "resolved": "file:../../../../tmp/uniswap-smart-order-router-3.59.0-native-1.tgz",
-      "integrity": "sha512-HvdrY63x0+7akUoK7ulBXkLVp546T2RMyaZT4XnuBw0DISiECl44hjyMYz0JZdMIarEEMfWU6QmVSQn1E03CXg==",
-      "license": "GPL",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.0.0.tgz",
+      "integrity": "sha512-3OW6ZgjQnY6RG+hiAaiPBe3Bl1t9SHeh4NqyrFET99VeiGMyUUboBCyCa1wIZEvWfasDyKSF17Zfw8XyipGdQQ==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -28423,8 +28422,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "file:/tmp/uniswap-smart-order-router-3.59.0-native-1.tgz",
-      "integrity": "sha512-HvdrY63x0+7akUoK7ulBXkLVp546T2RMyaZT4XnuBw0DISiECl44hjyMYz0JZdMIarEEMfWU6QmVSQn1E03CXg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.0.0.tgz",
+      "integrity": "sha512-3OW6ZgjQnY6RG+hiAaiPBe3Bl1t9SHeh4NqyrFET99VeiGMyUUboBCyCa1wIZEvWfasDyKSF17Zfw8XyipGdQQ==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.11.2",
         "@uniswap/sdk-core": "^5.4.0",
-        "@uniswap/smart-order-router": "3.58.0",
+        "@uniswap/smart-order-router": "/tmp/uniswap-smart-order-router-3.59.0-native-1.tgz",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^3.0.2",
         "@uniswap/v2-sdk": "^4.3.2",
@@ -4749,9 +4749,10 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.58.0.tgz",
-      "integrity": "sha512-NhRV0vWVBjRl+7KuFxIarEGNPCmtJ808+XzMd4j7mJSOeF8lQaxfJtQjy31YrbkBinT1MJXluDWVXfVx3Cos0w==",
+      "version": "3.59.0-native-1",
+      "resolved": "file:../../../../tmp/uniswap-smart-order-router-3.59.0-native-1.tgz",
+      "integrity": "sha512-HvdrY63x0+7akUoK7ulBXkLVp546T2RMyaZT4XnuBw0DISiECl44hjyMYz0JZdMIarEEMfWU6QmVSQn1E03CXg==",
+      "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -28422,9 +28423,8 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-3.58.0.tgz",
-      "integrity": "sha512-NhRV0vWVBjRl+7KuFxIarEGNPCmtJ808+XzMd4j7mJSOeF8lQaxfJtQjy31YrbkBinT1MJXluDWVXfVx3Cos0w==",
+      "version": "file:/tmp/uniswap-smart-order-router-3.59.0-native-1.tgz",
+      "integrity": "sha512-HvdrY63x0+7akUoK7ulBXkLVp546T2RMyaZT4XnuBw0DISiECl44hjyMYz0JZdMIarEEMfWU6QmVSQn1E03CXg==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@uniswap/router-sdk": "^1.11.2",
     "@uniswap/sdk-core": "^5.4.0",
     "@types/semver": "^7.5.8",
-    "@uniswap/smart-order-router": "3.58.0",
+    "@uniswap/smart-order-router": "/tmp/uniswap-smart-order-router-3.59.0-native-1.tgz",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^3.0.2",
     "@uniswap/v2-sdk": "^4.3.2",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@uniswap/router-sdk": "^1.11.2",
     "@uniswap/sdk-core": "^5.4.0",
     "@types/semver": "^7.5.8",
-    "@uniswap/smart-order-router": "/tmp/uniswap-smart-order-router-3.59.0-native-1.tgz",
+    "@uniswap/smart-order-router": "4.0.0",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^3.0.2",
     "@uniswap/v2-sdk": "^4.3.2",

--- a/test/mocha/integ/handlers/router-entities/route-caching/dynamo-route-caching-provider.test.ts
+++ b/test/mocha/integ/handlers/router-entities/route-caching/dynamo-route-caching-provider.test.ts
@@ -3,13 +3,16 @@ import chaiAsPromised from 'chai-as-promised'
 import 'reflect-metadata'
 import { setupTables } from '../../../../dbSetup'
 import { DynamoRouteCachingProvider } from '../../../../../../lib/handlers/router-entities/route-caching'
-import { Protocol } from '@uniswap/router-sdk'
-import { ChainId, CurrencyAmount, TradeType } from '@uniswap/sdk-core'
+import { ADDRESS_ZERO, Protocol } from '@uniswap/router-sdk'
+import { ChainId, CurrencyAmount, Ether, TradeType } from '@uniswap/sdk-core'
 import JSBI from 'jsbi'
 import { FeeAmount, Pool } from '@uniswap/v3-sdk'
+import { Pool as V4Pool } from '@uniswap/v4-sdk'
 import { WNATIVE_ON } from '../../../../../utils/tokens'
 import { CacheMode, CachedRoute, CachedRoutes, UNI_MAINNET, USDC_MAINNET, V3Route } from '@uniswap/smart-order-router'
 import { DynamoDBTableProps } from '../../../../../../bin/stacks/routing-database-stack'
+import { V4Route } from '@uniswap/smart-order-router/build/main/routers'
+import { TICK_SPACINGS } from '../../../../../utils/ticks'
 
 chai.use(chaiAsPromised)
 
@@ -80,6 +83,17 @@ const TEST_WETH_USDC_POOL = new Pool(
   /* tickCurrent */ -69633
 )
 
+const TEST_ETH_USDC_POOL = new V4Pool(
+  Ether.onChain(ChainId.MAINNET),
+  USDC_MAINNET,
+  FeeAmount.HIGH,
+  TICK_SPACINGS[FeeAmount.HIGH],
+  ADDRESS_ZERO,
+  /* sqrtRatio */ '2437312313659959819381354528',
+  /* liquidity */ '10272714736694327408',
+  /* tickCurrent */ -69633
+)
+
 const TEST_UNI_USDC_POOL = new Pool(
   UNI_MAINNET,
   USDC_MAINNET,
@@ -90,15 +104,28 @@ const TEST_UNI_USDC_POOL = new Pool(
 )
 
 const TEST_WETH_USDC_V3_ROUTE = new V3Route([TEST_WETH_USDC_POOL], WETH, USDC_MAINNET)
+const TEST_ETH_USDC_V4_ROUTE = new V4Route([TEST_ETH_USDC_POOL], Ether.onChain(ChainId.MAINNET), USDC_MAINNET)
 const TEST_UNI_USDC_ROUTE = new V3Route([TEST_UNI_USDC_POOL], UNI_MAINNET, USDC_MAINNET)
 
 const TEST_CACHED_ROUTE = new CachedRoute({ route: TEST_WETH_USDC_V3_ROUTE, percent: 100 })
+const TEST_CACHED_ROUTE_V4 = new CachedRoute({ route: TEST_ETH_USDC_V4_ROUTE, percent: 100 })
 const TEST_CACHED_ROUTES = new CachedRoutes({
   routes: [TEST_CACHED_ROUTE],
   chainId: TEST_CACHED_ROUTE.route.chainId,
   currencyIn: WETH,
   currencyOut: USDC_MAINNET,
   protocolsCovered: [TEST_CACHED_ROUTE.protocol],
+  blockNumber: 0,
+  tradeType: TradeType.EXACT_INPUT,
+  originalAmount: '1',
+  blocksToLive: 5,
+})
+const TEST_CACHED_NATIVE_CURRENCY_ROUTES = new CachedRoutes({
+  routes: [TEST_CACHED_ROUTE_V4],
+  chainId: TEST_CACHED_ROUTE_V4.route.chainId,
+  currencyIn: Ether.onChain(ChainId.MAINNET),
+  currencyOut: USDC_MAINNET,
+  protocolsCovered: [TEST_CACHED_ROUTE_V4.protocol],
   blockNumber: 0,
   tradeType: TradeType.EXACT_INPUT,
   originalAmount: '1',
@@ -154,6 +181,76 @@ describe('DynamoRouteCachingProvider', async () => {
       TradeType.EXACT_INPUT,
       [Protocol.V3],
       TEST_CACHED_ROUTES.blockNumber
+    )
+    expect(route).to.not.be.undefined
+  })
+
+  it('Caches routes for a native currency input without v4 protocol', async () => {
+    const currencyAmount = CurrencyAmount.fromRawAmount(
+      Ether.onChain(ChainId.MAINNET),
+      JSBI.BigInt(1 * 10 ** WETH.decimals)
+    )
+    const cacheMode = await dynamoRouteCache.getCacheMode(
+      ChainId.MAINNET,
+      currencyAmount,
+      USDC_MAINNET,
+      TradeType.EXACT_INPUT,
+      [Protocol.V3]
+    )
+    expect(cacheMode).to.equal(CacheMode.Livemode)
+
+    const insertedIntoCache = await dynamoRouteCache.setCachedRoute(TEST_CACHED_ROUTES, currencyAmount)
+    expect(insertedIntoCache).to.be.true
+
+    const cacheModeFromCachedRoutes = await dynamoRouteCache.getCacheModeFromCachedRoutes(
+      TEST_CACHED_ROUTES,
+      currencyAmount
+    )
+    expect(cacheModeFromCachedRoutes).to.equal(CacheMode.Livemode)
+
+    // Fetches route successfully from cache when it has been cached.
+    const route = await dynamoRouteCache.getCachedRoute(
+      ChainId.MAINNET,
+      currencyAmount,
+      USDC_MAINNET,
+      TradeType.EXACT_INPUT,
+      [Protocol.V3],
+      TEST_CACHED_ROUTES.blockNumber
+    )
+    expect(route).to.not.be.undefined
+  })
+
+  it('Caches routes for a native currency input with v4 protocol', async () => {
+    const currencyAmount = CurrencyAmount.fromRawAmount(
+      Ether.onChain(ChainId.MAINNET),
+      JSBI.BigInt(1 * 10 ** WETH.decimals)
+    )
+    const cacheMode = await dynamoRouteCache.getCacheMode(
+      ChainId.MAINNET,
+      currencyAmount,
+      USDC_MAINNET,
+      TradeType.EXACT_INPUT,
+      [Protocol.V4]
+    )
+    expect(cacheMode).to.equal(CacheMode.Livemode)
+
+    const insertedIntoCache = await dynamoRouteCache.setCachedRoute(TEST_CACHED_NATIVE_CURRENCY_ROUTES, currencyAmount)
+    expect(insertedIntoCache).to.be.true
+
+    const cacheModeFromCachedRoutes = await dynamoRouteCache.getCacheModeFromCachedRoutes(
+      TEST_CACHED_NATIVE_CURRENCY_ROUTES,
+      currencyAmount
+    )
+    expect(cacheModeFromCachedRoutes).to.equal(CacheMode.Livemode)
+
+    // Fetches route successfully from cache when it has been cached.
+    const route = await dynamoRouteCache.getCachedRoute(
+      ChainId.MAINNET,
+      currencyAmount,
+      USDC_MAINNET,
+      TradeType.EXACT_INPUT,
+      [Protocol.V4],
+      TEST_CACHED_NATIVE_CURRENCY_ROUTES.blockNumber
     )
     expect(route).to.not.be.undefined
   })


### PR DESCRIPTION
Release https://github.com/Uniswap/smart-order-router/pull/721.

I ran all the e2e tests against local routing-api instance, and saw that the cached routes hit rate is still significantly higher than miss rate, which gives me the confidence the change is working as expected:

![Screenshot 2024-09-24 at 11.40.35 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/fb13e530-8623-4d78-8253-aa9e78b72f43.png)

