### PR TITLE
feat(unirpc): switch traffic for all chains at 100% (Mainnet 30%)

### DIFF
--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -4,7 +4,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.1,
     "healthCheckSampleProb": 0.1,
-    "providerInitialWeights": [0.5, 0.5],
+    "providerInitialWeights": [0, 1],
     "providerUrls": ["QUICKNODE_42220", "UNIRPC_0"],
     "providerNames": ["QUICKNODE", "UNIRPC"]
   },
@@ -13,7 +13,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.1,
     "healthCheckSampleProb": 0.1,
-    "providerInitialWeights": [0.5, 0.5],
+    "providerInitialWeights": [0, 1],
     "providerUrls": ["QUICKNODE_43114", "UNIRPC_0"],
     "providerNames": ["QUICKNODE", "UNIRPC"]
   },
@@ -22,7 +22,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.01,
     "healthCheckSampleProb": 0.01,
-    "providerInitialWeights": [0.7, 0.3],
+    "providerInitialWeights": [0, 1],
     "providerUrls": ["QUICKNODE_56", "UNIRPC_0"],
     "providerNames": ["QUICKNODE", "UNIRPC"]
   },
@@ -31,7 +31,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.1,
     "healthCheckSampleProb": 0.01,
-    "providerInitialWeights": [0.5, 0.5],
+    "providerInitialWeights": [0, 1],
     "providerUrls": ["QUICKNODE_10", "UNIRPC_0"],
     "providerNames": ["QUICKNODE", "UNIRPC"]
   },
@@ -40,7 +40,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.01,
     "healthCheckSampleProb": 0.01,
-    "providerInitialWeights": [0.5, 0.5],
+    "providerInitialWeights": [0, 1],
     "providerUrls": ["ALCHEMY_11155111", "UNIRPC_0"],
     "providerNames": ["ALCHEMY", "UNIRPC"],
     "enableDbSync": true
@@ -50,7 +50,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.25,
     "healthCheckSampleProb": 0.005,
-    "providerInitialWeights": [0.5, 0.5],
+    "providerInitialWeights": [0, 1],
     "providerUrls": ["QUICKNODE_137", "UNIRPC_0"],
     "providerNames": ["QUICKNODE", "UNIRPC"]
   },
@@ -59,7 +59,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.1,
     "healthCheckSampleProb": 0.002,
-    "providerInitialWeights": [0.7, 0.3],
+    "providerInitialWeights": [0, 1],
     "providerUrls": ["QUICKNODE_42161", "UNIRPC_0"],
     "providerNames": ["QUICKNODE", "UNIRPC"]
   },
@@ -68,7 +68,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.05,
     "healthCheckSampleProb": 0.0005,
-    "providerInitialWeights": [0.7, 0.3],
+    "providerInitialWeights": [0, 1],
     "providerUrls": ["QUICKNODE_8453", "UNIRPC_0"],
     "providerNames": ["QUICKNODE", "UNIRPC"]
   },
@@ -77,7 +77,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.05,
     "healthCheckSampleProb": 0.001,
-    "providerInitialWeights": [0.9, 0.1, 0],
+    "providerInitialWeights": [0.5, 0.5, 0],
     "providerUrls": ["QUICKNODE_1", "UNIRPC_0", "QUICKNODERETH_1"],
     "providerNames": ["QUICKNODE", "UNIRPC", "QUICKNODERETH"]
   },
@@ -86,7 +86,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.001,
     "healthCheckSampleProb": 0.001,
-    "providerInitialWeights": [0.5, 0.5],
+    "providerInitialWeights": [0, 1],
     "providerUrls": ["QUICKNODE_81457", "UNIRPC_0"],
     "providerNames": ["QUICKNODE", "UNIRPC"]
   },
@@ -95,7 +95,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.001,
     "healthCheckSampleProb": 0.001,
-    "providerInitialWeights": [0.5, 0.5],
+    "providerInitialWeights": [0, 1],
     "providerUrls": ["QUICKNODE_7777777", "UNIRPC_0"],
     "providerNames": ["QUICKNODE", "UNIRPC"]
   },
@@ -104,7 +104,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.01,
     "healthCheckSampleProb": 0.01,
-    "providerInitialWeights": [0.5, 0.5],
+    "providerInitialWeights": [0, 1],
     "providerUrls": ["QUICKNODE_324", "UNIRPC_0"],
     "providerNames": ["QUICKNODE", "UNIRPC"]
   },

--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -4,7 +4,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.1,
     "healthCheckSampleProb": 0.1,
-    "providerInitialWeights": [0.9, 0.1],
+    "providerInitialWeights": [0.5, 0.5],
     "providerUrls": ["QUICKNODE_42220", "UNIRPC_0"],
     "providerNames": ["QUICKNODE", "UNIRPC"]
   },
@@ -13,7 +13,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.1,
     "healthCheckSampleProb": 0.1,
-    "providerInitialWeights": [0.9, 0.1],
+    "providerInitialWeights": [0.5, 0.5],
     "providerUrls": ["QUICKNODE_43114", "UNIRPC_0"],
     "providerNames": ["QUICKNODE", "UNIRPC"]
   },
