### PR TITLE
fix: blast eth -> blast blast quote timeout

### DIFF
--- a/lib/handlers/shared.ts
+++ b/lib/handlers/shared.ts
@@ -46,7 +46,7 @@ export const DEFAULT_ROUTING_CONFIG_BY_CHAIN = (chainId: ChainId): AlphaRouterCo
         maxSplits: 3,
         distributionPercent: 10,
         forceCrossProtocol: false,
-      };
+      }
     case ChainId.BASE:
     case ChainId.OPTIMISM:
       return {

--- a/lib/handlers/shared.ts
+++ b/lib/handlers/shared.ts
@@ -15,6 +15,38 @@ export const SECONDS_PER_BLOCK_BY_CHAIN_ID: { [chainId in ChainId]?: number } = 
 
 export const DEFAULT_ROUTING_CONFIG_BY_CHAIN = (chainId: ChainId): AlphaRouterConfig => {
   switch (chainId) {
+    case ChainId.BLAST:
+      return {
+        v2PoolSelection: {
+          topN: 3,
+          topNDirectSwaps: 1,
+          topNTokenInOut: 5,
+          topNSecondHop: 2,
+          topNWithEachBaseToken: 2,
+          topNWithBaseToken: 6,
+        },
+        v3PoolSelection: {
+          topN: 2,
+          topNDirectSwaps: 2,
+          topNTokenInOut: 2,
+          topNSecondHop: 1,
+          topNWithEachBaseToken: 3,
+          topNWithBaseToken: 3,
+        },
+        v4PoolSelection: {
+          topN: 2,
+          topNDirectSwaps: 2,
+          topNTokenInOut: 2,
+          topNSecondHop: 1,
+          topNWithEachBaseToken: 3,
+          topNWithBaseToken: 3,
+        },
+        maxSwapsPerPath: 3,
+        minSplits: 1,
+        maxSplits: 3,
+        distributionPercent: 10,
+        forceCrossProtocol: false,
+      };
     case ChainId.BASE:
     case ChainId.OPTIMISM:
       return {


### PR DESCRIPTION
On blast, ETH -> Blast consistently cannot get quote. This is because this quote requires split routes in routing, therefore routing lambda timed out:

![Screenshot 2024-09-26 at 4.58.25 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/39012f88-ca2f-47a9-8fa8-d00d0cc2fc5e.png)

From the screenshot, I can see the best rout is a 3 split route for this quote. So that I can just have max split of 3, instead of 7. I verify this via a special `debugRoutingConfig` field against prod quote endpoint, therefore it would override maxSplit of 7 in this request runtime:

```
curl 'https://interface.gateway.uniswap.org/v2/quote' \
  -H 'origin: https://app.uniswap.org' \
  --data-raw '{
   "tokenInChainId":81457,
   "tokenIn":"ETH",
   "tokenOutChainId":81457,
   "tokenOut":"0xb1a5700fA2358173Fe465e6eA4Ff52E36e88E2ad",
   "amount":"1000000000000000000",
   "type":"EXACT_INPUT",
   "configs":[
      {
         "protocols":[
            "V2",
            "V3",
            "MIXED"
         ],
         "routingType":"CLASSIC",
         "unicornSecret":"INTENTIONALL_MASKED",
         "debugRoutingConfig": "{\"maxSplits\":3}",
         "enableUniversalRouter": true,
         "simulateFromAddress": "0x6B44ba0a126a2A1a8aa6cD1AdeeD002e141Bcd44"
       }
   ]
}'
{"routing":"CLASSIC","quote":{"methodParameters":{"calldata":"0x24856bc30000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000050b00000004000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000500000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000024000000000000000000000000000000000000000000000000000000000000003600000000000000000000000000000000000000000000000000000000000000480000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000de0b6b3a76400000000000000000000000000000000000000000000000000000000000000000120000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000004db7325476300000000000000000000000000000000000000000000000010017588e8d3a789bd7d00000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004243000000000000000000000000000000000000040001f44300000000000000000000000000000000000003002710b1a5700fa2358173fe465e6ea4ff52e36e88e2ad0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000004db7325476300000000000000000000000000000000000000000000000010ec67b630d5302443ad00000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002b4300000000000000000000000000000000000004000bb8b1a5700fa2358173fe465e6ea4ff52e36e88e2ad000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000429d069189e0000000000000000000000000000000000000000000000000d5629dc4db7d3e2771c00000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002b4300000000000000000000000000000000000004002710b1a5700fa2358173fe465e6ea4ff52e36e88e2ad0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000060000000000000000000000000b1a5700fa2358173fe465e6ea4ff52e36e88e2ad0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000002e44071b6760ab907846","value":"0x0de0b6b3a7640000","to":"0x643770E279d5D0733F21d6DC03A8efbABf3255B4"},"blockNumber":"9293928","amount":"1000000000000000000","amountDecimals":"1","quote":"219576167670291776211005","quoteDecimals":"219576.167670291776211005","quoteGasAdjusted":"219575955031611030862155","quoteGasAdjustedDecimals":"219575.955031611030862155","gasUseEstimateQuote":"212638680745348849","gasUseEstimateQuoteDecimals":"0.212638680745348849","gasUseEstimate":"656814","gasUseEstimateUSD":"0.002262498656780378","simulationStatus":"INSUFFICIENT_BALANCE","simulationError":false,"gasPriceWei":"1086291","route":[[{"type":"v3-pool","address":"0xf5A23bDD36a56EDe75D503F6f643d5eaF25B1a8F","tokenIn":{"chainId":81457,"decimals":"18","address":"0x4300000000000000000000000000000000000004","symbol":"WETH"},"tokenOut":{"chainId":81457,"decimals":"18","address":"0x4300000000000000000000000000000000000003","symbol":"USDB"},"fee":"500","liquidity":"1122150473924334622669","sqrtRatioX96":"1544176764435203736766387044","tickCurrent":"-78761","amountIn":"350000000000000000"},{"type":"v3-pool","address":"0x85287626E78602d0DA569332e419154B0bdeA035","tokenIn":{"chainId":81457,"decimals":"18","address":"0x4300000000000000000000000000000000000003","symbol":"USDB"},"tokenOut":{"chainId":81457,"decimals":"18","address":"0xb1a5700fA2358173Fe465e6eA4Ff52E36e88E2ad","symbol":"BLAST"},"fee":"10000","liquidity":"73397763780592865149076","sqrtRatioX96":"773508595070429709977288868080","tickCurrent":"45574","amountOut":"75962703643808465002751"}],[{"type":"v3-pool","address":"0x1cF4Cfc7a984A474ab03F444CcEdB30C3aE6f56c","tokenIn":{"chainId":81457,"decimals":"18","address":"0x4300000000000000000000000000000000000004","symbol":"WETH"},"tokenOut":{"chainId":81457,"decimals":"18","address":"0xb1a5700fA2358173Fe465e6eA4Ff52E36e88E2ad","symbol":"BLAST"},"fee":"3000","liquidity":"10736290066596042156316","sqrtRatioX96":"39621679228116925766806289499434","tickCurrent":"124302","amountIn":"350000000000000000","amountOut":"80318362384341807564435"}],[{"type":"v3-pool","address":"0x57529f9E2a23CC53Fc387B162d2aB0F1dF3Ed701","tokenIn":{"chainId":81457,"decimals":"18","address":"0x4300000000000000000000000000000000000004","symbol":"WETH"},"tokenOut":{"chainId":81457,"decimals":"18","address":"0xb1a5700fA2358173Fe465e6eA4Ff52E36e88E2ad","symbol":"BLAST"},"fee":"10000","liquidity":"28646518643054398879","sqrtRatioX96":"39610717986642837002097595061505","tickCurrent":"124296","amountIn":"300000000000000000","amountOut":"63295101642141503643819"}]],"routeString":"[V3] 35.00% = WETH -- 0.05% [0xf5A23bDD36a56EDe75D503F6f643d5eaF25B1a8F]USDB -- 1% [0x85287626E78602d0DA569332e419154B0bdeA035]BLAST, [V3] 35.00% = WETH -- 0.3% [0x1cF4Cfc7a984A474ab03F444CcEdB30C3aE6f56c]BLAST, [V3] 30.00% = WETH -- 1% [0x57529f9E2a23CC53Fc387B162d2aB0F1dF3Ed701]BLAST","quoteId":"a3cee87b-20b0-44f1-9484-aa58a972a28f","hitsCachedRoutes":true,"priceImpact":"12.29","requestId":"c366b6b2-dc5b-46fd-94c7-0f79b607ad9a","tradeType":"EXACT_INPUT","slippage":0.5},"requestId":"c366b6b2-dc5b-46fd-94c7-0f79b607ad9a","allQuotes":[{"routing":"CLASSIC","quote":{"methodParameters":{"calldata":"0x24856bc30000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000050b00000004000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000500000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000024000000000000000000000000000000000000000000000000000000000000003600000000000000000000000000000000000000000000000000000000000000480000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000de0b6b3a76400000000000000000000000000000000000000000000000000000000000000000120000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000004db7325476300000000000000000000000000000000000000000000000010017588e8d3a789bd7d00000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004243000000000000000000000000000000000000040001f44300000000000000000000000000000000000003002710b1a5700fa2358173fe465e6ea4ff52e36e88e2ad0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000004db7325476300000000000000000000000000000000000000000000000010ec67b630d5302443ad00000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002b4300000000000000000000000000000000000004000bb8b1a5700fa2358173fe465e6ea4ff52e36e88e2ad000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000429d069189e0000000000000000000000000000000000000000000000000d5629dc4db7d3e2771c00000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002b4300000000000000000000000000000000000004002710b1a5700fa2358173fe465e6ea4ff52e36e88e2ad0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000060000000000000000000000000b1a5700fa2358173fe465e6ea4ff52e36e88e2ad0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000002e44071b6760ab907846","value":"0x0de0b6b3a7640000","to":"0x643770E279d5D0733F21d6DC03A8efbABf3255B4"},"blockNumber":"9293928","amount":"1000000000000000000","amountDecimals":"1","quote":"219576167670291776211005","quoteDecimals":"219576.167670291776211005","quoteGasAdjusted":"219575955031611030862155","quoteGasAdjustedDecimals":"219575.955031611030862155","gasUseEstimateQuote":"212638680745348849","gasUseEstimateQuoteDecimals":"0.212638680745348849","gasUseEstimate":"656814","gasUseEstimateUSD":"0.002262498656780378","simulationStatus":"INSUFFICIENT_BALANCE","simulationError":false,"gasPriceWei":"1086291","route":[[{"type":"v3-pool","address":"0xf5A23bDD36a56EDe75D503F6f643d5eaF25B1a8F","tokenIn":{"chainId":81457,"decimals":"18","address":"0x4300000000000000000000000000000000000004","symbol":"WETH"},"tokenOut":{"chainId":81457,"decimals":"18","address":"0x4300000000000000000000000000000000000003","symbol":"USDB"},"fee":"500","liquidity":"1122150473924334622669","sqrtRatioX96":"1544176764435203736766387044","tickCurrent":"-78761","amountIn":"350000000000000000"},{"type":"v3-pool","address":"0x85287626E78602d0DA569332e419154B0bdeA035","tokenIn":{"chainId":81457,"decimals":"18","address":"0x4300000000000000000000000000000000000003","symbol":"USDB"},"tokenOut":{"chainId":81457,"decimals":"18","address":"0xb1a5700fA2358173Fe465e6eA4Ff52E36e88E2ad","symbol":"BLAST"},"fee":"10000","liquidity":"73397763780592865149076","sqrtRatioX96":"773508595070429709977288868080","tickCurrent":"45574","amountOut":"75962703643808465002751"}],[{"type":"v3-pool","address":"0x1cF4Cfc7a984A474ab03F444CcEdB30C3aE6f56c","tokenIn":{"chainId":81457,"decimals":"18","address":"0x4300000000000000000000000000000000000004","symbol":"WETH"},"tokenOut":{"chainId":81457,"decimals":"18","address":"0xb1a5700fA2358173Fe465e6eA4Ff52E36e88E2ad","symbol":"BLAST"},"fee":"3000","liquidity":"10736290066596042156316","sqrtRatioX96":"39621679228116925766806289499434","tickCurrent":"124302","amountIn":"350000000000000000","amountOut":"80318362384341807564435"}],[{"type":"v3-pool","address":"0x57529f9E2a23CC53Fc387B162d2aB0F1dF3Ed701","tokenIn":{"chainId":81457,"decimals":"18","address":"0x4300000000000000000000000000000000000004","symbol":"WETH"},"tokenOut":{"chainId":81457,"decimals":"18","address":"0xb1a5700fA2358173Fe465e6eA4Ff52E36e88E2ad","symbol":"BLAST"},"fee":"10000","liquidity":"28646518643054398879","sqrtRatioX96":"39610717986642837002097595061505","tickCurrent":"124296","amountIn":"300000000000000000","amountOut":"63295101642141503643819"}]],"routeString":"[V3] 35.00% = WETH -- 0.05% [0xf5A23bDD36a56EDe75D503F6f643d5eaF25B1a8F]USDB -- 1% [0x85287626E78602d0DA569332e419154B0bdeA035]BLAST, [V3] 35.00% = WETH -- 0.3% [0x1cF4Cfc7a984A474ab03F444CcEdB30C3aE6f56c]BLAST, [V3] 30.00% = WETH -- 1% [0x57529f9E2a23CC53Fc387B162d2aB0F1dF3Ed701]BLAST","quoteId":"a3cee87b-20b0-44f1-9484-aa58a972a28f","hitsCachedRoutes":true,"priceImpact":"12.29","requestId":"c366b6b2-dc5b-46fd-94c7-0f79b607ad9a","tradeType":"EXACT_INPUT","slippage":0.5}}]}%                                                                       
```

And to cross-check, max split of 4 will not get quote back:

```
curl 'https://interface.gateway.uniswap.org/v2/quote' \
  -H 'origin: https://app.uniswap.org' \
  --data-raw '{
   "tokenInChainId":81457,
   "tokenIn":"ETH",
   "tokenOutChainId":81457,
   "tokenOut":"0xb1a5700fA2358173Fe465e6eA4Ff52E36e88E2ad",
   "amount":"1000000000000000000",
   "type":"EXACT_INPUT",
   "configs":[
      {
         "protocols":[
            "V2",
            "V3",
            "MIXED"
         ],
         "routingType":"CLASSIC",
         "unicornSecret":"INTENTIONALLY_MASKED",
         "debugRoutingConfig": "{\"maxSplits\":4}",
         "enableUniversalRouter": true,
         "simulateFromAddress": "0x6B44ba0a126a2A1a8aa6cD1AdeeD002e141Bcd44"
       }
   ]
}'
{"errorCode":"QUOTE_ERROR","detail":"Request failed with status code 502","id":"1d384726-fec3-44ad-a8cf-4e352a7afdfc"}%                                
```

As long as the dev knows the unicornSecret value, they can hit the prod endpoint with overridable routing configs. This gives me confidence that max split of 3 will work in prod.

Note this config is straight from https://github.com/Uniswap/smart-order-router/blob/main/src/routers/alpha-router/config.ts#L15, the only difference is the max split.