### PR TITLE
fix: hardcode worldchain and astrochain gas limit

### DIFF
--- a/lib/util/estimateGasUsed.ts
+++ b/lib/util/estimateGasUsed.ts
@@ -1,6 +1,11 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { ChainId } from '@uniswap/sdk-core'
-import { CELO_UPPER_SWAP_GAS_LIMIT, ZKSYNC_UPPER_SWAP_GAS_LIMIT } from './gasLimit'
+import {
+  ASTROCHAIN_SEPOLIA_UPPER_SWAP_GAS_LIMIT,
+  CELO_UPPER_SWAP_GAS_LIMIT,
+  WORLDCHAIN_UPPER_SWAP_GAS_LIMIT,
+  ZKSYNC_UPPER_SWAP_GAS_LIMIT,
+} from './gasLimit'
 
 export function adhocCorrectGasUsed(estimatedGasUsed: BigNumber, chainId: ChainId, requestSource: string): BigNumber {
   const isMobileRequest = ['uniswap-ios', 'uniswap-android'].includes(requestSource)
@@ -28,6 +33,22 @@ export function adhocCorrectGasUsed(estimatedGasUsed: BigNumber, chainId: ChainI
       }
 
       return CELO_UPPER_SWAP_GAS_LIMIT
+    case ChainId.WORLDCHAIN:
+      if (estimatedGasUsed.gt(WORLDCHAIN_UPPER_SWAP_GAS_LIMIT)) {
+        // this is a check to ensure that we don't return the gas used smaller than upper swap gas limit,
+        // although this is unlikely
+        return estimatedGasUsed
+      }
+
+      return WORLDCHAIN_UPPER_SWAP_GAS_LIMIT
+    case ChainId.ASTROCHAIN_SEPOLIA:
+      if (estimatedGasUsed.gt(ASTROCHAIN_SEPOLIA_UPPER_SWAP_GAS_LIMIT)) {
+        // this is a check to ensure that we don't return the gas used smaller than upper swap gas limit,
+        // although this is unlikely
+        return estimatedGasUsed
+      }
+
+      return ASTROCHAIN_SEPOLIA_UPPER_SWAP_GAS_LIMIT
     default:
       return estimatedGasUsed
   }

--- a/lib/util/gasLimit.ts
+++ b/lib/util/gasLimit.ts
@@ -3,3 +3,7 @@ import { BigNumber } from '@ethersproject/bignumber'
 export const ZKSYNC_UPPER_SWAP_GAS_LIMIT = BigNumber.from(6000000)
 // CELO high gas limit from SOR https://github.com/Uniswap/smart-order-router/blob/main/src/routers/alpha-router/alpha-router.ts#L670
 export const CELO_UPPER_SWAP_GAS_LIMIT = BigNumber.from(5000000)
+// https://github.com/Uniswap/routing-api/blob/fe410751985995cb2904837e24f22da7dca1f518/lib/util/onChainQuoteProviderConfigs.ts#L340 divivde by 10
+export const WORLDCHAIN_UPPER_SWAP_GAS_LIMIT = BigNumber.from(300000)
+// https://github.com/Uniswap/routing-api/blob/fe410751985995cb2904837e24f22da7dca1f518/lib/util/onChainQuoteProviderConfigs.ts#L344 divivde by 10
+export const ASTROCHAIN_SEPOLIA_UPPER_SWAP_GAS_LIMIT = BigNumber.from(300000)


### PR DESCRIPTION
worldchain astrochain not supported on tenderly. we have to hardcode a higher gas limit, so that wallet and trading-api doesn't hit gas issue when submitting swap.