### PR TITLE
fix: bump sor to 4.6.2 - bump sdk-core for worldchain and unichain sepolia v2 router

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,8 +27,8 @@
         "@uniswap/default-token-list": "^11.13.0",
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.14.0",
-        "@uniswap/sdk-core": "^5.8.2",
-        "@uniswap/smart-order-router": "4.6.1",
+        "@uniswap/sdk-core": "^5.8.3",
+        "@uniswap/smart-order-router": "4.6.2",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^4.4.2",
         "@uniswap/v2-sdk": "^4.6.1",
@@ -4731,9 +4731,9 @@
       }
     },
     "node_modules/@uniswap/sdk-core": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/@uniswap/sdk-core/-/sdk-core-5.8.2.tgz",
-      "integrity": "sha512-4rQHqymPoOX7O3gTf2J4r7LgTrz69KudJQhNqJW+8HFnPMB8ncRSQbDgIQBp6dP46h9BDpJF4oAvpI7gc433mA==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/@uniswap/sdk-core/-/sdk-core-5.8.3.tgz",
+      "integrity": "sha512-TqemD6YrIt1U7fY4t6y/OYdRnqWv3QB4DSN15INh+uQXNoBBE/8zWmdYBB6/7yTES47NkalpSnbokNTyNNqrTA==",
       "dependencies": {
         "@ethersproject/address": "^5.0.2",
         "@ethersproject/bytes": "^5.7.0",
@@ -4750,16 +4750,16 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.6.1.tgz",
-      "integrity": "sha512-4T8f01B7QKUi0LY9J3eL8W+W1KbcxmY3ALolLPMCsHajPA7bW3uQUiTqk5uH87e1itcGuwqps0zEacSjYW/EGQ==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.6.2.tgz",
+      "integrity": "sha512-NH+q0RK3T/p/h7GcBjB0Ix37RHDZovD1IQM0D5zPFLGmbeIDBIaaBpHn3GYOUbN72I/3lsljesPXZM/k6eCaCw==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
         "@uniswap/default-token-list": "^11.13.0",
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.14.0",
-        "@uniswap/sdk-core": "^5.8.2",
+        "@uniswap/sdk-core": "^5.8.3",
         "@uniswap/swap-router-contracts": "^1.3.1",
         "@uniswap/token-lists": "^1.0.0-beta.31",
         "@uniswap/universal-router": "^1.6.0",
@@ -28433,9 +28433,9 @@
       }
     },
     "@uniswap/sdk-core": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/@uniswap/sdk-core/-/sdk-core-5.8.2.tgz",
-      "integrity": "sha512-4rQHqymPoOX7O3gTf2J4r7LgTrz69KudJQhNqJW+8HFnPMB8ncRSQbDgIQBp6dP46h9BDpJF4oAvpI7gc433mA==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/@uniswap/sdk-core/-/sdk-core-5.8.3.tgz",
+      "integrity": "sha512-TqemD6YrIt1U7fY4t6y/OYdRnqWv3QB4DSN15INh+uQXNoBBE/8zWmdYBB6/7yTES47NkalpSnbokNTyNNqrTA==",
       "requires": {
         "@ethersproject/address": "^5.0.2",
         "@ethersproject/bytes": "^5.7.0",
@@ -28449,16 +28449,16 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.6.1.tgz",
-      "integrity": "sha512-4T8f01B7QKUi0LY9J3eL8W+W1KbcxmY3ALolLPMCsHajPA7bW3uQUiTqk5uH87e1itcGuwqps0zEacSjYW/EGQ==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.6.2.tgz",
+      "integrity": "sha512-NH+q0RK3T/p/h7GcBjB0Ix37RHDZovD1IQM0D5zPFLGmbeIDBIaaBpHn3GYOUbN72I/3lsljesPXZM/k6eCaCw==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
         "@uniswap/default-token-list": "^11.13.0",
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.14.0",
-        "@uniswap/sdk-core": "^5.8.2",
+        "@uniswap/sdk-core": "^5.8.3",
         "@uniswap/swap-router-contracts": "^1.3.1",
         "@uniswap/token-lists": "^1.0.0-beta.31",
         "@uniswap/universal-router": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -85,13 +85,10 @@
     "@uniswap/default-token-list": "^11.13.0",
     "@uniswap/permit2-sdk": "^1.3.0",
     "@uniswap/router-sdk": "^1.14.0",
-    // TODO update sdk-once once https://github.com/Uniswap/sdks/pull/171 is merged and published
-    "@uniswap/sdk-core": "^5.8.2",
+    "@uniswap/sdk-core": "^5.8.3",
     "@types/semver": "^7.5.8",
-    // TODO update sor once https://github.com/Uniswap/smart-order-router/pull/748/files is merged and published
-    "@uniswap/smart-order-router": "4.6.1",
+    "@uniswap/smart-order-router": "4.6.2",
     "@uniswap/token-lists": "^1.0.0-beta.33",
-    // TODO update ur-sdk once https://github.com/Uniswap/sdks/pull/172 is merged and published
     "@uniswap/universal-router-sdk": "^4.4.2",
     "@uniswap/v2-sdk": "^4.6.1",
     "@uniswap/v3-periphery": "^1.4.4",

--- a/package.json
+++ b/package.json
@@ -85,10 +85,13 @@
     "@uniswap/default-token-list": "^11.13.0",
     "@uniswap/permit2-sdk": "^1.3.0",
     "@uniswap/router-sdk": "^1.14.0",
+    // TODO update sdk-once once https://github.com/Uniswap/sdks/pull/171 is merged and published
     "@uniswap/sdk-core": "^5.8.2",
     "@types/semver": "^7.5.8",
+    // TODO update sor once https://github.com/Uniswap/smart-order-router/pull/748/files is merged and published
     "@uniswap/smart-order-router": "4.6.1",
     "@uniswap/token-lists": "^1.0.0-beta.33",
+    // TODO update ur-sdk once https://github.com/Uniswap/sdks/pull/172 is merged and published
     "@uniswap/universal-router-sdk": "^4.4.2",
     "@uniswap/v2-sdk": "^4.6.1",
     "@uniswap/v3-periphery": "^1.4.4",


### PR DESCRIPTION
showhorn:
- worldchain and unichain sepolia LP unblock, due to incorrect UniswapV2Router02
- sepolia v4 re-deploy