### PR TITLE
feat(unirpc): gradual traffic increase for unirpc - step 3

### DIFF
--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -22,7 +22,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.01,
     "healthCheckSampleProb": 0.01,
-    "providerInitialWeights": [0.5, 0.5],
+    "providerInitialWeights": [0.3, 0.7],
     "providerUrls": ["QUICKNODE_56", "UNIRPC_0"],
     "providerNames": ["QUICKNODE", "UNIRPC"]
   },
@@ -59,7 +59,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.1,
     "healthCheckSampleProb": 0.002,
-    "providerInitialWeights": [0.5, 0.5],
+    "providerInitialWeights": [0.3, 0.7],
     "providerUrls": ["QUICKNODE_42161", "UNIRPC_0"],
     "providerNames": ["QUICKNODE", "UNIRPC"]
   },
@@ -68,7 +68,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0.05,
     "healthCheckSampleProb": 0.0005,
-    "providerInitialWeights": [0.8, 0.2],
+    "providerInitialWeights": [0.7, 0.3],
     "providerUrls": ["QUICKNODE_8453", "UNIRPC_0"],
     "providerNames": ["QUICKNODE", "UNIRPC"]
   },


### PR DESCRIPTION
### Description
Continue unirpc onboarding for routing API for all chains

This PR updates unirpc traffic for all chains (except Mainnet) **more conservatively** as follows:
- **high volume** chains remain at `10%`  (`Mainnet`)
- **mid volume** chains from `50%` to `70%` (`Arbitrum, Binance`)
- **Base** chain from `20%` to `30%`
- Rest are already at `100%`

Plan to monitor, then keep gradual conservative onboarding.