### PR TITLE
VPC endpoint to unirpc

### DIFF
--- a/bin/stacks/routing-lambda-stack.ts
+++ b/bin/stacks/routing-lambda-stack.ts
@@ -19,8 +19,8 @@ import * as aws_route53_targets from 'aws-cdk-lib/aws-route53-targets'
 
 const vpcEndpointServiceMap: Record<string, string> = {
   dev: 'com.amazonaws.vpce.us-east-2.vpce-svc-0945550ad67320638',
-  staging: '',
-  prod: '',
+  staging: 'com.amazonaws.vpce.us-east-2.vpce-svc-00e58a4116063039d',
+  prod: 'com.amazonaws.vpce.us-east-2.vpce-svc-04784c683b22cfabb',
 }
 const privateHostedZoneName = 'unihq.org'
 
@@ -177,6 +177,7 @@ export class RoutingLambdaStack extends cdk.NestedStack {
 
     const cachingRoutingLambda = new aws_lambda_nodejs.NodejsFunction(this, 'CachingRoutingLambda', {
       role: lambdaRole,
+      vpc: vpc,
       runtime: aws_lambda.Runtime.NODEJS_18_X,
       entry: path.join(__dirname, '../../lib/handlers/index.ts'),
       handler: 'quoteHandler',

--- a/bin/stacks/routing-lambda-stack.ts
+++ b/bin/stacks/routing-lambda-stack.ts
@@ -91,7 +91,7 @@ export class RoutingLambdaStack extends cdk.NestedStack {
 
     // TODO: Add if not dev , not create
     const vpc = new ec2.Vpc(this, `RoutingLambdaVPC-${stage}`, {
-      maxAzs: 2, // Number of availability zones
+      maxAzs: 4, // Number of availability zones
       subnetConfiguration: [
         {
           name: `RoutingPublicSubnet-${stage}`,

--- a/cdk.context.json
+++ b/cdk.context.json
@@ -1,0 +1,7 @@
+{
+  "availability-zones:account=145079444317:region=us-east-2": [
+    "us-east-2a",
+    "us-east-2b",
+    "us-east-2c"
+  ]
+}

--- a/cdk.context.json
+++ b/cdk.context.json
@@ -1,7 +1,0 @@
-{
-  "availability-zones:account=145079444317:region=us-east-2": [
-    "us-east-2a",
-    "us-east-2b",
-    "us-east-2c"
-  ]
-}


### PR DESCRIPTION
1. put routing-api behind a vpc
2. created a vpc endpoint to connect to unirpc vpc endpoint service in uniswap-backend account
3. created route53 to point routing-dev to the vpc endpoint to avoid updating the endpoint on the service side.