### PR TITLE
fix: raise v4 subgraph totalValueLockedETH filtering threshold from 0 to 0.01 eth

### DIFF
--- a/lib/cron/cache-config.ts
+++ b/lib/cron/cache-config.ts
@@ -71,9 +71,8 @@ export const v2SubgraphUrlOverride = (chainId: ChainId) => {
   }
 }
 
-// TODO: ROUTE-225 - follow up on v4 subgraph pools filtering threshold
-const v4TrackedEthThreshold = 0 // Pools need at least 0 of trackedEth to be selected
-const v4UntrackedUsdThreshold = 0 // Pools need at least 0k USD (untracked) to be selected (for metrics only)
+const v4TrackedEthThreshold = 0.01 // Pools need at least 0.01 of trackedEth to be selected
+const v4UntrackedUsdThreshold = 0 // v4 subgraph totalValueLockedUSDUntracked returns 0, even with the pools that have appropriate liqudities and correct pool pricing
 
 export const v3TrackedEthThreshold = 0.01 // Pools need at least 0.01 of trackedEth to be selected
 const v3UntrackedUsdThreshold = 25000 // Pools need at least 25K USD (untracked) to be selected (for metrics only)


### PR DESCRIPTION
for example, below v4 pool from sepolia v4 subgraph has good liquidity and correct ETH:USDC sqrtPriceX96:

```
{
        "id": "0xedfb549279d9a3179b88cffa6f3dbe0be9713cfef2a592ed84aa1866b5d6fe1e",
        "token0": {
          "symbol": "ETH",
          "id": "0x0000000000000000000000000000000000000000"
        },
        "token1": {
          "symbol": "USDC",
          "id": "0x1c7d4b196cb0c7b01d743fbc6116a902379c7238"
        },
        "feeTier": "1500",
        "tick": "-199337",
        "tickSpacing": "30",
        "liquidity": "78419054283340",
        "hooks": "0x0000000000000000000000000000000000000020",
        "totalValueLockedUSD": "4461.186564266090216538997840216723",
        "totalValueLockedETH": "1.93727461978776941464871099029113",
        "totalValueLockedUSDUntracked": "0",
        "sqrtPrice": "3720139933953207328491692"
      },
```

meanwhile below one has incorrect sqrtPriceX96 and bad liquidity:

```
{
        "id": "0x31a0d134cae16b840bfea2cde2c18328024a345bb8459381b5c747ee80552280",
        "token0": {
          "symbol": "ETH",
          "id": "0x0000000000000000000000000000000000000000"
        },
        "token1": {
          "symbol": "USDC",
          "id": "0x1c7d4b196cb0c7b01d743fbc6116a902379c7238"
        },
        "feeTier": "1500",
        "tick": "-181",
        "tickSpacing": "40",
        "liquidity": "85647129",
        "hooks": "0x0000000000000000000000000000000000000000",
        "totalValueLockedUSD": "15.34798303615918873349520768694015",
        "totalValueLockedETH": "0.006664876613555354715749978717862528",
        "totalValueLockedUSDUntracked": "0",
        "sqrtPrice": "78517620563033212495166708499"
      },
``` 

we are still going to use ETH TVL to approximate liquidity, although this might not accurately capture the concentrated liquidity in v4, as it is today with v3 concentrated liquidity. we have follow-up plan.