### PR TITLE
feat(unirpc): onboard all chains at 1/5/10%

### DIFF
--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -4,18 +4,18 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.1,
     "healthCheckSampleProb": 0.1,
-    "providerInitialWeights": [1],
-    "providerUrls": ["QUICKNODE_42220"],
-    "providerNames": ["QUICKNODE"]
+    "providerInitialWeights": [0.9, 0.1],
+    "providerUrls": ["QUICKNODE_42220", "UNIRPC_0"],
+    "providerNames": ["QUICKNODE", "UNIRPC"]
   },
   {
     "chainId": 43114,
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.1,
     "healthCheckSampleProb": 0.1,
-    "providerInitialWeights": [1],
-    "providerUrls": ["QUICKNODE_43114"],
-    "providerNames": ["QUICKNODE"]
+    "providerInitialWeights": [0.9, 0.1],
+    "providerUrls": ["QUICKNODE_43114", "UNIRPC_0"],
+    "providerNames": ["QUICKNODE", "UNIRPC"]
   },
   {
     "chainId": 56,
@@ -31,18 +31,18 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.1,
     "healthCheckSampleProb": 0.01,
-    "providerInitialWeights": [1],
-    "providerUrls": ["QUICKNODE_10"],
-    "providerNames": ["QUICKNODE"]
+    "providerInitialWeights": [0.9, 0.1],
+    "providerUrls": ["QUICKNODE_10", "UNIRPC_0"],
+    "providerNames": ["QUICKNODE", "UNIRPC"]
   },
   {
     "chainId": 11155111,
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.01,
     "healthCheckSampleProb": 0.01,
-    "providerInitialWeights": [1],
-    "providerUrls": ["ALCHEMY_11155111"],
-    "providerNames": ["ALCHEMY"],
+    "providerInitialWeights": [0.9, 0.1],
+    "providerUrls": ["ALCHEMY_11155111", "UNIRPC_0"],
+    "providerNames": ["ALCHEMY", "UNIRPC"],
     "enableDbSync": true
   },
   {
@@ -50,63 +50,63 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.25,
     "healthCheckSampleProb": 0.005,
-    "providerInitialWeights": [1],
-    "providerUrls": ["QUICKNODE_137"],
-    "providerNames": ["QUICKNODE"]
+    "providerInitialWeights": [0.9, 0.1],
+    "providerUrls": ["QUICKNODE_137", "UNIRPC_0"],
+    "providerNames": ["QUICKNODE", "UNIRPC"]
   },
   {
     "chainId": 42161,
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.1,
     "healthCheckSampleProb": 0.002,
-    "providerInitialWeights": [1],
-    "providerUrls": ["QUICKNODE_42161"],
-    "providerNames": ["QUICKNODE"]
+    "providerInitialWeights": [0.95, 0.05],
+    "providerUrls": ["QUICKNODE_42161", "UNIRPC_0"],
+    "providerNames": ["QUICKNODE", "UNIRPC"]
   },
   {
     "chainId": 8453,
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.05,
     "healthCheckSampleProb": 0.0005,
-    "providerInitialWeights": [1],
-    "providerUrls": ["QUICKNODE_8453"],
-    "providerNames": ["QUICKNODE"]
+    "providerInitialWeights": [0.95, 0.05],
+    "providerUrls": ["QUICKNODE_8453", "UNIRPC_0"],
+    "providerNames": ["QUICKNODE", "UNIRPC"]
   },
   {
     "chainId": 1,
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.05,
     "healthCheckSampleProb": 0.001,
-    "providerInitialWeights": [1, 0],
-    "providerUrls": ["QUICKNODE_1", "QUICKNODERETH_1"],
-    "providerNames": ["QUICKNODE", "QUICKNODERETH"]
+    "providerInitialWeights": [0.99, 0.01, 0],
+    "providerUrls": ["QUICKNODE_1", "UNIRPC_0", "QUICKNODERETH_1"],
+    "providerNames": ["QUICKNODE", "UNIRPC", "QUICKNODERETH"]
   },
   {
     "chainId": 81457,
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.001,
     "healthCheckSampleProb": 0.001,
-    "providerInitialWeights": [1],
-    "providerUrls": ["QUICKNODE_81457"],
-    "providerNames": ["QUICKNODE"]
+    "providerInitialWeights": [0.9, 0.1],
+    "providerUrls": ["QUICKNODE_81457", "UNIRPC_0"],
+    "providerNames": ["QUICKNODE", "UNIRPC"]
   },
   {
     "chainId": 7777777,
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.001,
     "healthCheckSampleProb": 0.001,
-    "providerInitialWeights": [1],
-    "providerUrls": ["QUICKNODE_7777777"],
-    "providerNames": ["QUICKNODE"]
+    "providerInitialWeights": [0.9, 0.1],
+    "providerUrls": ["QUICKNODE_7777777", "UNIRPC_0"],
+    "providerNames": ["QUICKNODE", "UNIRPC"]
   },
   {
     "chainId": 324,
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.01,
     "healthCheckSampleProb": 0.01,
-    "providerInitialWeights": [1],
-    "providerUrls": ["QUICKNODE_324"],
-    "providerNames": ["QUICKNODE"]
+    "providerInitialWeights": [0.9, 0.1],
+    "providerUrls": ["QUICKNODE_324", "UNIRPC_0"],
+    "providerNames": ["QUICKNODE", "UNIRPC"]
   },
   {
     "chainId": 480,


### PR DESCRIPTION
Continue `unirpc` onboarding for routing API for all chains
BNB 10% traffic has been running on unirpc at 10% for ~2 weeks without issues.

This PR onboard all other chains as follows:
- **high volume** chains at `1%` (`Mainnet`)
- **mid volume** chains at `5%` (`Base, Arbitrum`)
- **low volume** chains at `10%` (all the rest)

Plan to monitor for a few days, then increase further.

Tested on private AWS + E2E tests with unirpc traffic ([dashboard](https://app.datadoghq.com/dashboard/3tp-vmc-q3n/unirpc-service-dashboard?fromUser=true&refresh_mode=paused&tpl_var_serviceid%5B0%5D=routing_api&from_ts=1728365806109&to_ts=1728366314804&live=false))