### PR TITLE
chore: bump sor to 4.7.0 - feat: SOR level implementation to support 1) expanding mixed quoter v1 to L2s 2) support migrate mixed quoter v1 to mixed quoter v2 across chains

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -398,7 +398,9 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
                   useMixedRouteQuoter
                     ? mixedRouteContainsV4Pool
                       ? MIXED_ROUTE_QUOTER_V2_ADDRESSES[chainId]
-                      : MIXED_ROUTE_QUOTER_V1_ADDRESSES[chainId]
+                      : MIXED_ROUTE_QUOTER_V1_ADDRESSES[chainId] ??
+                        // besides mainnet, only base has mixed quoter v1 deployed
+                        (chainId === ChainId.BASE ? '0xe544efae946f0008ae9a8d64493efa7886b73776' : undefined)
                     : protocol === Protocol.V3
                     ? NEW_QUOTER_V2_ADDRESSES[chainId]
                     : PROTOCOL_V4_QUOTER_ADDRESSES[chainId],
@@ -474,7 +476,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
 
           const v4Supported = [ChainId.SEPOLIA]
 
-          const mixedSupported = [ChainId.MAINNET, ChainId.SEPOLIA, ChainId.GOERLI, ChainId.BASE]
+          const mixedSupported = [ChainId.MAINNET, ChainId.SEPOLIA, ChainId.GOERLI]
 
           return {
             chainId,

--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -356,15 +356,17 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
                 provider,
                 multicall2Provider,
                 RETRY_OPTIONS[chainId],
-                (optimisticCachedRoutes, useMixedRouteQuoter) => {
-                  const protocol = useMixedRouteQuoter ? Protocol.MIXED : Protocol.V3
+                (optimisticCachedRoutes, protocol) => {
                   return optimisticCachedRoutes
                     ? OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS[protocol][chainId]
                     : NON_OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS[protocol][chainId]
                 },
-                GAS_ERROR_FAILURE_OVERRIDES[chainId],
-                SUCCESS_RATE_FAILURE_OVERRIDES[chainId],
-                BLOCK_NUMBER_CONFIGS[chainId],
+                // nice to have protocol level gas error failure overrides, this is in prep for v4 and mixed w/ v4
+                (_protocol) => GAS_ERROR_FAILURE_OVERRIDES[chainId],
+                // nice to have protocol level success rate failure overrides, this is in prep for v4 and mixed w/ v4
+                (_protocol) => SUCCESS_RATE_FAILURE_OVERRIDES[chainId],
+                // nice to have protocol level block number configs overrides, this is in prep for v4 and mixed w/ v4
+                (_protocol) => BLOCK_NUMBER_CONFIGS[chainId],
                 // We will only enable shadow sample mixed quoter on Base
                 (useMixedRouteQuoter: boolean, mixedRouteContainsV4Pool: boolean, protocol: Protocol) =>
                   useMixedRouteQuoter
@@ -386,9 +388,12 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
                     ? OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS[protocol][chainId]
                     : NON_OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS[protocol][chainId]
                 },
-                GAS_ERROR_FAILURE_OVERRIDES[chainId],
-                SUCCESS_RATE_FAILURE_OVERRIDES[chainId],
-                BLOCK_NUMBER_CONFIGS[chainId],
+                // nice to have protocol level gas error failure overrides, this is in prep for v4 and mixed w/ v4
+                (_protocol) => GAS_ERROR_FAILURE_OVERRIDES[chainId],
+                // nice to have protocol level success rate failure overrides, this is in prep for v4 and mixed w/ v4
+                (_protocol) => SUCCESS_RATE_FAILURE_OVERRIDES[chainId],
+                // nice to have protocol level block number configs overrides, this is in prep for v4 and mixed w/ v4
+                (_protocol) => BLOCK_NUMBER_CONFIGS[chainId],
                 (useMixedRouteQuoter: boolean, mixedRouteContainsV4Pool: boolean, protocol: Protocol) =>
                   useMixedRouteQuoter
                     ? mixedRouteContainsV4Pool

--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -474,6 +474,8 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
 
           const v4Supported = [ChainId.SEPOLIA]
 
+          const mixedSupported = [ChainId.MAINNET, ChainId.SEPOLIA, ChainId.GOERLI, ChainId.BASE]
+
           return {
             chainId,
             dependencies: {
@@ -506,6 +508,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
               tokenPropertiesProvider,
               v2Supported,
               v4Supported,
+              mixedSupported,
             },
           }
         })

--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -69,7 +69,7 @@ import { OnChainTokenFeeFetcher } from '@uniswap/smart-order-router/build/main/p
 import { PortionProvider } from '@uniswap/smart-order-router/build/main/providers/portion-provider'
 import { GlobalRpcProviders } from '../rpc/GlobalRpcProviders'
 import { StaticJsonRpcProvider } from '@ethersproject/providers'
