### PR TITLE
chore: bump sor to 4.7.1 - fix: v4 subgraph provider add ETH base token, and custom fee tier and tick spacings

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -9,6 +9,7 @@ import {
   EIP1559GasPriceProvider,
   EthEstimateGasSimulator,
   FallbackTenderlySimulator,
+  getApplicableV4FeesTickspacingsHooks,
   IGasPriceProvider,
   IMetric,
   IOnChainQuoteProvider,
@@ -85,6 +86,10 @@ import { UniJsonRpcProvider } from '../rpc/UniJsonRpcProvider'
 import { GraphQLTokenFeeFetcher } from '../graphql/graphql-token-fee-fetcher'
 import { UniGraphQLProvider } from '../graphql/graphql-provider'
 import { TrafficSwitcherITokenFeeFetcher } from '../util/traffic-switch/traffic-switcher-i-token-fee-fetcher'
+import {
+  emptyV4FeeTickSpacingsHookAddresses,
+  EXTRA_V4_FEE_TICK_SPACINGS_HOOK_ADDRESSES,
+} from '../util/extraV4FeeTiersTickSpacingsHookAddresses'
 
 export const SUPPORTED_CHAINS: ChainId[] = [
   ChainId.MAINNET,
@@ -478,6 +483,10 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
 
           const mixedSupported = [ChainId.MAINNET, ChainId.SEPOLIA, ChainId.GOERLI]
 
+          const v4PoolsParams = getApplicableV4FeesTickspacingsHooks(chainId).concat(
+            EXTRA_V4_FEE_TICK_SPACINGS_HOOK_ADDRESSES[chainId] ?? emptyV4FeeTickSpacingsHookAddresses
+          )
+
           return {
             chainId,
             dependencies: {
@@ -511,6 +520,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
               v2Supported,
               v4Supported,
               mixedSupported,
+              v4PoolsParams,
             },
           }
         })

--- a/lib/util/extraV4FeeTiersTickSpacingsHookAddresses.ts
+++ b/lib/util/extraV4FeeTiersTickSpacingsHookAddresses.ts
@@ -1,0 +1,41 @@
+import { ChainId } from '@uniswap/sdk-core'
+
+export const emptyV4FeeTickSpacingsHookAddresses: Array<[number, number, string]> = new Array<
+  [number, number, string]
+>()
+
+export const EXTRA_V4_FEE_TICK_SPACINGS_HOOK_ADDRESSES: { [chain in ChainId]: Array<[number, number, string]> } = {
+  [ChainId.MAINNET]: emptyV4FeeTickSpacingsHookAddresses,
+  [ChainId.GOERLI]: emptyV4FeeTickSpacingsHookAddresses,
+  [ChainId.SEPOLIA]: [
+    // NOTE, we are only supporting hook routing in sepolia,
+    // because those are the only liquid ETH/USDC pools with hardcoded hooks, that we LP'ed against sepolia v4 pool manager
+    // we will not support any hook routing in initial v4 launch in any production networks
+    [500, 10, '0x0000000000000000000000000000000000000020'],
+    [1500, 30, '0x0000000000000000000000000000000000000020'],
+    [3000, 60, '0x0000000000000000000000000000000000000020'],
+  ],
+  [ChainId.OPTIMISM]: emptyV4FeeTickSpacingsHookAddresses,
+  [ChainId.OPTIMISM_GOERLI]: emptyV4FeeTickSpacingsHookAddresses,
+  [ChainId.OPTIMISM_SEPOLIA]: emptyV4FeeTickSpacingsHookAddresses,
+  [ChainId.ARBITRUM_ONE]: emptyV4FeeTickSpacingsHookAddresses,
+  [ChainId.ARBITRUM_GOERLI]: emptyV4FeeTickSpacingsHookAddresses,
+  [ChainId.ARBITRUM_SEPOLIA]: emptyV4FeeTickSpacingsHookAddresses,
+  [ChainId.POLYGON]: emptyV4FeeTickSpacingsHookAddresses,
+  [ChainId.POLYGON_MUMBAI]: emptyV4FeeTickSpacingsHookAddresses,
+  [ChainId.CELO]: emptyV4FeeTickSpacingsHookAddresses,
+  [ChainId.CELO_ALFAJORES]: emptyV4FeeTickSpacingsHookAddresses,
+  [ChainId.GNOSIS]: emptyV4FeeTickSpacingsHookAddresses,
+  [ChainId.MOONBEAM]: emptyV4FeeTickSpacingsHookAddresses,
+  [ChainId.BNB]: emptyV4FeeTickSpacingsHookAddresses,
+  [ChainId.AVALANCHE]: emptyV4FeeTickSpacingsHookAddresses,
+  [ChainId.BASE_GOERLI]: emptyV4FeeTickSpacingsHookAddresses,
+  [ChainId.BASE]: emptyV4FeeTickSpacingsHookAddresses,
+  [ChainId.ZORA]: emptyV4FeeTickSpacingsHookAddresses,
+  [ChainId.ZORA_SEPOLIA]: emptyV4FeeTickSpacingsHookAddresses,
+  [ChainId.ROOTSTOCK]: emptyV4FeeTickSpacingsHookAddresses,
+  [ChainId.BLAST]: emptyV4FeeTickSpacingsHookAddresses,
+  [ChainId.ZKSYNC]: emptyV4FeeTickSpacingsHookAddresses,
+  [ChainId.WORLDCHAIN]: emptyV4FeeTickSpacingsHookAddresses,
+  [ChainId.ASTROCHAIN_SEPOLIA]: emptyV4FeeTickSpacingsHookAddresses,
+}

