### PR TITLE
fix: sepolia cached routes filter blocks to live to unblock v4 swap bug bash on sepolia

### DIFF
--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -478,9 +478,7 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
     // if it's on sepolia, then we want to filter expired routes by blocks to live
     // this is to unblock v4 routing tests on sepolia
     if (cachedRoutes?.chainId === ChainId.SEPOLIA) {
-      return cachedRoutes?.notExpired(_blockNumber, _optimistic)
-        ? cachedRoutes
-        : undefined;
+      return cachedRoutes?.notExpired(_blockNumber, _optimistic) ? cachedRoutes : undefined
     } else {
       // otherwise, we keep it here, but we need a better plan for how to fix filtering expired cached routes
       return cachedRoutes

--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -475,7 +475,16 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
     _blockNumber: number,
     _optimistic: boolean
   ): CachedRoutes | undefined {
-    return cachedRoutes
+    // if it's on sepolia, then we want to filter expired routes by blocks to live
+    // this is to unblock v4 routing tests on sepolia
+    if (cachedRoutes?.chainId === ChainId.SEPOLIA) {
+      return cachedRoutes?.notExpired(_blockNumber, _optimistic)
+        ? cachedRoutes
+        : undefined;
+    } else {
+      // otherwise, we keep it here, but we need a better plan for how to fix filtering expired cached routes
+      return cachedRoutes
+    }
   }
 
   /**


### PR DESCRIPTION
I found out why cached routes cache invalidation doesn't work. Because we forgot to filter cached routes based on the blocks to live https://github.com/Uniswap/routing-api/blob/main/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts#L478. 

I was first debugging against prod trading-api public endpoint https://app.warp.dev/block/ghxWNHwhcCy4P0n7qpqexD, on why it keeps returning a v4 pool, that returns a pool that doesn't even exist on the re-deployed v4 sepolia PoolManager[0xE8E23e97Fa135823143d6b9Cba9c699040D51F70]. Then I realized, the pool id 0xb793c6019fbdb95575103e55874d923da9386f689076f64659f1fff6bd3ac31f belongs to the previously deployed v4 sepolia  PoolManager. Then I realized, this is prob another cached routes becoming stale case.

then I was able to repro on my local endpoint https://app.warp.dev/block/U6GvrgSvHrAfl9tESL2ZgE, with the pool id 0xb793c6019fbdb95575103e55874d923da9386f689076f64659f1fff6bd3ac31f that also doesn't exist on PoolManager[0xE8E23e97Fa135823143d6b9Cba9c699040D51F70]. After this fix, I can finally get the pool I want to go through in https://app.warp.dev/block/hWUIoJFIDXoFOrsKt1W27R. Those are the 1 ETH / 2160 USDC pools with hardcoded hook address 0x0000000000000000000000000000000000000020 that was LP'ed today against v4 position manager. Hence this gives me confidence the fix can also work on prod routing-api.

We need this quick fix to unblock the native ETH -> USDC v4 swap bug bash tomorrow. We need to properly fix the cached routes cache invalidation in a separate PR.