### PR TITLE
chore: bump sor to 4.6.0 - feat: tenderly support astrochain sepolia

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.14.0",
         "@uniswap/sdk-core": "^5.8.0",
-        "@uniswap/smart-order-router": "4.5.3",
+        "@uniswap/smart-order-router": "4.6.0",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^4.3.2",
         "@uniswap/v2-sdk": "^4.6.1",
@@ -4750,9 +4750,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.5.3.tgz",
-      "integrity": "sha512-59FTLid+7+y292nRdZAwdsq8l8mRrhgNBXWoPPOMqgL2t1xJutDgqXqCGKwbfG3CU6mkixGS0FeUY+wApyjr+Q==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.6.0.tgz",
+      "integrity": "sha512-SQp2l3rcDXqzJt9JLrkvjzEcCXpjs+aD0JImpTQLWcW5ejhaYShWNvJznO1nkV2btknhK5ZmtaVTQpi8LKloMQ==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -28449,9 +28449,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.5.3.tgz",
-      "integrity": "sha512-59FTLid+7+y292nRdZAwdsq8l8mRrhgNBXWoPPOMqgL2t1xJutDgqXqCGKwbfG3CU6mkixGS0FeUY+wApyjr+Q==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.6.0.tgz",
+      "integrity": "sha512-SQp2l3rcDXqzJt9JLrkvjzEcCXpjs+aD0JImpTQLWcW5ejhaYShWNvJznO1nkV2btknhK5ZmtaVTQpi8LKloMQ==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@uniswap/router-sdk": "^1.14.0",
     "@uniswap/sdk-core": "^5.8.0",
     "@types/semver": "^7.5.8",
-    "@uniswap/smart-order-router": "4.5.3",
+    "@uniswap/smart-order-router": "4.6.0",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^4.3.2",
     "@uniswap/v2-sdk": "^4.6.1",

--- a/test/mocha/e2e/quote.test.ts
+++ b/test/mocha/e2e/quote.test.ts
@@ -2850,8 +2850,7 @@ describe('quote', function () {
       // We will follow up supporting ZORA and ROOTSTOCK
       c != ChainId.ZORA_SEPOLIA &&
       c != ChainId.ROOTSTOCK &&
-      c != ChainId.GOERLI &&
-      c != ChainId.ASTROCHAIN_SEPOLIA
+      c != ChainId.GOERLI
   )) {
     for (const type of TRADE_TYPES) {
       const erc1 = TEST_ERC20_1[chain]()
@@ -2960,7 +2959,8 @@ describe('quote', function () {
           }
 
           // Current WETH/USDB pool (https://blastscan.io/address/0xf52b4b69123cbcf07798ae8265642793b2e8990c) has low WETH amount
-          const amount = type === 'exactOut' && chain === ChainId.BLAST ? '0.002' : '1'
+          const amount =
+            type === 'exactOut' && (chain === ChainId.BLAST || chain === ChainId.ASTROCHAIN_SEPOLIA) ? '0.002' : '1'
 
           const quoteReq: QuoteQueryParams = {
             tokenInAddress: erc1.address,
@@ -3098,7 +3098,8 @@ describe('quote', function () {
           }
 
           // Current WETH/USDB pool (https://blastscan.io/address/0xf52b4b69123cbcf07798ae8265642793b2e8990c) has low WETH amount
-          const amount = type === 'exactOut' && chain === ChainId.BLAST ? '0.002' : '1'
+          const amount =
+            type === 'exactOut' && (chain === ChainId.BLAST || chain === ChainId.ASTROCHAIN_SEPOLIA) ? '0.002' : '1'
 
           const quoteReq: QuoteQueryParams = {
             tokenInAddress: erc1.address,


### PR DESCRIPTION
chore: bump sor to 4.6.0 - feat: tenderly support astrochain sepolia

re-enabling astrochain sepolia quote e2e tests, they all passed on my local: https://app.warp.dev/block/sbMpHGGDo53AfcPH7Tuc6J

can see tenderly sim success via a personal endpoint invoke https://app.warp.dev/block/abQCxMK2pP3XGQPOHsgnVI