### PR TITLE
chore: bump SOR to 4.7.2 - fix: add v4 related split routes metrics and routeToString

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.14.0",
         "@uniswap/sdk-core": "^5.8.3",
-        "@uniswap/smart-order-router": "4.7.1",
+        "@uniswap/smart-order-router": "4.7.2",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^4.4.2",
         "@uniswap/v2-sdk": "^4.6.1",
@@ -4750,9 +4750,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.7.1.tgz",
-      "integrity": "sha512-YrZSOScUsUcM1rFCYH21UrXFlz1OfRCKnEQekE75feni6opi+QQd6tiNI+y8EsXWhNaDedyytNYPCpd8BFPYJQ==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.7.2.tgz",
+      "integrity": "sha512-qkqh8FEeTRug+Q2jV3bYyacNHFJ4hZt55mmiwEU4sfp2fXIjle7MTKvnIEkj71pf1zIcUaAx2v5Of118rvYVOQ==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -28449,9 +28449,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.7.1.tgz",
-      "integrity": "sha512-YrZSOScUsUcM1rFCYH21UrXFlz1OfRCKnEQekE75feni6opi+QQd6tiNI+y8EsXWhNaDedyytNYPCpd8BFPYJQ==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.7.2.tgz",
+      "integrity": "sha512-qkqh8FEeTRug+Q2jV3bYyacNHFJ4hZt55mmiwEU4sfp2fXIjle7MTKvnIEkj71pf1zIcUaAx2v5Of118rvYVOQ==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@uniswap/router-sdk": "^1.14.0",
     "@uniswap/sdk-core": "^5.8.3",
     "@types/semver": "^7.5.8",
-    "@uniswap/smart-order-router": "4.7.1",
+    "@uniswap/smart-order-router": "4.7.2",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^4.4.2",
     "@uniswap/v2-sdk": "^4.6.1",


### PR DESCRIPTION
release https://github.com/Uniswap/smart-order-router/pull/750