### PR TITLE
fix: filter out non-zero hooks address during v4 subgraph cron job

### DIFF
--- a/lib/cron/cache-pools.ts
+++ b/lib/cron/cache-pools.ts
@@ -5,7 +5,8 @@ import {
   V2SubgraphPool,
   V2SubgraphProvider,
   V3SubgraphPool,
-  V3SubgraphProvider, V4SubgraphPool
+  V3SubgraphProvider,
+  V4SubgraphPool,
 } from '@uniswap/smart-order-router'
 import { EventBridgeEvent, ScheduledHandler } from 'aws-lambda'
 import { S3 } from 'aws-sdk'
@@ -224,7 +225,7 @@ const handler: ScheduledHandler = metricScope((metrics) => async (event: EventBr
 
     if (protocol === Protocol.V4) {
       pools = (pools as Array<V4SubgraphPool>).filter((pool: V4SubgraphPool) => {
-        const shouldFilterOut = !HOOKS_ADDRESSES_ALLOWLIST[chainId].includes(pool.id.toLowerCase())
+        const shouldFilterOut = !HOOKS_ADDRESSES_ALLOWLIST[chainId].includes(pool.hooks.toLowerCase())
 
         if (shouldFilterOut) {
           log.info(`Filtering out pool ${pool.id} from ${protocol} on ${chainId}`)

--- a/lib/util/extraV4FeeTiersTickSpacingsHookAddresses.ts
+++ b/lib/util/extraV4FeeTiersTickSpacingsHookAddresses.ts
@@ -1,4 +1,5 @@
 import { ChainId } from '@uniswap/sdk-core'
+import { extraHooksAddressesOnSepolia } from './hooksAddressesAllowlist'
 
 export const emptyV4FeeTickSpacingsHookAddresses: Array<[number, number, string]> = new Array<
   [number, number, string]
@@ -18,9 +19,9 @@ export const EXTRA_V4_FEE_TICK_SPACINGS_HOOK_ADDRESSES: { [chain in ChainId]: Ar
     // NOTE, we are only supporting hook routing in sepolia,
     // because those are the only liquid ETH/USDC pools with hardcoded hooks, that we LP'ed against sepolia v4 pool manager
     // we will not support any hook routing in initial v4 launch in any production networks
-    [500, 10, '0x0000000000000000000000000000000000000020'],
-    [1500, 30, '0x0000000000000000000000000000000000000020'],
-    [3000, 60, '0x0000000000000000000000000000000000000020'],
+    [500, 10, extraHooksAddressesOnSepolia],
+    [1500, 30, extraHooksAddressesOnSepolia],
+    [3000, 60, extraHooksAddressesOnSepolia],
   ],
   [ChainId.OPTIMISM]: emptyV4FeeTickSpacingsHookAddresses,
   [ChainId.OPTIMISM_GOERLI]: emptyV4FeeTickSpacingsHookAddresses,

--- a/lib/util/hooksAddressesAllowlist.ts
+++ b/lib/util/hooksAddressesAllowlist.ts
@@ -8,7 +8,7 @@ export const extraHooksAddressesOnSepolia = '0x000000000000000000000000000000000
 export const HOOKS_ADDRESSES_ALLOWLIST: { [chain in ChainId]: Array<string> } = {
   [ChainId.MAINNET]: [ADDRESS_ZERO],
   [ChainId.GOERLI]: [ADDRESS_ZERO],
-  [ChainId.SEPOLIA]: [ADDRESS_ZERO],
+  [ChainId.SEPOLIA]: [ADDRESS_ZERO, extraHooksAddressesOnSepolia],
   [ChainId.OPTIMISM]: [ADDRESS_ZERO],
   [ChainId.OPTIMISM_GOERLI]: [ADDRESS_ZERO],
   [ChainId.OPTIMISM_SEPOLIA]: [ADDRESS_ZERO],

--- a/lib/util/hooksAddressesAllowlist.ts
+++ b/lib/util/hooksAddressesAllowlist.ts
@@ -3,10 +3,12 @@ import { ADDRESS_ZERO } from '@uniswap/router-sdk'
 
 export const extraHooksAddressesOnSepolia = '0x0000000000000000000000000000000000000020'
 
-export const HOOKS_ADDRESSES_ALLOWLIST: {  [chain in ChainId]: Array<string> } = {
+// we do not allow v4 pools with non-zero hook address to be routed through in the initial v4 launch.
+// this is the ultimate safeguard in the routing subgraph pool cron job.
+export const HOOKS_ADDRESSES_ALLOWLIST: { [chain in ChainId]: Array<string> } = {
   [ChainId.MAINNET]: [ADDRESS_ZERO],
   [ChainId.GOERLI]: [ADDRESS_ZERO],
-  [ChainId.SEPOLIA]: [ADDRESS_ZERO].concat(extraHooksAddressesOnSepolia),
+  [ChainId.SEPOLIA]: [ADDRESS_ZERO],
   [ChainId.OPTIMISM]: [ADDRESS_ZERO],
   [ChainId.OPTIMISM_GOERLI]: [ADDRESS_ZERO],
   [ChainId.OPTIMISM_SEPOLIA]: [ADDRESS_ZERO],

--- a/lib/util/hooksAddressesAllowlist.ts
+++ b/lib/util/hooksAddressesAllowlist.ts
@@ -1,0 +1,33 @@
+import { ChainId } from '@uniswap/sdk-core'
+import { ADDRESS_ZERO } from '@uniswap/router-sdk'
+
+export const extraHooksAddressesOnSepolia = '0x0000000000000000000000000000000000000020'
+
+export const HOOKS_ADDRESSES_ALLOWLIST: {  [chain in ChainId]: Array<string> } = {
+  [ChainId.MAINNET]: [ADDRESS_ZERO],
+  [ChainId.GOERLI]: [ADDRESS_ZERO],
+  [ChainId.SEPOLIA]: [ADDRESS_ZERO].concat(extraHooksAddressesOnSepolia),
+  [ChainId.OPTIMISM]: [ADDRESS_ZERO],
+  [ChainId.OPTIMISM_GOERLI]: [ADDRESS_ZERO],
+  [ChainId.OPTIMISM_SEPOLIA]: [ADDRESS_ZERO],
+  [ChainId.ARBITRUM_ONE]: [ADDRESS_ZERO],
+  [ChainId.ARBITRUM_GOERLI]: [ADDRESS_ZERO],
+  [ChainId.ARBITRUM_SEPOLIA]: [ADDRESS_ZERO],
+  [ChainId.POLYGON]: [ADDRESS_ZERO],
+  [ChainId.POLYGON_MUMBAI]: [ADDRESS_ZERO],
+  [ChainId.CELO]: [ADDRESS_ZERO],
+  [ChainId.CELO_ALFAJORES]: [ADDRESS_ZERO],
+  [ChainId.GNOSIS]: [ADDRESS_ZERO],
+  [ChainId.MOONBEAM]: [ADDRESS_ZERO],
+  [ChainId.BNB]: [ADDRESS_ZERO],
+  [ChainId.AVALANCHE]: [ADDRESS_ZERO],
+  [ChainId.BASE_GOERLI]: [ADDRESS_ZERO],
+  [ChainId.BASE]: [ADDRESS_ZERO],
+  [ChainId.ZORA]: [ADDRESS_ZERO],
+  [ChainId.ZORA_SEPOLIA]: [ADDRESS_ZERO],
+  [ChainId.ROOTSTOCK]: [ADDRESS_ZERO],
+  [ChainId.BLAST]: [ADDRESS_ZERO],
+  [ChainId.ZKSYNC]: [ADDRESS_ZERO],
+  [ChainId.WORLDCHAIN]: [ADDRESS_ZERO],
+  [ChainId.ASTROCHAIN_SEPOLIA]: [ADDRESS_ZERO],
+}


### PR DESCRIPTION
i just realized a bug, that routing-api/SOR is actually including the non-zero hooks v4 pools, due to how 1) routing-api subgraph cron job 2) SOR get-candidate-pools work together.

for context, yesterday i realized i forgot to pass in some v4 related alpha router params, when i was fixing the cached routes cache invalidation bug https://github.com/Uniswap/routing-api/pull/869/files#r1805582600. then i realized it doesn;t make sense, that it doesn;t make sense that the prod public trading-api endpoint can route through the v4 pool with the hardcoded hook address 0x0000000000000000000000000000000000000020 https://app.warp.dev/block/WQn2uwJFv6SxNzB4kGjOiO, as i was adding this hardcoded hook address in https://github.com/Uniswap/routing-api/pull/872/files#diff-f259fdf1090ba4d745924307d17fcefdeb89bc4a2154cf17ea6f74cdc045eefa. Since [v4PoolsParams](https://github.com/Uniswap/routing-api/pull/872/files#diff-42941f26ebe3855c458055f7f2269f22a2f85265c24cb1c5ac8dd78d20e0a947R486) didnt get passed into [alpha router params](https://github.com/Uniswap/routing-api/pull/869/files#diff-fe7bfddf4e23f6bcb50753b6b4f42dcea2be8ed0339e67401a488827b27f68b2R144), the only possible is that routing-api and SOR can somehow route through the hook v4 pools automatically.

then i realized in in get-candidate-pools, v4 [directswap](https://github.com/Uniswap/smart-order-router/blob/main/src/routers/alpha-router/functions/get-candidate-pools.ts#L537) will just populate whatever v4 subgraph returns, and it goes inside the if condition [if (top2DirectSwapPool.length == 0 && topNDirectSwaps > 0) ](https://github.com/Uniswap/smart-order-router/blob/main/src/routers/alpha-router/functions/get-candidate-pools.ts#L550), if there's no direct swap from subgraph. I was only passing in [emptyV4FeeTickSpacingsHookAddresses](https://github.com/Uniswap/smart-order-router/blob/main/src/routers/alpha-router/functions/get-candidate-pools.ts#L550) inside if that condition as [v4PoolParams](https://github.com/Uniswap/smart-order-router/blob/main/src/routers/alpha-router/functions/get-candidate-pools.ts#L555).

To fix this, we have to ensure during the routing-api cron job time, for any v4 pool, we filter out non-zero hook address pool for now. i was validating on my local by only allowing zero hook address v4 pool on my local routing cron job, and i was able to see v4 pools with 0x0000000000000000000000000000000000000020 hook addresses got filtered out:

![Screenshot 2024-10-18 at 7.07.35 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/a5379c7a-1cec-42fe-a442-4d7db2302a19.png)

```
{
        "id": "0x9bd8e3ed32766adcc1542ef03ea02f99877f4abd8e5b31dd274b3d029eb4483e",
        "token0": {
          "symbol": "ETH",
          "id": "0x0000000000000000000000000000000000000000",
          "derivedETH": "1"
        },
        "token1": {
          "symbol": "USDC",
          "id": "0x1c7d4b196cb0c7b01d743fbc6116a902379c7238",
          "derivedETH": "0.0004345963274718904446220446907986495"
        },
        "feeTier": "500",
        "tick": "-198877",
        "tickSpacing": "10",
        "liquidity": "78419054283340",
        "hooks": "0x0000000000000000000000000000000000000020",
        "totalValueLockedUSD": "4461.45962729090710774877218570905",
        "totalValueLockedETH": "1.938222767770840108752269938125131",
        "totalValueLockedUSDUntracked": "0",
        "sqrtPrice": "3806602437404081577108314"
      },
```

then hitting against my local quote endpoint, it can no longer route through any 0x0000000000000000000000000000000000000020 hook-address v4 pool: https://app.warp.dev/block/5YKy6oKUF2cdHhBFRDEaWs