### PR TITLE
feat(unirpc): gradual traffic increase for unirpc - stop 2

### DIFF
--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -4,7 +4,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.1,
     "healthCheckSampleProb": 0.1,
-    "providerInitialWeights": [0.25, 0.75],
+    "providerInitialWeights": [0, 1],
     "providerUrls": ["QUICKNODE_42220", "UNIRPC_0"],
     "providerNames": ["QUICKNODE", "UNIRPC"]
   },
@@ -13,7 +13,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.1,
     "healthCheckSampleProb": 0.1,
-    "providerInitialWeights": [0.25, 0.75],
+    "providerInitialWeights": [0, 1],
     "providerUrls": ["QUICKNODE_43114", "UNIRPC_0"],
     "providerNames": ["QUICKNODE", "UNIRPC"]
   },
@@ -22,7 +22,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.01,
     "healthCheckSampleProb": 0.01,
-    "providerInitialWeights": [0.6, 0.4],
+    "providerInitialWeights": [0.5, 0.5],
     "providerUrls": ["QUICKNODE_56", "UNIRPC_0"],
     "providerNames": ["QUICKNODE", "UNIRPC"]
   },
@@ -31,7 +31,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.1,
     "healthCheckSampleProb": 0.01,
-    "providerInitialWeights": [0.25, 0.75],
+    "providerInitialWeights": [0, 1],
     "providerUrls": ["QUICKNODE_10", "UNIRPC_0"],
     "providerNames": ["QUICKNODE", "UNIRPC"]
   },
@@ -40,7 +40,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.01,
     "healthCheckSampleProb": 0.01,
-    "providerInitialWeights": [0.25, 0.75],
+    "providerInitialWeights": [0, 1],
     "providerUrls": ["ALCHEMY_11155111", "UNIRPC_0"],
     "providerNames": ["ALCHEMY", "UNIRPC"],
     "enableDbSync": true
@@ -50,7 +50,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.25,
     "healthCheckSampleProb": 0.005,
-    "providerInitialWeights": [0.25, 0.75],
+    "providerInitialWeights": [0, 1],
     "providerUrls": ["QUICKNODE_137", "UNIRPC_0"],
     "providerNames": ["QUICKNODE", "UNIRPC"]
   },
@@ -59,7 +59,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.1,
     "healthCheckSampleProb": 0.002,
-    "providerInitialWeights": [0.6, 0.4],
+    "providerInitialWeights": [0.5, 0.5],
     "providerUrls": ["QUICKNODE_42161", "UNIRPC_0"],
     "providerNames": ["QUICKNODE", "UNIRPC"]
   },
@@ -68,7 +68,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.05,
     "healthCheckSampleProb": 0.0005,
-    "providerInitialWeights": [0.9, 0.1],
+    "providerInitialWeights": [0.8, 0.2],
     "providerUrls": ["QUICKNODE_8453", "UNIRPC_0"],
     "providerNames": ["QUICKNODE", "UNIRPC"]
   },
@@ -86,7 +86,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.001,
     "healthCheckSampleProb": 0.001,
-    "providerInitialWeights": [0.25, 0.75],
+    "providerInitialWeights": [0, 1],
     "providerUrls": ["QUICKNODE_81457", "UNIRPC_0"],
     "providerNames": ["QUICKNODE", "UNIRPC"]
   },
@@ -95,7 +95,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.001,
     "healthCheckSampleProb": 0.001,
-    "providerInitialWeights": [0.25, 0.75],
+    "providerInitialWeights": [0, 1],
     "providerUrls": ["QUICKNODE_7777777", "UNIRPC_0"],
     "providerNames": ["QUICKNODE", "UNIRPC"]
   },
@@ -104,7 +104,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.01,
     "healthCheckSampleProb": 0.01,
-    "providerInitialWeights": [0.25, 0.75],
+    "providerInitialWeights": [0, 1],
     "providerUrls": ["QUICKNODE_324", "UNIRPC_0"],
     "providerNames": ["QUICKNODE", "UNIRPC"]
   },


### PR DESCRIPTION
### Description
Continue unirpc onboarding for routing API for all chains
We are currently onboarded all chains at 10/40/75%.

This PR updates unirpc traffic for all chains (except Mainnet) **more conservatively** as follows:
- **high volume** chains remain at `10%`  (`Mainnet`)
- **mid volume** chains from `40%` to `50%` (`Arbitrum, Binance`)
- **Base** chain from `10%` to `20%`
- **low volume** chains from `75%` to `100%` (all the rest)

Plan to monitor, then keep gradual conservative onboarding.