### PR TITLE
feat: expose price impact in routing-api response

### DIFF
--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -477,7 +477,8 @@ export class QuoteHandler extends APIGLambdaHandler<
       blockNumber,
       simulationStatus,
       hitsCachedRoute,
-      portionAmount: outputPortionAmount, // TODO: name it back to portionAmount
+      portionAmount: outputPortionAmount, // TODO: name it back to portionAmount,
+      trade,
     } = swapRoute
 
     const estimatedGasUsed = adhocCorrectGasUsed(preProcessedEstimatedGasUsed, chainId, requestSource)
@@ -682,6 +683,7 @@ export class QuoteHandler extends APIGLambdaHandler<
       portionRecipient: outputPortionAmount && portionRecipient,
       portionAmount: outputPortionAmount?.quotient.toString(),
       portionAmountDecimals: outputPortionAmount?.toExact(),
+      priceImpact: trade?.priceImpact?.toFixed(),
     }
 
     this.logRouteMetrics(

--- a/lib/handlers/schema.ts
+++ b/lib/handlers/schema.ts
@@ -89,6 +89,7 @@ export const QuoteResponseSchemaJoi = Joi.object().keys({
   portionRecipient: Joi.string().optional(),
   portionAmount: Joi.string().optional(),
   portionAmountDecimals: Joi.string().optional(),
+  priceImpact: Joi.string().optional(),
 })
 
 export type QuoteResponse = {
@@ -119,4 +120,5 @@ export type QuoteResponse = {
   portionRecipient?: string
   portionAmount?: string
   portionAmountDecimals?: string
+  priceImpact?: string
 }

--- a/test/mocha/e2e/quote.test.ts
+++ b/test/mocha/e2e/quote.test.ts
@@ -1,6 +1,6 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { AllowanceTransfer, PermitSingle } from '@uniswap/permit2-sdk'
-import { ChainId, Currency, CurrencyAmount, Ether, Fraction, Percent, Rounding, Token, WETH9 } from '@uniswap/sdk-core'
+import { ChainId, Currency, CurrencyAmount, Ether, Fraction, Rounding, Token, WETH9 } from '@uniswap/sdk-core'
 import {
   CEUR_CELO,
   CEUR_CELO_ALFAJORES,

--- a/test/mocha/e2e/quote.test.ts
+++ b/test/mocha/e2e/quote.test.ts
@@ -1,6 +1,6 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { AllowanceTransfer, PermitSingle } from '@uniswap/permit2-sdk'
-import { ChainId, Currency, CurrencyAmount, Ether, Fraction, Rounding, Token, WETH9 } from '@uniswap/sdk-core'
+import { ChainId, Currency, CurrencyAmount, Ether, Fraction, Percent, Rounding, Token, WETH9 } from '@uniswap/sdk-core'
 import {
   CEUR_CELO,
   CEUR_CELO_ALFAJORES,
@@ -356,13 +356,15 @@ describe('quote', function () {
 
             const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(`${API}?${queryParams}`)
             const {
-              data: { quote, quoteDecimals, quoteGasAdjustedDecimals, methodParameters },
+              data: { quote, quoteDecimals, quoteGasAdjustedDecimals, methodParameters, priceImpact },
               status,
             } = response
 
             expect(status).to.equal(200)
             expect(parseFloat(quoteDecimals)).to.be.greaterThan(90)
             expect(parseFloat(quoteDecimals)).to.be.lessThan(110)
+
+            expect(Number(priceImpact)).to.be.greaterThan(0)
 
             if (type == 'exactIn') {
               expect(parseFloat(quoteGasAdjustedDecimals)).to.be.lessThanOrEqual(parseFloat(quoteDecimals))


### PR DESCRIPTION
expose price impact for classic route, so that URA can cross compare against UniswapX quote.