### PR TITLE
fix: reomve worldchain and astrochain sepolia from v2 supported list

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -465,8 +465,6 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
             ChainId.BNB,
             ChainId.AVALANCHE,
             ChainId.BLAST,
-            ChainId.WORLDCHAIN,
-            ChainId.ASTROCHAIN_SEPOLIA,
           ]
 
           const v4Supported = [ChainId.SEPOLIA]


### PR DESCRIPTION
Someone created a v2 WETH/USDC [pool](https://worldchain-mainnet.explorer.alchemy.com/address/0x5A5189307EAe50B0ef16EFF3812B798091A4dd52), without adding any liquidities. Therefore routing-api/SOR starts erroring out from error is from the v2 gas model https://github.com/Uniswap/smart-order-router/blob/main/src/routers/alpha-router/gas-models/v2/v2-heuristic-gas-model.ts#L291.

There's the same type of risk for astrochain sepolia, which is someone creates a v2 WETH/USDC pool on astrochain sepolia without adding liquidity. The same safest thing is to remove worldchain and astrochain sepolia from v2 support. both chains have v3 WETH/USDC with some liquidities.

Since routing-api e2e test enables worldchain and astrochain sepolia for quote tests, if there's an issue, code pipeline will fail. Although I don't expect regression.