--- a/lib/util/extraV4FeeTiersTickSpacingsHookAddresses.ts
+++ b/lib/util/extraV4FeeTiersTickSpacingsHookAddresses.ts
@@ -4,6 +4,13 @@ export const emptyV4FeeTickSpacingsHookAddresses: Array<[number, number, string]
   [number, number, string]
 >()
 
+// this is v4 launch readiness.
+// we can't really predict which fee tier + tick spacings v4 pools might get popular, until we launch
+// we will have to add in adhoc fashion in routing per chain.
+// we cannot search the entire fee tier + tick spacings for v4 pools,
+// because it would be too expensive to search all v4 pools on-chain
+// There are 10k fee tiers (0 - 100% with increment of 0.01%) and 32766 tick spacings (min 1, max 32767)
+// so roughly 32mil v4 pools without hooks
 export const EXTRA_V4_FEE_TICK_SPACINGS_HOOK_ADDRESSES: { [chain in ChainId]: Array<[number, number, string]> } = {
   [ChainId.MAINNET]: emptyV4FeeTickSpacingsHookAddresses,
   [ChainId.GOERLI]: emptyV4FeeTickSpacingsHookAddresses,

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.14.0",
         "@uniswap/sdk-core": "^5.8.3",
-        "@uniswap/smart-order-router": "4.7.0",
+        "@uniswap/smart-order-router": "4.7.1",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^4.4.2",
         "@uniswap/v2-sdk": "^4.6.1",
@@ -4750,9 +4750,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.7.0.tgz",
-      "integrity": "sha512-1ABtIhHR2I5baMFiiLULDQlDua8EaR8PQpNW0limyYR9DfDdy9zd6ESko5DV5YDWVWBwvIJQRxUW4+9Gc+AUPQ==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.7.1.tgz",
+      "integrity": "sha512-YrZSOScUsUcM1rFCYH21UrXFlz1OfRCKnEQekE75feni6opi+QQd6tiNI+y8EsXWhNaDedyytNYPCpd8BFPYJQ==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -28449,9 +28449,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.7.0.tgz",
-      "integrity": "sha512-1ABtIhHR2I5baMFiiLULDQlDua8EaR8PQpNW0limyYR9DfDdy9zd6ESko5DV5YDWVWBwvIJQRxUW4+9Gc+AUPQ==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.7.1.tgz",
+      "integrity": "sha512-YrZSOScUsUcM1rFCYH21UrXFlz1OfRCKnEQekE75feni6opi+QQd6tiNI+y8EsXWhNaDedyytNYPCpd8BFPYJQ==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@uniswap/router-sdk": "^1.14.0",
     "@uniswap/sdk-core": "^5.8.3",
     "@types/semver": "^7.5.8",
-    "@uniswap/smart-order-router": "4.7.0",
+    "@uniswap/smart-order-router": "4.7.1",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^4.4.2",
     "@uniswap/v2-sdk": "^4.6.1",


### PR DESCRIPTION
release https://github.com/Uniswap/smart-order-router/pull/751