@@ -22,7 +22,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.01,
     "healthCheckSampleProb": 0.01,
-    "providerInitialWeights": [0.9, 0.1],
+    "providerInitialWeights": [0.7, 0.3],
     "providerUrls": ["QUICKNODE_56", "UNIRPC_0"],
     "providerNames": ["QUICKNODE", "UNIRPC"]
   },
@@ -31,7 +31,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.1,
     "healthCheckSampleProb": 0.01,
-    "providerInitialWeights": [0.9, 0.1],
+    "providerInitialWeights": [0.5, 0.5],
     "providerUrls": ["QUICKNODE_10", "UNIRPC_0"],
     "providerNames": ["QUICKNODE", "UNIRPC"]
   },
@@ -40,7 +40,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.01,
     "healthCheckSampleProb": 0.01,
-    "providerInitialWeights": [0.9, 0.1],
+    "providerInitialWeights": [0.5, 0.5],
     "providerUrls": ["ALCHEMY_11155111", "UNIRPC_0"],
     "providerNames": ["ALCHEMY", "UNIRPC"],
     "enableDbSync": true
@@ -50,7 +50,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.25,
     "healthCheckSampleProb": 0.005,
-    "providerInitialWeights": [0.9, 0.1],
+    "providerInitialWeights": [0.5, 0.5],
     "providerUrls": ["QUICKNODE_137", "UNIRPC_0"],
     "providerNames": ["QUICKNODE", "UNIRPC"]
   },
@@ -59,7 +59,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.1,
     "healthCheckSampleProb": 0.002,
-    "providerInitialWeights": [0.95, 0.05],
+    "providerInitialWeights": [0.7, 0.3],
     "providerUrls": ["QUICKNODE_42161", "UNIRPC_0"],
     "providerNames": ["QUICKNODE", "UNIRPC"]
   },
@@ -68,7 +68,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.05,
     "healthCheckSampleProb": 0.0005,
-    "providerInitialWeights": [0.95, 0.05],
+    "providerInitialWeights": [0.7, 0.3],
     "providerUrls": ["QUICKNODE_8453", "UNIRPC_0"],
     "providerNames": ["QUICKNODE", "UNIRPC"]
   },
@@ -77,7 +77,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.05,
     "healthCheckSampleProb": 0.001,
-    "providerInitialWeights": [0.99, 0.01, 0],
+    "providerInitialWeights": [0.9, 0.1, 0],
     "providerUrls": ["QUICKNODE_1", "UNIRPC_0", "QUICKNODERETH_1"],
     "providerNames": ["QUICKNODE", "UNIRPC", "QUICKNODERETH"]
   },
@@ -86,7 +86,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.001,
     "healthCheckSampleProb": 0.001,
-    "providerInitialWeights": [0.9, 0.1],
+    "providerInitialWeights": [0.5, 0.5],
     "providerUrls": ["QUICKNODE_81457", "UNIRPC_0"],
     "providerNames": ["QUICKNODE", "UNIRPC"]
   },
@@ -95,7 +95,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.001,
     "healthCheckSampleProb": 0.001,
-    "providerInitialWeights": [0.9, 0.1],
+    "providerInitialWeights": [0.5, 0.5],
     "providerUrls": ["QUICKNODE_7777777", "UNIRPC_0"],
     "providerNames": ["QUICKNODE", "UNIRPC"]
   },
@@ -104,7 +104,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.01,
     "healthCheckSampleProb": 0.01,
-    "providerInitialWeights": [0.9, 0.1],
+    "providerInitialWeights": [0.5, 0.5],
     "providerUrls": ["QUICKNODE_324", "UNIRPC_0"],
     "providerNames": ["QUICKNODE", "UNIRPC"]
   },

--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -77,7 +77,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.05,
     "healthCheckSampleProb": 0.001,
-    "providerInitialWeights": [0.5, 0.5, 0],
+    "providerInitialWeights": [0.7, 0.3, 0],
     "providerUrls": ["QUICKNODE_1", "UNIRPC_0", "QUICKNODERETH_1"],
     "providerNames": ["QUICKNODE", "UNIRPC", "QUICKNODERETH"]
   },


### PR DESCRIPTION
_**Note**: 
Plan to check this in later this week or coming Monday, once we monitor `unirpc` traffic switch that went live on Tue Oct 15th._

### Description
Continue unirpc onboarding for routing API for all chains
We have onboarded all chains at 10/30/50% without issues so far ([dashboard](https://app.datadoghq.com/dashboard/3tp-vmc-q3n/unirpc-service-dashboard?fromUser=true&refresh_mode=sliding&tpl_var_serviceid%5B0%5D=routing_api&from_ts=1729006934865&to_ts=1729021334865&live=true)).

This PR updates unirpc traffic for all chains as follows:
- **high volume** chains from `10%` to `30%` (`Mainnet`)
- **mid volume** chains from `30%` to `100%` (`Base, Arbitrum, Binance`)
- **low volume** chains from `50%` to `100%` (all the rest)

Plan to monitor for a few days, then fully onboard everything.