### PR TITLE
chore: bump sor to 4.3.1

### DIFF
--- a/lib/handlers/quote/injector.ts
+++ b/lib/handlers/quote/injector.ts
@@ -37,7 +37,7 @@ export class QuoteHandlerInjector extends InjectorSOR<
     // All other requests will only log warnings and errors.
     // Note that we use WARN as a default rather than ERROR
     // to capture Tapcompare logs in the smart-order-router.
-    const logLevel = Math.random() < 0.1 ? bunyan.DEBUG : bunyan.DEBUG
+    const logLevel = Math.random() < 0.1 ? bunyan.INFO : bunyan.WARN
 
     const {
       tokenInAddress,

--- a/lib/handlers/quote/injector.ts
+++ b/lib/handlers/quote/injector.ts
@@ -37,7 +37,7 @@ export class QuoteHandlerInjector extends InjectorSOR<
     // All other requests will only log warnings and errors.
     // Note that we use WARN as a default rather than ERROR
     // to capture Tapcompare logs in the smart-order-router.
-    const logLevel = Math.random() < 0.1 ? bunyan.INFO : bunyan.WARN
+    const logLevel = Math.random() < 0.1 ? bunyan.DEBUG : bunyan.DEBUG
 
     const {
       tokenInAddress,

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.12.1",
         "@uniswap/sdk-core": "^5.4.0",
-        "@uniswap/smart-order-router": "4.3.0",
+        "@uniswap/smart-order-router": "4.3.1",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^3.1.2",
         "@uniswap/v2-sdk": "^4.3.2",
@@ -4750,9 +4750,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.3.0.tgz",
-      "integrity": "sha512-JdQfi2yKcZRwHrfze+AxnNgXPfAxcIBEiaGzgo1NIEO3WOouTM71MhXuSUm3603FOPVzqJLxCzL3bdLVVCEFbw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.3.1.tgz",
+      "integrity": "sha512-Y66sTtt89v4FNbXEvce6BEMXvTVJWOJ2iEQgTMtwZY940f664z70s3XQBoeyFf644QFfe8w0NQ6BqDfUvCkXIw==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -28449,9 +28449,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.3.0.tgz",
-      "integrity": "sha512-JdQfi2yKcZRwHrfze+AxnNgXPfAxcIBEiaGzgo1NIEO3WOouTM71MhXuSUm3603FOPVzqJLxCzL3bdLVVCEFbw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.3.1.tgz",
+      "integrity": "sha512-Y66sTtt89v4FNbXEvce6BEMXvTVJWOJ2iEQgTMtwZY940f664z70s3XQBoeyFf644QFfe8w0NQ6BqDfUvCkXIw==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@uniswap/router-sdk": "^1.12.1",
     "@uniswap/sdk-core": "^5.4.0",
     "@types/semver": "^7.5.8",
-    "@uniswap/smart-order-router": "4.3.0",
+    "@uniswap/smart-order-router": "4.3.1",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^3.1.2",
     "@uniswap/v2-sdk": "^4.3.2",


### PR DESCRIPTION
chore: bump sor to 4.3.1

chore: bump sor 4.3.1 - fix: v4 subgraph not properly including native currency in v4 candidate pools

added ETH -> erc20 e2e quote test:
exact in https://app.warp.dev/block/TI4zj5GnBdCprZ4bZPJW2T
exact out https://app.warp.dev/block/iV65PwxmKtisG8leGNcwTn