-import { TrafficSwitchOnChainQuoteProvider } from './quote/provider-migration/v3/traffic-switch-on-chain-quote-provider'
+import { TrafficSwitchOnChainQuoteProvider } from './quote/provider-migration/traffic-switch-on-chain-quote-provider'
 import {
   BLOCK_NUMBER_CONFIGS,
   GAS_ERROR_FAILURE_OVERRIDES,

--- a/lib/handlers/quote/provider-migration/traffic-switch-on-chain-quote-provider.ts
+++ b/lib/handlers/quote/provider-migration/traffic-switch-on-chain-quote-provider.ts
@@ -9,9 +9,9 @@ import {
 } from '@uniswap/smart-order-router'
 import { ChainId, Currency, CurrencyAmount } from '@uniswap/sdk-core'
 import { ProviderConfig } from '@uniswap/smart-order-router/build/main/providers/provider'
-import { QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION } from '../../util/quote-provider-traffic-switch-configuration'
+import { QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION } from '../util/quote-provider-traffic-switch-configuration'
 import { BigNumber } from 'ethers'
-import { LIKELY_OUT_OF_GAS_THRESHOLD, NEW_QUOTER_DEPLOY_BLOCK } from '../../../../util/onChainQuoteProviderConfigs'
+import { LIKELY_OUT_OF_GAS_THRESHOLD, NEW_QUOTER_DEPLOY_BLOCK } from '../../../util/onChainQuoteProviderConfigs'
 import { Protocol } from '@uniswap/router-sdk'
 
 export type TrafficSwitchOnChainQuoteProviderProps = {

--- a/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
+++ b/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
@@ -10,13 +10,14 @@ export type QuoteProviderTrafficSwitchConfiguration = {
 
 export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
   chainId: ChainId,
-  protocol: Protocol // we only make special case for mixed, because v3 is already live, meanwhile v4 is not live yet
+  protocol: Protocol // only v3 and mixed on L1 is alive, once it needs to live switch 100%, otherwise, can have 0% switch
 ): QuoteProviderTrafficSwitchConfiguration => {
   switch (chainId) {
     // Mumbai was deprecated on April 13th. Do not sample at all
     case ChainId.POLYGON_MUMBAI:
       switch (protocol) {
         case Protocol.MIXED:
+        case Protocol.V4:
           return {
             switchExactInPercentage: 0.0,
             samplingExactInPercentage: 0,
@@ -35,6 +36,7 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
     case ChainId.SEPOLIA:
       switch (protocol) {
         case Protocol.MIXED:
+        case Protocol.V4:
           return {
             switchExactInPercentage: 100,
             samplingExactInPercentage: 0,
@@ -59,6 +61,13 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
             switchExactOutPercentage: 0,
             samplingExactOutPercentage: 1,
           } as QuoteProviderTrafficSwitchConfiguration
+        case Protocol.V4:
+          return {
+            switchExactInPercentage: 0,
+            samplingExactInPercentage: 0,
+            switchExactOutPercentage: 0,
+            samplingExactOutPercentage: 0,
+          } as QuoteProviderTrafficSwitchConfiguration
         default:
           return {
             switchExactInPercentage: 100,
@@ -69,6 +78,13 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
       }
     case ChainId.MAINNET:
       switch (protocol) {
+        case Protocol.V4:
+          return {
+            switchExactInPercentage: 0,
+            samplingExactInPercentage: 0,
+            switchExactOutPercentage: 0,
+            samplingExactOutPercentage: 0,
+          } as QuoteProviderTrafficSwitchConfiguration
         default:
           // Total RPM for 'QuoteTotalCallsToProvider' is around 20k-30k (across all chains), so 0.1% means 20-30 RPM shadow sampling
           return {
@@ -81,6 +97,7 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
     case ChainId.ARBITRUM_ONE:
       switch (protocol) {
         case Protocol.MIXED:
+        case Protocol.V4:
           return {
             switchExactInPercentage: 0,
             samplingExactInPercentage: 0,
@@ -99,6 +116,7 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
     case ChainId.POLYGON:
       switch (protocol) {
         case Protocol.MIXED:
+        case Protocol.V4:
           return {
             switchExactInPercentage: 0,
             samplingExactInPercentage: 0,
@@ -117,6 +135,7 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
     case ChainId.OPTIMISM:
       switch (protocol) {
         case Protocol.MIXED:
+        case Protocol.V4:
           return {
             switchExactInPercentage: 0,
             samplingExactInPercentage: 0,
@@ -135,6 +154,7 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
     case ChainId.BLAST:
       switch (protocol) {
         case Protocol.MIXED:
+        case Protocol.V4:
           return {
             switchExactInPercentage: 0,
             samplingExactInPercentage: 0,
@@ -153,6 +173,7 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
     case ChainId.BNB:
       switch (protocol) {
         case Protocol.MIXED:
+        case Protocol.V4:
           return {
             switchExactInPercentage: 0,
             samplingExactInPercentage: 0,
@@ -171,6 +192,7 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
     case ChainId.CELO:
       switch (protocol) {
         case Protocol.MIXED:
+        case Protocol.V4:
           return {
             switchExactInPercentage: 0,
             samplingExactInPercentage: 0,
@@ -189,6 +211,7 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
     case ChainId.AVALANCHE:
       switch (protocol) {
         case Protocol.MIXED:
+        case Protocol.V4:
           return {
             switchExactInPercentage: 0,
             samplingExactInPercentage: 0,
@@ -209,6 +232,7 @@ export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
     case ChainId.ASTROCHAIN_SEPOLIA:
       switch (protocol) {
         case Protocol.MIXED:
+        case Protocol.V4:
           return {
             switchExactInPercentage: 0,
             samplingExactInPercentage: 0,

--- a/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
+++ b/lib/handlers/quote/util/quote-provider-traffic-switch-configuration.ts
@@ -1,4 +1,5 @@
 import { ChainId } from '@uniswap/sdk-core'
+import { Protocol } from '@uniswap/router-sdk'
 
 export type QuoteProviderTrafficSwitchConfiguration = {
   switchExactInPercentage: number
@@ -8,106 +9,220 @@ export type QuoteProviderTrafficSwitchConfiguration = {
 }
 
 export const QUOTE_PROVIDER_TRAFFIC_SWITCH_CONFIGURATION = (
-  chainId: ChainId
+  chainId: ChainId,
+  protocol: Protocol // we only make special case for mixed, because v3 is already live, meanwhile v4 is not live yet
 ): QuoteProviderTrafficSwitchConfiguration => {
   switch (chainId) {
     // Mumbai was deprecated on April 13th. Do not sample at all
     case ChainId.POLYGON_MUMBAI:
-      return {
-        switchExactInPercentage: 0.0,
-        samplingExactInPercentage: 0,
-        switchExactOutPercentage: 0.0,
-        samplingExactOutPercentage: 0,
-      } as QuoteProviderTrafficSwitchConfiguration
+      switch (protocol) {
+        case Protocol.MIXED:
+          return {
+            switchExactInPercentage: 0.0,
+            samplingExactInPercentage: 0,
+            switchExactOutPercentage: 0.0,
+            samplingExactOutPercentage: 0,
+          } as QuoteProviderTrafficSwitchConfiguration
+        default:
+          return {
+            switchExactInPercentage: 0.0,
+            samplingExactInPercentage: 0,
+            switchExactOutPercentage: 0.0,
+            samplingExactOutPercentage: 0,
+          } as QuoteProviderTrafficSwitchConfiguration
+      }
     // Sepolia together have well below 50 RPM, so we can shadow sample 100% of traffic
     case ChainId.SEPOLIA:
-      return {
-        switchExactInPercentage: 0.0,
-        samplingExactInPercentage: 100,
-        switchExactOutPercentage: 0.0,
-        samplingExactOutPercentage: 100,
-      } as QuoteProviderTrafficSwitchConfiguration
+      switch (protocol) {
+        case Protocol.MIXED:
+          return {
+            switchExactInPercentage: 100,
+            samplingExactInPercentage: 0,
+            switchExactOutPercentage: 100,
+            samplingExactOutPercentage: 0,
+          } as QuoteProviderTrafficSwitchConfiguration
+        default:
+          return {
+            switchExactInPercentage: 0.0,
+            samplingExactInPercentage: 100,
+            switchExactOutPercentage: 0.0,
+            samplingExactOutPercentage: 100,
+          } as QuoteProviderTrafficSwitchConfiguration
+      }
     case ChainId.BASE:
-      // Base RPC eth_call traffic is about double mainnet, so we can shadow sample 0.05% of traffic
-      return {
-        switchExactInPercentage: 100,
-        samplingExactInPercentage: 0,
-        switchExactOutPercentage: 100,
-        samplingExactOutPercentage: 0,
-      } as QuoteProviderTrafficSwitchConfiguration
+      switch (protocol) {
+        // only base as L2 has mixed quoter v1 deployed
+        case Protocol.MIXED:
+          return {
+            switchExactInPercentage: 0,
+            samplingExactInPercentage: 1,
+            switchExactOutPercentage: 0,
+            samplingExactOutPercentage: 1,
+          } as QuoteProviderTrafficSwitchConfiguration
+        default:
+          return {
+            switchExactInPercentage: 100,
+            samplingExactInPercentage: 0,
+            switchExactOutPercentage: 100,
+            samplingExactOutPercentage: 0,
+          } as QuoteProviderTrafficSwitchConfiguration
+      }
     case ChainId.MAINNET:
-      // Total RPM for 'QuoteTotalCallsToProvider' is around 20k-30k (across all chains), so 0.1% means 20-30 RPM shadow sampling
-      return {
-        switchExactInPercentage: 100,
-        samplingExactInPercentage: 0,
-        switchExactOutPercentage: 100,
-        samplingExactOutPercentage: 0,
-      } as QuoteProviderTrafficSwitchConfiguration
+      switch (protocol) {
+        default:
+          // Total RPM for 'QuoteTotalCallsToProvider' is around 20k-30k (across all chains), so 0.1% means 20-30 RPM shadow sampling
+          return {
+            switchExactInPercentage: 100,
+            samplingExactInPercentage: 0,
+            switchExactOutPercentage: 100,
+            samplingExactOutPercentage: 0,
+          } as QuoteProviderTrafficSwitchConfiguration
+      }
     case ChainId.ARBITRUM_ONE:
-      // Arbitrum RPC eth_call traffic is about half of mainnet, so we can shadow sample 0.2% of traffic
-      return {
-        switchExactInPercentage: 100,
-        samplingExactInPercentage: 0,
-        switchExactOutPercentage: 100,
-        samplingExactOutPercentage: 0,
-      } as QuoteProviderTrafficSwitchConfiguration
+      switch (protocol) {
+        case Protocol.MIXED:
+          return {
+            switchExactInPercentage: 0,
+            samplingExactInPercentage: 0,
+            switchExactOutPercentage: 0,
+            samplingExactOutPercentage: 0,
+          } as QuoteProviderTrafficSwitchConfiguration
+        default:
+          // Arbitrum RPC eth_call traffic is about half of mainnet, so we can shadow sample 0.2% of traffic
+          return {
+            switchExactInPercentage: 100,
+            samplingExactInPercentage: 0,
+            switchExactOutPercentage: 100,
+            samplingExactOutPercentage: 0,
+          } as QuoteProviderTrafficSwitchConfiguration
+      }
     case ChainId.POLYGON:
-      // Total RPM for 'QuoteTotalCallsToProvider' is around 20k-30k (across all chains), so 0.1% means 20-30 RPM shadow sampling
-      return {
-        switchExactInPercentage: 100,
-        samplingExactInPercentage: 0,
-        switchExactOutPercentage: 100,
-        samplingExactOutPercentage: 0,
-      } as QuoteProviderTrafficSwitchConfiguration
+      switch (protocol) {
+        case Protocol.MIXED:
+          return {
+            switchExactInPercentage: 0,
+            samplingExactInPercentage: 0,
+            switchExactOutPercentage: 0,
+            samplingExactOutPercentage: 0,
+          } as QuoteProviderTrafficSwitchConfiguration
+        default:
+          // Total RPM for 'QuoteTotalCallsToProvider' is around 20k-30k (across all chains), so 0.1% means 20-30 RPM shadow sampling
+          return {
+            switchExactInPercentage: 100,
+            samplingExactInPercentage: 0,
+            switchExactOutPercentage: 100,
+            samplingExactOutPercentage: 0,
+          } as QuoteProviderTrafficSwitchConfiguration
+      }
     case ChainId.OPTIMISM:
-      // Optimism RPC eth_call traffic is about 1/10 of mainnet, so we can shadow sample 1% of traffic
-      return {
-        switchExactInPercentage: 100,
-        samplingExactInPercentage: 0,
-        switchExactOutPercentage: 100,
-        samplingExactOutPercentage: 0,
-      } as QuoteProviderTrafficSwitchConfiguration
+      switch (protocol) {
+        case Protocol.MIXED:
+          return {
+            switchExactInPercentage: 0,
+            samplingExactInPercentage: 0,
+            switchExactOutPercentage: 0,
+            samplingExactOutPercentage: 0,
+          } as QuoteProviderTrafficSwitchConfiguration
+        default:
+          // Optimism RPC eth_call traffic is about 1/10 of mainnet, so we can shadow sample 1% of traffic
+          return {
+            switchExactInPercentage: 100,
+            samplingExactInPercentage: 0,
+            switchExactOutPercentage: 100,
+            samplingExactOutPercentage: 0,
+          } as QuoteProviderTrafficSwitchConfiguration
+      }
     case ChainId.BLAST:
-      // Blast RPC eth_call traffic is about 1/10 of mainnet, so we can shadow sample 1% of traffic
-      return {
-        switchExactInPercentage: 100,
-        samplingExactInPercentage: 0,
-        switchExactOutPercentage: 100,
-        samplingExactOutPercentage: 0,
-      } as QuoteProviderTrafficSwitchConfiguration
+      switch (protocol) {
+        case Protocol.MIXED:
+          return {
+            switchExactInPercentage: 0,
+            samplingExactInPercentage: 0,
+            switchExactOutPercentage: 0,
+            samplingExactOutPercentage: 0,
+          } as QuoteProviderTrafficSwitchConfiguration
+        default:
+          // Blast RPC eth_call traffic is about 1/10 of mainnet, so we can shadow sample 1% of traffic
+          return {
+            switchExactInPercentage: 100,
+            samplingExactInPercentage: 0,
+            switchExactOutPercentage: 100,
+            samplingExactOutPercentage: 0,
+          } as QuoteProviderTrafficSwitchConfiguration
+      }
     case ChainId.BNB:
-      // BNB RPC eth_call traffic is about 1/10 of mainnet, so we can shadow sample 1% of traffic
-      return {
-        switchExactInPercentage: 100,
-        samplingExactInPercentage: 0,
-        switchExactOutPercentage: 100,
-        samplingExactOutPercentage: 0,
+      switch (protocol) {
+        case Protocol.MIXED:
+          return {
+            switchExactInPercentage: 0,
+            samplingExactInPercentage: 0,
+            switchExactOutPercentage: 0,
+            samplingExactOutPercentage: 0,
+          } as QuoteProviderTrafficSwitchConfiguration
+        default:
+          // BNB RPC eth_call traffic is about 1/10 of mainnet, so we can shadow sample 1% of traffic
+          return {
+            switchExactInPercentage: 100,
+            samplingExactInPercentage: 0,
+            switchExactOutPercentage: 100,
+            samplingExactOutPercentage: 0,
+          } as QuoteProviderTrafficSwitchConfiguration
       }
     case ChainId.CELO:
-      // Celo RPC eth_call traffic is about 1/100 of mainnet, so we can shadow sample 10% of traffic
-      return {
-        switchExactInPercentage: 100,
-        samplingExactInPercentage: 0,
-        switchExactOutPercentage: 100,
-        samplingExactOutPercentage: 0,
-      } as QuoteProviderTrafficSwitchConfiguration
+      switch (protocol) {
+        case Protocol.MIXED:
+          return {
+            switchExactInPercentage: 0,
+            samplingExactInPercentage: 0,
+            switchExactOutPercentage: 0,
+            samplingExactOutPercentage: 0,
+          } as QuoteProviderTrafficSwitchConfiguration
+        default:
+          // Celo RPC eth_call traffic is about 1/100 of mainnet, so we can shadow sample 10% of traffic
+          return {
+            switchExactInPercentage: 100,
+            samplingExactInPercentage: 0,
+            switchExactOutPercentage: 100,
+            samplingExactOutPercentage: 0,
+          } as QuoteProviderTrafficSwitchConfiguration
+      }
     case ChainId.AVALANCHE:
-      // Avalanche RPC eth_call traffic is about 1/100 of mainnet, so we can shadow sample 10% of traffic
-      return {
-        switchExactInPercentage: 100,
-        samplingExactInPercentage: 0,
-        switchExactOutPercentage: 100,
-        samplingExactOutPercentage: 0,
-      } as QuoteProviderTrafficSwitchConfiguration
+      switch (protocol) {
+        case Protocol.MIXED:
+          return {
+            switchExactInPercentage: 0,
+            samplingExactInPercentage: 0,
+            switchExactOutPercentage: 0,
+            samplingExactOutPercentage: 0,
+          } as QuoteProviderTrafficSwitchConfiguration
+        default:
+          // Avalanche RPC eth_call traffic is about 1/100 of mainnet, so we can shadow sample 10% of traffic
+          return {
+            switchExactInPercentage: 100,
+            samplingExactInPercentage: 0,
+            switchExactOutPercentage: 100,
+            samplingExactOutPercentage: 0,
+          } as QuoteProviderTrafficSwitchConfiguration
+      }
     // worldchain and astrochain sepolia don't have the view-only quoter yet, so we can shadow sample 0.1% of traffic
     case ChainId.WORLDCHAIN:
     case ChainId.ASTROCHAIN_SEPOLIA:
-      return {
-        switchExactInPercentage: 0.0,
-        samplingExactInPercentage: 0.1,
-        switchExactOutPercentage: 0.0,
-        samplingExactOutPercentage: 0.1,
-      } as QuoteProviderTrafficSwitchConfiguration
+      switch (protocol) {
+        case Protocol.MIXED:
+          return {
+            switchExactInPercentage: 0,
+            samplingExactInPercentage: 0,
+            switchExactOutPercentage: 0,
+            samplingExactOutPercentage: 0,
+          } as QuoteProviderTrafficSwitchConfiguration
+        default:
+          return {
+            switchExactInPercentage: 0.0,
+            samplingExactInPercentage: 0.1,
+            switchExactOutPercentage: 0.0,
+            samplingExactOutPercentage: 0.1,
+          } as QuoteProviderTrafficSwitchConfiguration
+      }
     // If we accidentally switch a traffic, we have the protection to shadow sample only 0.1% of traffic
     default:
       return {

--- a/lib/util/onChainQuoteProviderConfigs.ts
+++ b/lib/util/onChainQuoteProviderConfigs.ts
@@ -120,6 +120,72 @@ export const OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [protocol: string]: { [cha
       quoteMinSuccessRate: 0.1,
     },
   },
+  // V4 can be the same as V4 to begin. likely v4 is more gas efficient because of pool singleton for swaps by accounting mechanism
+  [Protocol.V4]: {
+    ...constructSameBatchParamsMap(DEFAULT_BATCH_PARAMS),
+    [ChainId.BASE]: {
+      multicallChunk: 1320,
+      gasLimitPerCall: 100_000,
+      quoteMinSuccessRate: 0.1,
+    },
+    [ChainId.ARBITRUM_ONE]: {
+      multicallChunk: 3000,
+      gasLimitPerCall: 75_000,
+      quoteMinSuccessRate: 0.15,
+    },
+    [ChainId.OPTIMISM]: {
+      multicallChunk: 1650,
+      gasLimitPerCall: 80_000,
+      quoteMinSuccessRate: 0.1,
+    },
+    [ChainId.CELO]: {
+      multicallChunk: 6240,
+      gasLimitPerCall: 80_000,
+      quoteMinSuccessRate: 0,
+    },
+    [ChainId.BLAST]: {
+      multicallChunk: 1200,
+      gasLimitPerCall: 80_000,
+      quoteMinSuccessRate: 0.1,
+    },
+    [ChainId.AVALANCHE]: {
+      multicallChunk: 2625,
+      gasLimitPerCall: 60_000,
+      quoteMinSuccessRate: 0.15,
+    },
+    [ChainId.BNB]: {
+      multicallChunk: 1850,
+      gasLimitPerCall: 80_000,
+      quoteMinSuccessRate: 0.15,
+    },
+    [ChainId.POLYGON]: {
+      multicallChunk: 1850,
+      gasLimitPerCall: 80_000,
+      quoteMinSuccessRate: 0.15,
+    },
+    [ChainId.MAINNET]: {
+      multicallChunk: 1974,
+      gasLimitPerCall: 75_000,
+      quoteMinSuccessRate: 0.15,
+    },
+    [ChainId.ZKSYNC]: {
+      multicallChunk: 20,
+      gasLimitPerCall: 4_000_000,
+      quoteMinSuccessRate: 0.1,
+    },
+    // TODO: once worldchain has view-quoter, optimize muilcallChunk and gasLimitPerCall
+    [ChainId.WORLDCHAIN]: {
+      multicallChunk: 80,
+      gasLimitPerCall: 1_200_000,
+      quoteMinSuccessRate: 0.1,
+    },
+    // TODO: once astrochain-sepolia has view-quoter, optimize muilcallChunk and gasLimitPerCall
+    [ChainId.ASTROCHAIN_SEPOLIA]: {
+      multicallChunk: 80,
+      gasLimitPerCall: 1_200_000,
+      quoteMinSuccessRate: 0.1,
+    },
+  },
   [Protocol.MIXED]: {
     ...constructSameBatchParamsMap(DEFAULT_BATCH_PARAMS),
     [ChainId.BASE]: {
@@ -184,6 +250,72 @@ export const OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [protocol: string]: { [cha
 
 export const NON_OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [protocol: string]: { [chainId: number]: BatchParams } } = {
   [Protocol.V3]: {
+    ...constructSameBatchParamsMap(DEFAULT_BATCH_PARAMS),
+    [ChainId.BASE]: {
+      multicallChunk: 660,
+      gasLimitPerCall: 200_000,
+      quoteMinSuccessRate: 0.1,
+    },
+    [ChainId.ARBITRUM_ONE]: {
+      multicallChunk: 1125,
+      gasLimitPerCall: 200_000,
+      quoteMinSuccessRate: 0.15,
+    },
+    [ChainId.OPTIMISM]: {
+      multicallChunk: 880,
+      gasLimitPerCall: 150_000,
+      quoteMinSuccessRate: 0.1,
+    },
+    [ChainId.CELO]: {
+      multicallChunk: 3120,
+      gasLimitPerCall: 160_000,
+      quoteMinSuccessRate: 0,
+    },
+    [ChainId.BLAST]: {
+      multicallChunk: 1200,
+      gasLimitPerCall: 80_000,
+      quoteMinSuccessRate: 0.1,
+    },
+    [ChainId.AVALANCHE]: {
+      multicallChunk: 420,
+      gasLimitPerCall: 375_000,
+      quoteMinSuccessRate: 0.15,
+    },
+    [ChainId.BNB]: {
+      multicallChunk: 2961,
+      gasLimitPerCall: 50_000,
+      quoteMinSuccessRate: 0.15,
+    },
+    [ChainId.POLYGON]: {
+      multicallChunk: 987,
+      gasLimitPerCall: 150_000,
+      quoteMinSuccessRate: 0.15,
+    },
+    [ChainId.MAINNET]: {
+      multicallChunk: 987,
+      gasLimitPerCall: 150_000,
+      quoteMinSuccessRate: 0.15,
+    },
+    [ChainId.ZKSYNC]: {
+      multicallChunk: 20,
+      gasLimitPerCall: 4_000_000,
+      quoteMinSuccessRate: 0.1,
+    },
+    // TODO: once worldchain has view-quoter, optimize muilcallChunk and gasLimitPerCall
+    [ChainId.WORLDCHAIN]: {
+      multicallChunk: 80,
+      gasLimitPerCall: 1_200_000,
+      quoteMinSuccessRate: 0.1,
+    },
+    // TODO: once astrochain-sepolia has view-quoter, optimize muilcallChunk and gasLimitPerCall
+    [ChainId.ASTROCHAIN_SEPOLIA]: {
+      multicallChunk: 80,
+      gasLimitPerCall: 1_200_000,
+      quoteMinSuccessRate: 0.1,
+    },
+  },
+  // V4 can be the same as V4 to begin. likely v4 is more gas efficient because of pool singleton for swaps by accounting mechanism
+  [Protocol.V4]: {
     ...constructSameBatchParamsMap(DEFAULT_BATCH_PARAMS),
     [ChainId.BASE]: {
       multicallChunk: 660,

--- a/lib/util/onChainQuoteProviderConfigs.ts
+++ b/lib/util/onChainQuoteProviderConfigs.ts
@@ -315,266 +315,267 @@ export const OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [protocol in Protocol]: { 
   },
 }
 
-export const NON_OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [protocol in Protocol]: { [chainId: number]: BatchParams } } = {
-  // V2 doesn't apply because v2 doesnt call onchain-quote provider at all
-  // we use Protocol enum type to remember for each new protocol version, we will add the protocol specific tuning
-  [Protocol.V2]: {
-    ...constructSameBatchParamsMap(DEFAULT_BATCH_PARAMS),
-    [ChainId.BASE]: {
-      multicallChunk: 660,
-      gasLimitPerCall: 200_000,
-      quoteMinSuccessRate: 0.1,
+export const NON_OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [protocol in Protocol]: { [chainId: number]: BatchParams } } =
+  {
+    // V2 doesn't apply because v2 doesnt call onchain-quote provider at all
+    // we use Protocol enum type to remember for each new protocol version, we will add the protocol specific tuning
+    [Protocol.V2]: {
+      ...constructSameBatchParamsMap(DEFAULT_BATCH_PARAMS),
+      [ChainId.BASE]: {
+        multicallChunk: 660,
+        gasLimitPerCall: 200_000,
+        quoteMinSuccessRate: 0.1,
+      },
+      [ChainId.ARBITRUM_ONE]: {
+        multicallChunk: 1125,
+        gasLimitPerCall: 200_000,
+        quoteMinSuccessRate: 0.15,
+      },
+      [ChainId.OPTIMISM]: {
+        multicallChunk: 880,
+        gasLimitPerCall: 150_000,
+        quoteMinSuccessRate: 0.1,
+      },
+      [ChainId.CELO]: {
+        multicallChunk: 3120,
+        gasLimitPerCall: 160_000,
+        quoteMinSuccessRate: 0,
+      },
+      [ChainId.BLAST]: {
+        multicallChunk: 1200,
+        gasLimitPerCall: 80_000,
+        quoteMinSuccessRate: 0.1,
+      },
+      [ChainId.AVALANCHE]: {
+        multicallChunk: 420,
+        gasLimitPerCall: 375_000,
+        quoteMinSuccessRate: 0.15,
+      },
+      [ChainId.BNB]: {
+        multicallChunk: 2961,
+        gasLimitPerCall: 50_000,
+        quoteMinSuccessRate: 0.15,
+      },
+      [ChainId.POLYGON]: {
+        multicallChunk: 987,
+        gasLimitPerCall: 150_000,
+        quoteMinSuccessRate: 0.15,
+      },
+      [ChainId.MAINNET]: {
+        multicallChunk: 987,
+        gasLimitPerCall: 150_000,
+        quoteMinSuccessRate: 0.15,
+      },
+      [ChainId.ZKSYNC]: {
+        multicallChunk: 20,
+        gasLimitPerCall: 4_000_000,
+        quoteMinSuccessRate: 0.1,
+      },
+      // TODO: once worldchain has view-quoter, optimize muilcallChunk and gasLimitPerCall
+      [ChainId.WORLDCHAIN]: {
+        multicallChunk: 80,
+        gasLimitPerCall: 1_200_000,
+        quoteMinSuccessRate: 0.1,
+      },
+      // TODO: once astrochain-sepolia has view-quoter, optimize muilcallChunk and gasLimitPerCall
+      [ChainId.ASTROCHAIN_SEPOLIA]: {
+        multicallChunk: 80,
+        gasLimitPerCall: 1_200_000,
+        quoteMinSuccessRate: 0.1,
+      },
     },
-    [ChainId.ARBITRUM_ONE]: {
-      multicallChunk: 1125,
-      gasLimitPerCall: 200_000,
-      quoteMinSuccessRate: 0.15,
+    [Protocol.V3]: {
+      ...constructSameBatchParamsMap(DEFAULT_BATCH_PARAMS),
+      [ChainId.BASE]: {
+        multicallChunk: 660,
+        gasLimitPerCall: 200_000,
+        quoteMinSuccessRate: 0.1,
+      },
+      [ChainId.ARBITRUM_ONE]: {
+        multicallChunk: 1125,
+        gasLimitPerCall: 200_000,
+        quoteMinSuccessRate: 0.15,
+      },
+      [ChainId.OPTIMISM]: {
+        multicallChunk: 880,
+        gasLimitPerCall: 150_000,
+        quoteMinSuccessRate: 0.1,
+      },
+      [ChainId.CELO]: {
+        multicallChunk: 3120,
+        gasLimitPerCall: 160_000,
+        quoteMinSuccessRate: 0,
+      },
+      [ChainId.BLAST]: {
+        multicallChunk: 1200,
+        gasLimitPerCall: 80_000,
+        quoteMinSuccessRate: 0.1,
+      },
+      [ChainId.AVALANCHE]: {
+        multicallChunk: 420,
+        gasLimitPerCall: 375_000,
+        quoteMinSuccessRate: 0.15,
+      },
+      [ChainId.BNB]: {
+        multicallChunk: 2961,
+        gasLimitPerCall: 50_000,
+        quoteMinSuccessRate: 0.15,
+      },
+      [ChainId.POLYGON]: {
+        multicallChunk: 987,
+        gasLimitPerCall: 150_000,
+        quoteMinSuccessRate: 0.15,
+      },
+      [ChainId.MAINNET]: {
+        multicallChunk: 987,
+        gasLimitPerCall: 150_000,
+        quoteMinSuccessRate: 0.15,
+      },
+      [ChainId.ZKSYNC]: {
+        multicallChunk: 20,
+        gasLimitPerCall: 4_000_000,
+        quoteMinSuccessRate: 0.1,
+      },
+      // TODO: once worldchain has view-quoter, optimize muilcallChunk and gasLimitPerCall
+      [ChainId.WORLDCHAIN]: {
+        multicallChunk: 80,
+        gasLimitPerCall: 1_200_000,
+        quoteMinSuccessRate: 0.1,
+      },
+      // TODO: once astrochain-sepolia has view-quoter, optimize muilcallChunk and gasLimitPerCall
+      [ChainId.ASTROCHAIN_SEPOLIA]: {
+        multicallChunk: 80,
+        gasLimitPerCall: 1_200_000,
+        quoteMinSuccessRate: 0.1,
+      },
     },
-    [ChainId.OPTIMISM]: {
-      multicallChunk: 880,
-      gasLimitPerCall: 150_000,
-      quoteMinSuccessRate: 0.1,
+    // V4 can be the same as V4 to begin. likely v4 is more gas efficient because of pool singleton for swaps by accounting mechanism
+    [Protocol.V4]: {
+      ...constructSameBatchParamsMap(DEFAULT_BATCH_PARAMS),
+      [ChainId.BASE]: {
+        multicallChunk: 660,
+        gasLimitPerCall: 200_000,
+        quoteMinSuccessRate: 0.1,
+      },
+      [ChainId.ARBITRUM_ONE]: {
+        multicallChunk: 1125,
+        gasLimitPerCall: 200_000,
+        quoteMinSuccessRate: 0.15,
+      },
+      [ChainId.OPTIMISM]: {
+        multicallChunk: 880,
+        gasLimitPerCall: 150_000,
+        quoteMinSuccessRate: 0.1,
+      },
+      [ChainId.CELO]: {
+        multicallChunk: 3120,
+        gasLimitPerCall: 160_000,
+        quoteMinSuccessRate: 0,
+      },
+      [ChainId.BLAST]: {
+        multicallChunk: 1200,
+        gasLimitPerCall: 80_000,
+        quoteMinSuccessRate: 0.1,
+      },
+      [ChainId.AVALANCHE]: {
+        multicallChunk: 420,
+        gasLimitPerCall: 375_000,
+        quoteMinSuccessRate: 0.15,
+      },
+      [ChainId.BNB]: {
+        multicallChunk: 2961,
+        gasLimitPerCall: 50_000,
+        quoteMinSuccessRate: 0.15,
+      },
+      [ChainId.POLYGON]: {
+        multicallChunk: 987,
+        gasLimitPerCall: 150_000,
+        quoteMinSuccessRate: 0.15,
+      },
+      [ChainId.MAINNET]: {
+        multicallChunk: 987,
+        gasLimitPerCall: 150_000,
+        quoteMinSuccessRate: 0.15,
+      },
+      [ChainId.ZKSYNC]: {
+        multicallChunk: 20,
+        gasLimitPerCall: 4_000_000,
+        quoteMinSuccessRate: 0.1,
+      },
+      // TODO: once worldchain has view-quoter, optimize muilcallChunk and gasLimitPerCall
+      [ChainId.WORLDCHAIN]: {
+        multicallChunk: 80,
+        gasLimitPerCall: 1_200_000,
+        quoteMinSuccessRate: 0.1,
+      },
+      // TODO: once astrochain-sepolia has view-quoter, optimize muilcallChunk and gasLimitPerCall
+      [ChainId.ASTROCHAIN_SEPOLIA]: {
+        multicallChunk: 80,
+        gasLimitPerCall: 1_200_000,
+        quoteMinSuccessRate: 0.1,
+      },
     },
-    [ChainId.CELO]: {
-      multicallChunk: 3120,
-      gasLimitPerCall: 160_000,
-      quoteMinSuccessRate: 0,
+    [Protocol.MIXED]: {
+      ...constructSameBatchParamsMap(DEFAULT_BATCH_PARAMS),
+      [ChainId.BASE]: {
+        multicallChunk: 660,
+        gasLimitPerCall: 200_000,
+        quoteMinSuccessRate: 0.1,
+      },
+      [ChainId.ARBITRUM_ONE]: {
+        multicallChunk: 1125,
+        gasLimitPerCall: 200_000,
+        quoteMinSuccessRate: 0.15,
+      },
+      [ChainId.OPTIMISM]: {
+        multicallChunk: 880,
+        gasLimitPerCall: 150_000,
+        quoteMinSuccessRate: 0.1,
+      },
+      [ChainId.CELO]: {
+        multicallChunk: 3120,
+        gasLimitPerCall: 160_000,
+        quoteMinSuccessRate: 0,
+      },
+      [ChainId.BLAST]: {
+        multicallChunk: 1200,
+        gasLimitPerCall: 80_000,
+        quoteMinSuccessRate: 0.1,
+      },
+      [ChainId.AVALANCHE]: {
+        multicallChunk: 420,
+        gasLimitPerCall: 375_000,
+        quoteMinSuccessRate: 0.15,
+      },
+      [ChainId.BNB]: {
+        multicallChunk: 2961,
+        gasLimitPerCall: 50_000,
+        quoteMinSuccessRate: 0.15,
+      },
+      [ChainId.POLYGON]: {
+        multicallChunk: 987,
+        gasLimitPerCall: 150_000,
+        quoteMinSuccessRate: 0.15,
+      },
+      [ChainId.ZKSYNC]: {
+        multicallChunk: 20,
+        gasLimitPerCall: 4_000_000,
+        quoteMinSuccessRate: 0.1,
+      },
+      // TODO: once worldchain has view-quoter, optimize muilcallChunk and gasLimitPerCall
+      [ChainId.WORLDCHAIN]: {
+        multicallChunk: 80,
+        gasLimitPerCall: 1_200_000,
+        quoteMinSuccessRate: 0.1,
+      },
+      // TODO: once astrochain-sepolia has view-quoter, optimize muilcallChunk and gasLimitPerCall
+      [ChainId.ASTROCHAIN_SEPOLIA]: {
+        multicallChunk: 80,
+        gasLimitPerCall: 1_200_000,
+        quoteMinSuccessRate: 0.1,
+      },
     },
-    [ChainId.BLAST]: {
-      multicallChunk: 1200,
-      gasLimitPerCall: 80_000,
-      quoteMinSuccessRate: 0.1,
-    },
-    [ChainId.AVALANCHE]: {
-      multicallChunk: 420,
-      gasLimitPerCall: 375_000,
-      quoteMinSuccessRate: 0.15,
-    },
-    [ChainId.BNB]: {
-      multicallChunk: 2961,
-      gasLimitPerCall: 50_000,
-      quoteMinSuccessRate: 0.15,
-    },
-    [ChainId.POLYGON]: {
-      multicallChunk: 987,
-      gasLimitPerCall: 150_000,
-      quoteMinSuccessRate: 0.15,
-    },
-    [ChainId.MAINNET]: {
-      multicallChunk: 987,
-      gasLimitPerCall: 150_000,
-      quoteMinSuccessRate: 0.15,
-    },
-    [ChainId.ZKSYNC]: {
-      multicallChunk: 20,
-      gasLimitPerCall: 4_000_000,
-      quoteMinSuccessRate: 0.1,
-    },
-    // TODO: once worldchain has view-quoter, optimize muilcallChunk and gasLimitPerCall
-    [ChainId.WORLDCHAIN]: {
-      multicallChunk: 80,
-      gasLimitPerCall: 1_200_000,
-      quoteMinSuccessRate: 0.1,
-    },
-    // TODO: once astrochain-sepolia has view-quoter, optimize muilcallChunk and gasLimitPerCall
-    [ChainId.ASTROCHAIN_SEPOLIA]: {
-      multicallChunk: 80,
-      gasLimitPerCall: 1_200_000,
-      quoteMinSuccessRate: 0.1,
-    },
-  },
-  [Protocol.V3]: {
-    ...constructSameBatchParamsMap(DEFAULT_BATCH_PARAMS),
-    [ChainId.BASE]: {
-      multicallChunk: 660,
-      gasLimitPerCall: 200_000,
-      quoteMinSuccessRate: 0.1,
-    },
-    [ChainId.ARBITRUM_ONE]: {
-      multicallChunk: 1125,
-      gasLimitPerCall: 200_000,
-      quoteMinSuccessRate: 0.15,
-    },
-    [ChainId.OPTIMISM]: {
-      multicallChunk: 880,
-      gasLimitPerCall: 150_000,
-      quoteMinSuccessRate: 0.1,
-    },
-    [ChainId.CELO]: {
-      multicallChunk: 3120,
-      gasLimitPerCall: 160_000,
-      quoteMinSuccessRate: 0,
-    },
-    [ChainId.BLAST]: {
-      multicallChunk: 1200,
-      gasLimitPerCall: 80_000,
-      quoteMinSuccessRate: 0.1,
-    },
-    [ChainId.AVALANCHE]: {
-      multicallChunk: 420,
-      gasLimitPerCall: 375_000,
-      quoteMinSuccessRate: 0.15,
-    },
-    [ChainId.BNB]: {
-      multicallChunk: 2961,
-      gasLimitPerCall: 50_000,
-      quoteMinSuccessRate: 0.15,
-    },
-    [ChainId.POLYGON]: {
-      multicallChunk: 987,
-      gasLimitPerCall: 150_000,
-      quoteMinSuccessRate: 0.15,
-    },
-    [ChainId.MAINNET]: {
-      multicallChunk: 987,
-      gasLimitPerCall: 150_000,
-      quoteMinSuccessRate: 0.15,
-    },
-    [ChainId.ZKSYNC]: {
-      multicallChunk: 20,
-      gasLimitPerCall: 4_000_000,
-      quoteMinSuccessRate: 0.1,
-    },
-    // TODO: once worldchain has view-quoter, optimize muilcallChunk and gasLimitPerCall
-    [ChainId.WORLDCHAIN]: {
-      multicallChunk: 80,
-      gasLimitPerCall: 1_200_000,
-      quoteMinSuccessRate: 0.1,
-    },
-    // TODO: once astrochain-sepolia has view-quoter, optimize muilcallChunk and gasLimitPerCall
-    [ChainId.ASTROCHAIN_SEPOLIA]: {
-      multicallChunk: 80,
-      gasLimitPerCall: 1_200_000,
-      quoteMinSuccessRate: 0.1,
-    },
-  },
-  // V4 can be the same as V4 to begin. likely v4 is more gas efficient because of pool singleton for swaps by accounting mechanism
-  [Protocol.V4]: {
-    ...constructSameBatchParamsMap(DEFAULT_BATCH_PARAMS),
-    [ChainId.BASE]: {
-      multicallChunk: 660,
-      gasLimitPerCall: 200_000,
-      quoteMinSuccessRate: 0.1,
-    },
-    [ChainId.ARBITRUM_ONE]: {
-      multicallChunk: 1125,
-      gasLimitPerCall: 200_000,
-      quoteMinSuccessRate: 0.15,
-    },
-    [ChainId.OPTIMISM]: {
-      multicallChunk: 880,
-      gasLimitPerCall: 150_000,
-      quoteMinSuccessRate: 0.1,
-    },
-    [ChainId.CELO]: {
-      multicallChunk: 3120,
-      gasLimitPerCall: 160_000,
-      quoteMinSuccessRate: 0,
-    },
-    [ChainId.BLAST]: {
-      multicallChunk: 1200,
-      gasLimitPerCall: 80_000,
-      quoteMinSuccessRate: 0.1,
-    },
-    [ChainId.AVALANCHE]: {
-      multicallChunk: 420,
-      gasLimitPerCall: 375_000,
-      quoteMinSuccessRate: 0.15,
-    },
-    [ChainId.BNB]: {
-      multicallChunk: 2961,
-      gasLimitPerCall: 50_000,
-      quoteMinSuccessRate: 0.15,
-    },
-    [ChainId.POLYGON]: {
-      multicallChunk: 987,
-      gasLimitPerCall: 150_000,
-      quoteMinSuccessRate: 0.15,
-    },
-    [ChainId.MAINNET]: {
-      multicallChunk: 987,
-      gasLimitPerCall: 150_000,
-      quoteMinSuccessRate: 0.15,
-    },
-    [ChainId.ZKSYNC]: {
-      multicallChunk: 20,
-      gasLimitPerCall: 4_000_000,
-      quoteMinSuccessRate: 0.1,
-    },
-    // TODO: once worldchain has view-quoter, optimize muilcallChunk and gasLimitPerCall
-    [ChainId.WORLDCHAIN]: {
-      multicallChunk: 80,
-      gasLimitPerCall: 1_200_000,
-      quoteMinSuccessRate: 0.1,
-    },
-    // TODO: once astrochain-sepolia has view-quoter, optimize muilcallChunk and gasLimitPerCall
-    [ChainId.ASTROCHAIN_SEPOLIA]: {
-      multicallChunk: 80,
-      gasLimitPerCall: 1_200_000,
-      quoteMinSuccessRate: 0.1,
-    },
-  },
-  [Protocol.MIXED]: {
-    ...constructSameBatchParamsMap(DEFAULT_BATCH_PARAMS),
-    [ChainId.BASE]: {
-      multicallChunk: 660,
-      gasLimitPerCall: 200_000,
-      quoteMinSuccessRate: 0.1,
-    },
-    [ChainId.ARBITRUM_ONE]: {
-      multicallChunk: 1125,
-      gasLimitPerCall: 200_000,
-      quoteMinSuccessRate: 0.15,
-    },
-    [ChainId.OPTIMISM]: {
-      multicallChunk: 880,
-      gasLimitPerCall: 150_000,
-      quoteMinSuccessRate: 0.1,
-    },
-    [ChainId.CELO]: {
-      multicallChunk: 3120,
-      gasLimitPerCall: 160_000,
-      quoteMinSuccessRate: 0,
-    },
-    [ChainId.BLAST]: {
-      multicallChunk: 1200,
-      gasLimitPerCall: 80_000,
-      quoteMinSuccessRate: 0.1,
-    },
-    [ChainId.AVALANCHE]: {
-      multicallChunk: 420,
-      gasLimitPerCall: 375_000,
-      quoteMinSuccessRate: 0.15,
-    },
-    [ChainId.BNB]: {
-      multicallChunk: 2961,
-      gasLimitPerCall: 50_000,
-      quoteMinSuccessRate: 0.15,
-    },
-    [ChainId.POLYGON]: {
-      multicallChunk: 987,
-      gasLimitPerCall: 150_000,
-      quoteMinSuccessRate: 0.15,
-    },
-    [ChainId.ZKSYNC]: {
-      multicallChunk: 20,
-      gasLimitPerCall: 4_000_000,
-      quoteMinSuccessRate: 0.1,
-    },
-    // TODO: once worldchain has view-quoter, optimize muilcallChunk and gasLimitPerCall
-    [ChainId.WORLDCHAIN]: {
-      multicallChunk: 80,
-      gasLimitPerCall: 1_200_000,
-      quoteMinSuccessRate: 0.1,
-    },
-    // TODO: once astrochain-sepolia has view-quoter, optimize muilcallChunk and gasLimitPerCall
-    [ChainId.ASTROCHAIN_SEPOLIA]: {
-      multicallChunk: 80,
-      gasLimitPerCall: 1_200_000,
-      quoteMinSuccessRate: 0.1,
-    },
-  },
-}
+  }
 
 export const GAS_ERROR_FAILURE_OVERRIDES: { [chainId: number]: FailureOverrides } = {
   ...constructSameGasErrorFailureOverridesMap(DEFAULT_GAS_ERROR_FAILURE_OVERRIDES),

--- a/lib/util/onChainQuoteProviderConfigs.ts
+++ b/lib/util/onChainQuoteProviderConfigs.ts
@@ -54,7 +54,74 @@ export const RETRY_OPTIONS: { [chainId: number]: AsyncRetry.Options | undefined 
   },
 }
 
-export const OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [protocol: string]: { [chainId: number]: BatchParams } } = {
+export const OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [protocol in Protocol]: { [chainId: number]: BatchParams } } = {
+  // V2 doesn't apply because v2 doesnt call onchain-quote provider at all
+  // we use Protocol enum type to remember for each new protocol version, we will add the protocol specific tuning
+  [Protocol.V2]: {
+    ...constructSameBatchParamsMap(DEFAULT_BATCH_PARAMS),
+    [ChainId.BASE]: {
+      multicallChunk: 1320,
+      gasLimitPerCall: 100_000,
+      quoteMinSuccessRate: 0.1,
+    },
+    [ChainId.ARBITRUM_ONE]: {
+      multicallChunk: 3000,
+      gasLimitPerCall: 75_000,
+      quoteMinSuccessRate: 0.15,
+    },
+    [ChainId.OPTIMISM]: {
+      multicallChunk: 1650,
+      gasLimitPerCall: 80_000,
+      quoteMinSuccessRate: 0.1,
+    },
+    [ChainId.CELO]: {
+      multicallChunk: 6240,
+      gasLimitPerCall: 80_000,
+      quoteMinSuccessRate: 0,
+    },
+    [ChainId.BLAST]: {
+      multicallChunk: 1200,
+      gasLimitPerCall: 80_000,
+      quoteMinSuccessRate: 0.1,
+    },
+    [ChainId.AVALANCHE]: {
+      multicallChunk: 2625,
+      gasLimitPerCall: 60_000,
+      quoteMinSuccessRate: 0.15,
+    },
+    [ChainId.BNB]: {
+      multicallChunk: 1850,
+      gasLimitPerCall: 80_000,
+      quoteMinSuccessRate: 0.15,
+    },
+    [ChainId.POLYGON]: {
+      multicallChunk: 1850,
+      gasLimitPerCall: 80_000,
+      quoteMinSuccessRate: 0.15,
+    },
+    [ChainId.MAINNET]: {
+      multicallChunk: 1974,
+      gasLimitPerCall: 75_000,
+      quoteMinSuccessRate: 0.15,
+    },
+    [ChainId.ZKSYNC]: {
+      multicallChunk: 20,
+      gasLimitPerCall: 4_000_000,
+      quoteMinSuccessRate: 0.1,
+    },
+    // TODO: once worldchain has view-quoter, optimize muilcallChunk and gasLimitPerCall
+    [ChainId.WORLDCHAIN]: {
+      multicallChunk: 80,
+      gasLimitPerCall: 1_200_000,
+      quoteMinSuccessRate: 0.1,
+    },
+    // TODO: once astrochain-sepolia has view-quoter, optimize muilcallChunk and gasLimitPerCall
+    [ChainId.ASTROCHAIN_SEPOLIA]: {
+      multicallChunk: 80,
+      gasLimitPerCall: 1_200_000,
+      quoteMinSuccessRate: 0.1,
+    },
+  },
   [Protocol.V3]: {
     ...constructSameBatchParamsMap(DEFAULT_BATCH_PARAMS),
     [ChainId.BASE]: {
@@ -248,7 +315,74 @@ export const OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [protocol: string]: { [cha
   },
 }
 
-export const NON_OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [protocol: string]: { [chainId: number]: BatchParams } } = {
+export const NON_OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [protocol in Protocol]: { [chainId: number]: BatchParams } } = {
+  // V2 doesn't apply because v2 doesnt call onchain-quote provider at all
+  // we use Protocol enum type to remember for each new protocol version, we will add the protocol specific tuning
+  [Protocol.V2]: {
+    ...constructSameBatchParamsMap(DEFAULT_BATCH_PARAMS),
+    [ChainId.BASE]: {
+      multicallChunk: 660,
+      gasLimitPerCall: 200_000,
+      quoteMinSuccessRate: 0.1,
+    },
+    [ChainId.ARBITRUM_ONE]: {
+      multicallChunk: 1125,
+      gasLimitPerCall: 200_000,
+      quoteMinSuccessRate: 0.15,
+    },
+    [ChainId.OPTIMISM]: {
+      multicallChunk: 880,
+      gasLimitPerCall: 150_000,
+      quoteMinSuccessRate: 0.1,
+    },
+    [ChainId.CELO]: {
+      multicallChunk: 3120,
+      gasLimitPerCall: 160_000,
+      quoteMinSuccessRate: 0,
+    },
+    [ChainId.BLAST]: {
+      multicallChunk: 1200,
+      gasLimitPerCall: 80_000,
+      quoteMinSuccessRate: 0.1,
+    },
+    [ChainId.AVALANCHE]: {
+      multicallChunk: 420,
+      gasLimitPerCall: 375_000,
+      quoteMinSuccessRate: 0.15,
+    },
+    [ChainId.BNB]: {
+      multicallChunk: 2961,
+      gasLimitPerCall: 50_000,
+      quoteMinSuccessRate: 0.15,
+    },
+    [ChainId.POLYGON]: {
+      multicallChunk: 987,
+      gasLimitPerCall: 150_000,
+      quoteMinSuccessRate: 0.15,
+    },
+    [ChainId.MAINNET]: {
+      multicallChunk: 987,
+      gasLimitPerCall: 150_000,
+      quoteMinSuccessRate: 0.15,
+    },
+    [ChainId.ZKSYNC]: {
+      multicallChunk: 20,
+      gasLimitPerCall: 4_000_000,
+      quoteMinSuccessRate: 0.1,
+    },
+    // TODO: once worldchain has view-quoter, optimize muilcallChunk and gasLimitPerCall
+    [ChainId.WORLDCHAIN]: {
+      multicallChunk: 80,
+      gasLimitPerCall: 1_200_000,
+      quoteMinSuccessRate: 0.1,
+    },
+    // TODO: once astrochain-sepolia has view-quoter, optimize muilcallChunk and gasLimitPerCall
+    [ChainId.ASTROCHAIN_SEPOLIA]: {
+      multicallChunk: 80,
+      gasLimitPerCall: 1_200_000,
+      quoteMinSuccessRate: 0.1,
+    },
+  },
   [Protocol.V3]: {
     ...constructSameBatchParamsMap(DEFAULT_BATCH_PARAMS),
     [ChainId.BASE]: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.14.0",
         "@uniswap/sdk-core": "^5.8.3",
-        "@uniswap/smart-order-router": "4.6.2",
+        "@uniswap/smart-order-router": "4.7.0",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^4.4.2",
         "@uniswap/v2-sdk": "^4.6.1",
@@ -4750,9 +4750,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.6.2.tgz",
-      "integrity": "sha512-NH+q0RK3T/p/h7GcBjB0Ix37RHDZovD1IQM0D5zPFLGmbeIDBIaaBpHn3GYOUbN72I/3lsljesPXZM/k6eCaCw==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.7.0.tgz",
+      "integrity": "sha512-1ABtIhHR2I5baMFiiLULDQlDua8EaR8PQpNW0limyYR9DfDdy9zd6ESko5DV5YDWVWBwvIJQRxUW4+9Gc+AUPQ==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -28449,9 +28449,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.6.2.tgz",
-      "integrity": "sha512-NH+q0RK3T/p/h7GcBjB0Ix37RHDZovD1IQM0D5zPFLGmbeIDBIaaBpHn3GYOUbN72I/3lsljesPXZM/k6eCaCw==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.7.0.tgz",
+      "integrity": "sha512-1ABtIhHR2I5baMFiiLULDQlDua8EaR8PQpNW0limyYR9DfDdy9zd6ESko5DV5YDWVWBwvIJQRxUW4+9Gc+AUPQ==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@uniswap/router-sdk": "^1.14.0",
     "@uniswap/sdk-core": "^5.8.3",
     "@types/semver": "^7.5.8",
-    "@uniswap/smart-order-router": "4.6.2",
+    "@uniswap/smart-order-router": "4.7.0",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^4.4.2",
     "@uniswap/v2-sdk": "^4.6.1",

--- a/test/mocha/integ/handlers/quote/provider-migration/traffic-switch-quote-provider.test.ts
+++ b/test/mocha/integ/handlers/quote/provider-migration/traffic-switch-quote-provider.test.ts
@@ -9,6 +9,7 @@ import { getMockedOnChainQuoteProvider } from '../../../../../test-utils/mocked-
 import { ProviderConfig } from '@uniswap/smart-order-router/build/main/providers/provider'
 import { AmountQuote } from '@uniswap/smart-order-router/build/main/providers/on-chain-quote-provider'
 import { BigNumber } from 'ethers'
+import { Protocol } from '@uniswap/router-sdk'
 
 describe('TrafficSwitchOnChainQuoteProvider', () => {
   const amountIns = [CurrencyAmount.fromRawAmount(WRAPPED_NATIVE_CURRENCY[ChainId.MAINNET], '1000000000000000000')]
@@ -28,14 +29,18 @@ describe('TrafficSwitchOnChainQuoteProvider', () => {
   })
 
   it('switch exact in traffic and sample quotes', async () => {
-    spy.withArgs(`ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_TOTAL_CHAIN_ID_${ChainId.MAINNET}`, 1, MetricLoggerUnit.None)
     spy.withArgs(
-      `ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_SAMPLING_CHAIN_ID_${ChainId.MAINNET}`,
+      `ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_TOTAL_CHAIN_ID_${ChainId.MAINNET}_PROTOCOL_${Protocol.V3}`,
       1,
       MetricLoggerUnit.None
     )
     spy.withArgs(
-      `ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_TARGET_CHAIN_ID_${ChainId.MAINNET}`,
+      `ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_SAMPLING_CHAIN_ID_${ChainId.MAINNET}_PROTOCOL_${Protocol.V3}`,
+      1,
+      MetricLoggerUnit.None
+    )
+    spy.withArgs(
+      `ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_TARGET_CHAIN_ID_${ChainId.MAINNET}_PROTOCOL_${Protocol.V3}`,
       1,
       MetricLoggerUnit.None
     )
@@ -45,8 +50,8 @@ describe('TrafficSwitchOnChainQuoteProvider', () => {
 
     const trafficSwitchProvider =
       new (class SwitchTrafficSwitchOnChainQuoteProvider extends TrafficSwitchOnChainQuoteProvider {
-        override readonly SHOULD_SWITCH_EXACT_IN_TRAFFIC = (_: ChainId) => true
-        override readonly SHOULD_SAMPLE_EXACT_IN_TRAFFIC = (_: ChainId) => true
+        override readonly SHOULD_SWITCH_EXACT_IN_TRAFFIC = (_chainId: ChainId, _protocol: Protocol) => true
+        override readonly SHOULD_SAMPLE_EXACT_IN_TRAFFIC = (_chainId: ChainId, _protocol: Protocol) => true
       })({
         currentQuoteProvider: currentQuoteProvider,
         targetQuoteProvider: targetQuoteProvider,
@@ -61,9 +66,13 @@ describe('TrafficSwitchOnChainQuoteProvider', () => {
   })
 
   it('does not switch exact in traffic and sample quotes', async () => {
-    spy.withArgs(`ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_TOTAL_CHAIN_ID_${ChainId.MAINNET}`, 1, MetricLoggerUnit.None)
     spy.withArgs(
-      `ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_CHAIN_ID_${ChainId.MAINNET}`,
+      `ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_TOTAL_CHAIN_ID_${ChainId.MAINNET}_PROTOCOL_${Protocol.V3}`,
+      1,
+      MetricLoggerUnit.None
+    )
+    spy.withArgs(
+      `ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_CHAIN_ID_${ChainId.MAINNET}_PROTOCOL_${Protocol.V3}`,
       1,
       MetricLoggerUnit.None
     )
@@ -73,8 +82,8 @@ describe('TrafficSwitchOnChainQuoteProvider', () => {
 
     const trafficSwitchProvider =
       new (class SwitchTrafficSwitchOnChainQuoteProvider extends TrafficSwitchOnChainQuoteProvider {
-        override readonly SHOULD_SWITCH_EXACT_IN_TRAFFIC = (_: ChainId) => true
-        override readonly SHOULD_SAMPLE_EXACT_IN_TRAFFIC = (_: ChainId) => true
+        override readonly SHOULD_SWITCH_EXACT_IN_TRAFFIC = (_chainId: ChainId, _protocol: Protocol) => true
+        override readonly SHOULD_SAMPLE_EXACT_IN_TRAFFIC = (_chainId: ChainId, _protocol: Protocol) => true
       })({
         currentQuoteProvider: currentQuoteProvider,
         targetQuoteProvider: targetQuoteProvider,
@@ -90,17 +99,17 @@ describe('TrafficSwitchOnChainQuoteProvider', () => {
 
   it('switch exact out traffic and sample quotes', async () => {
     spy.withArgs(
-      `ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_TOTAL_CHAIN_ID_${ChainId.MAINNET}`,
+      `ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_TOTAL_CHAIN_ID_${ChainId.MAINNET}_PROTOCOL_${Protocol.V3}`,
       1,
       MetricLoggerUnit.None
     )
     spy.withArgs(
-      `ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_SAMPLING_CHAIN_ID_${ChainId.MAINNET}`,
+      `ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_SAMPLING_CHAIN_ID_${ChainId.MAINNET}_PROTOCOL_${Protocol.V3}`,
       1,
       MetricLoggerUnit.None
     )
     spy.withArgs(
-      `ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_TARGET_CHAIN_ID_${ChainId.MAINNET}`,
+      `ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_TARGET_CHAIN_ID_${ChainId.MAINNET}_PROTOCOL_${Protocol.V3}`,
       1,
       MetricLoggerUnit.None
     )
@@ -110,8 +119,8 @@ describe('TrafficSwitchOnChainQuoteProvider', () => {
 
     const trafficSwitchProvider =
       new (class SwitchTrafficSwitchOnChainQuoteProvider extends TrafficSwitchOnChainQuoteProvider {
-        override readonly SHOULD_SWITCH_EXACT_OUT_TRAFFIC = (_: ChainId) => true
-        override readonly SHOULD_SAMPLE_EXACT_OUT_TRAFFIC = (_: ChainId) => true
+        override readonly SHOULD_SWITCH_EXACT_OUT_TRAFFIC = (_chainId: ChainId, _protocol: Protocol) => true
+        override readonly SHOULD_SAMPLE_EXACT_OUT_TRAFFIC = (_chainId: ChainId, _protocol: Protocol) => true
       })({
         currentQuoteProvider: currentQuoteProvider,
         targetQuoteProvider: targetQuoteProvider,
@@ -127,12 +136,12 @@ describe('TrafficSwitchOnChainQuoteProvider', () => {
 
   it('does not switch exact out traffic and sample quotes', async () => {
     spy.withArgs(
-      `ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_TOTAL_CHAIN_ID_${ChainId.MAINNET}`,
+      `ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_TOTAL_CHAIN_ID_${ChainId.MAINNET}_PROTOCOL_${Protocol.V3}`,
       1,
       MetricLoggerUnit.None
     )
     spy.withArgs(
-      `ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_CURRENT_CHAIN_ID_${ChainId.MAINNET}`,
+      `ON_CHAIN_QUOTE_PROVIDER_EXACT_OUT_TRAFFIC_CURRENT_CHAIN_ID_${ChainId.MAINNET}_PROTOCOL_${Protocol.V3}`,
       1,
       MetricLoggerUnit.None
     )
@@ -142,8 +151,8 @@ describe('TrafficSwitchOnChainQuoteProvider', () => {
 
     const trafficSwitchProvider =
       new (class SwitchTrafficSwitchOnChainQuoteProvider extends TrafficSwitchOnChainQuoteProvider {
-        override readonly SHOULD_SWITCH_EXACT_OUT_TRAFFIC = (_: ChainId) => true
-        override readonly SHOULD_SAMPLE_EXACT_OUT_TRAFFIC = (_: ChainId) => true
+        override readonly SHOULD_SWITCH_EXACT_OUT_TRAFFIC = (_chainId: ChainId, _protocol: Protocol) => true
+        override readonly SHOULD_SAMPLE_EXACT_OUT_TRAFFIC = (_chainId: ChainId, _protocol: Protocol) => true
       })({
         currentQuoteProvider: currentQuoteProvider,
         targetQuoteProvider: targetQuoteProvider,
@@ -165,8 +174,8 @@ describe('TrafficSwitchOnChainQuoteProvider', () => {
 
     const trafficSwitchProvider =
       new (class SwitchTrafficSwitchOnChainQuoteProvider extends TrafficSwitchOnChainQuoteProvider {
-        override readonly SHOULD_SAMPLE_EXACT_IN_TRAFFIC = (_: ChainId) => true
-        override readonly SHOULD_SWITCH_EXACT_IN_TRAFFIC = (_: ChainId) => false
+        override readonly SHOULD_SAMPLE_EXACT_IN_TRAFFIC = (_chainId: ChainId, _protocol: Protocol) => true
+        override readonly SHOULD_SWITCH_EXACT_IN_TRAFFIC = (_chainId: ChainId, _protocol: Protocol) => false
       })({
         currentQuoteProvider: currentQuoteProvider,
         targetQuoteProvider: targetQuoteProvider,
@@ -189,8 +198,8 @@ describe('TrafficSwitchOnChainQuoteProvider', () => {
 
     const trafficSwitchProvider =
       new (class SwitchTrafficSwitchOnChainQuoteProvider extends TrafficSwitchOnChainQuoteProvider {
-        override readonly SHOULD_SAMPLE_EXACT_IN_TRAFFIC = (_: ChainId) => true
-        override readonly SHOULD_SWITCH_EXACT_IN_TRAFFIC = (_: ChainId) => true
+        override readonly SHOULD_SAMPLE_EXACT_IN_TRAFFIC = (_chainId: ChainId, _protocol: Protocol) => true
+        override readonly SHOULD_SWITCH_EXACT_IN_TRAFFIC = (_chainId: ChainId, _protocol: Protocol) => true
       })({
         currentQuoteProvider: currentQuoteProvider,
         targetQuoteProvider: targetQuoteProvider,
@@ -213,8 +222,8 @@ describe('TrafficSwitchOnChainQuoteProvider', () => {
 
     const trafficSwitchProvider =
       new (class SwitchTrafficSwitchOnChainQuoteProvider extends TrafficSwitchOnChainQuoteProvider {
-        override readonly SHOULD_SAMPLE_EXACT_OUT_TRAFFIC = (_: ChainId) => true
-        override readonly SHOULD_SWITCH_EXACT_OUT_TRAFFIC = (_: ChainId) => false
+        override readonly SHOULD_SAMPLE_EXACT_OUT_TRAFFIC = (_chainId: ChainId, _protocol: Protocol) => true
+        override readonly SHOULD_SWITCH_EXACT_OUT_TRAFFIC = (_chainId: ChainId, _protocol: Protocol) => false
       })({
         currentQuoteProvider: currentQuoteProvider,
         targetQuoteProvider: targetQuoteProvider,
@@ -237,8 +246,8 @@ describe('TrafficSwitchOnChainQuoteProvider', () => {
 
     const trafficSwitchProvider =
       new (class SwitchTrafficSwitchOnChainQuoteProvider extends TrafficSwitchOnChainQuoteProvider {
-        override readonly SHOULD_SAMPLE_EXACT_OUT_TRAFFIC = (_: ChainId) => true
-        override readonly SHOULD_SWITCH_EXACT_OUT_TRAFFIC = (_: ChainId) => true
+        override readonly SHOULD_SAMPLE_EXACT_OUT_TRAFFIC = (_chainId: ChainId, _protocol: Protocol) => true
+        override readonly SHOULD_SWITCH_EXACT_OUT_TRAFFIC = (_chainId: ChainId, _protocol: Protocol) => true
       })({
         currentQuoteProvider: currentQuoteProvider,
         targetQuoteProvider: targetQuoteProvider,
@@ -255,12 +264,12 @@ describe('TrafficSwitchOnChainQuoteProvider', () => {
 
   it('sample exact in quotes and current quoter out of gas for the quote', async () => {
     spy.withArgs(
-      `ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MATCH_CHAIN_ID_${ChainId.MAINNET}`,
+      `ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MATCH_CHAIN_ID_${ChainId.MAINNET}_PROTOCOL_${Protocol.V3}`,
       1,
       MetricLoggerUnit.None
     )
     spy.withArgs(
-      `ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MISMATCH_CHAIN_ID_${ChainId.MAINNET}`,
+      `ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MISMATCH_CHAIN_ID_${ChainId.MAINNET}_PROTOCOL_${Protocol.V3}`,
       1,
       MetricLoggerUnit.None
     )
@@ -288,7 +297,7 @@ describe('TrafficSwitchOnChainQuoteProvider', () => {
 
     const trafficSwitchProvider =
       new (class SwitchTrafficSwitchOnChainQuoteProvider extends TrafficSwitchOnChainQuoteProvider {
-        override readonly SHOULD_SAMPLE_EXACT_IN_TRAFFIC = (_: ChainId) => true
+        override readonly SHOULD_SAMPLE_EXACT_IN_TRAFFIC = (_chainId: ChainId, _protocol: Protocol) => true
       })({
         currentQuoteProvider: currentQuoteProvider,
         targetQuoteProvider: targetQuoteProvider,
@@ -300,13 +309,13 @@ describe('TrafficSwitchOnChainQuoteProvider', () => {
     // We will check neither match nor mismatch metric was logged
     sinon.assert.neverCalledWith(
       spy,
-      `ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MATCH_CHAIN_ID_${ChainId.MAINNET}`,
+      `ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MATCH_CHAIN_ID_${ChainId.MAINNET}_PROTOCOL_${Protocol.V3}`,
       1,
       MetricLoggerUnit.None
     )
     sinon.assert.neverCalledWith(
       spy,
-      `ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MISMATCH_CHAIN_ID_${ChainId.MAINNET}`,
+      `ON_CHAIN_QUOTE_PROVIDER_EXACT_IN_TRAFFIC_CURRENT_AND_TARGET_QUOTES_MISMATCH_CHAIN_ID_${ChainId.MAINNET}_PROTOCOL_${Protocol.V3}`,
       1,
       MetricLoggerUnit.None
     )

--- a/test/mocha/integ/handlers/quote/provider-migration/traffic-switch-quote-provider.test.ts
+++ b/test/mocha/integ/handlers/quote/provider-migration/traffic-switch-quote-provider.test.ts
@@ -1,7 +1,7 @@
 import sinon, { SinonSpy } from 'sinon'
 import { metric } from '@uniswap/smart-order-router/build/main/util/metric'
 import { MetricLoggerUnit, RouteWithQuotes, USDC_MAINNET, WRAPPED_NATIVE_CURRENCY } from '@uniswap/smart-order-router'
-import { TrafficSwitchOnChainQuoteProvider } from '../../../../../../lib/handlers/quote/provider-migration/v3/traffic-switch-on-chain-quote-provider'
+import { TrafficSwitchOnChainQuoteProvider } from '../../../../../../lib/handlers/quote/provider-migration/traffic-switch-on-chain-quote-provider'
 import { ChainId, CurrencyAmount } from '@uniswap/sdk-core'
 import { V3Route } from '@uniswap/smart-order-router/build/main/routers'
 import { USDC_WETH_LOW } from '../../../../../test-utils/mocked-data'


### PR DESCRIPTION
this PR compliments https://github.com/Uniswap/smart-order-router/pull/746, and will be able to achieve:
1. routing-api to shadow sample mixed routing against mixed quoter v1 across L2s. There's no accuracy to compare, just make sure routing-api shadow mixed routing success rate is high - existing metrics in routing-api ON_CHAIN_QUOTE_PROVIDER_${this.EXACT_IN_METRIC}_TRAFFIC_TARGET_FAILED_CHAIN_ID_${this.chainId}

On L2, only Base has the MixedRouteQuoterV1 deployed (see [context](https://uniswapteam.slack.com/archives/C021SU4PMR7/p1715195416711929?thread_ts=1712077488.419319&cid=C021SU4PMR7)). I thought its due to the lack of FOT and exact out support. But its actually due to SOR only enables mixed routing on L1 https://github.com/Uniswap/smart-order-router/blob/66927c4e4f7e75138df48afab1c33a6c6d8d8f15/src/routers/alpha-router/alpha-router.ts#L2081.

Therefore in this PR, I will only enable shadow sampling against Base mixed routing on L2, but keep 100% mixed routing traffic on L1.

I also enhanced existing unit test coverages.

tests all passed on my local https://app.warp.dev/block/afa5Lrn5JUeIIscuDGm14B

Tested on my personal AWS account:

- [x]  L1 mainnet - I can see only V3 and Mixed, all hitting target quoter address. Because V3 is migrated from revert quoter to view-only quoter on L1, and MixedRouteQuoterV1 is live on L1. V4 is not deployed to L1.
<img width="1213" alt="Screenshot 2024-10-14 at 3 25 42 PM" src="https://github.com/user-attachments/assets/2795755a-15ca-4362-9f0d-12f35cd8fde1">

- [x] Optimism - I can see only V3 hitting targer quoter address. V4 and MixedRouteQuoterV1 is not deployed to Optimism.
<img width="1212" alt="Screenshot 2024-10-14 at 3 31 37 PM" src="https://github.com/user-attachments/assets/8b14b831-dcd6-4c12-8c31-cc96ddf3c689">

- [x] Arb -   I can see only V3 hitting targer quoter address. V4 and MixedRouteQuoterV1 is not deployed to Arb.
<img width="1211" alt="Screenshot 2024-10-14 at 3 33 32 PM" src="https://github.com/user-attachments/assets/4d82d0dd-b685-4512-b697-478e1a79a20e">

- [x] Polygon - I can see only V3 hitting targer quoter address. V4 and MixedRouteQuoterV1 is not deployed to Polygon.
<img width="1210" alt="Screenshot 2024-10-14 at 3 34 31 PM" src="https://github.com/user-attachments/assets/a0c34191-4272-4bf6-a6bb-86270621feb8">

- [x] Celo - I can see only V3 hitting targer quoter address. V4 and MixedRouteQuoterV1 is not deployed to Celo.
<img width="1212" alt="Screenshot 2024-10-14 at 3 35 14 PM" src="https://github.com/user-attachments/assets/d1efa077-1fbb-46c8-918d-62d00acac706">

- [x] BNB - I can see only V3 hitting targer quoter address. V4 and MixedRouteQuoterV1 is not deployed to BNB.
<img width="1223" alt="Screenshot 2024-10-14 at 3 36 11 PM" src="https://github.com/user-attachments/assets/0095477c-3f52-4197-8cca-5483052a3f01">

- [x] AVAX - I can see only V3 hitting targer quoter address. V4 and MixedRouteQuoterV1 is not deployed to AVAX.
<img width="1212" alt="Screenshot 2024-10-14 at 3 37 28 PM" src="https://github.com/user-attachments/assets/4e95318e-8aa8-476f-aef0-87f95c37c15d">

- [x] BASE - I can see only V3 hitting targer quoter address. V4 not deployed to BASE. MixedRouteQuoterV1 deployed, but sampling rate too low.
<img width="1223" alt="Screenshot 2024-10-14 at 3 38 21 PM" src="https://github.com/user-attachments/assets/b9200b8b-d45b-48ae-b2c9-69da0a7658ec">
