### PR TITLE
fix(rpc): set timeout to 8s (default was 120s)

### DIFF
--- a/lib/rpc/SingleJsonRpcProvider.ts
+++ b/lib/rpc/SingleJsonRpcProvider.ts
@@ -73,6 +73,7 @@ export class SingleJsonRpcProvider extends StaticJsonRpcProvider {
       {
         url: url,
         headers: headers,
+        timeout: 8000 // 8 seconds (default is 120s)
       },
       network
     )

--- a/lib/rpc/SingleJsonRpcProvider.ts
+++ b/lib/rpc/SingleJsonRpcProvider.ts
@@ -73,7 +73,7 @@ export class SingleJsonRpcProvider extends StaticJsonRpcProvider {
       {
         url: url,
         headers: headers,
-        timeout: 8000 // 8 seconds (default is 120s)
+        timeout: 8000, // 8 seconds (default is 120s)
       },
       network
     )


### PR DESCRIPTION
Sets timeout of rpc calls to `9s`.
Default was `120s` and we were hitting some concurrency spillover issues on provider blips and on `p99.99` ([dashboard](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~'Uniswap~'RPC_GATEWAY_1_UNKNOWN_evaluated_0_latency_call~'Service~'RoutingAPI~(id~'m5~label~'RPC_GATEWAY_1_UNKNOWN_evaluated_0_latency_call))~(~'.~'RPC_GATEWAY_1_QUIKNODE_GETH_evaluated_0_latency_call~'.~'.~(id~'m7~label~'RPC_GATEWAY_1_QUIKNODE_evaluated_0_latency_call))~(~'.~'RPC_GATEWAY_8453_UNKNOWN_evaluated_0_latency_call~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_8453_QUIKNODE_evaluated_0_latency_call~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_42161_QUIKNODE_evaluated_0_latency_call~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_42161_UNKNOWN_evaluated_0_latency_call~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_43114_UNKNOWN_evaluated_0_latency_call~'.~'.~(visible~false))~(~'.~'RPC_GATEWAY_43114_QUIKNODE_evaluated_0_latency_call~'.~'.~(visible~false)))~view~'timeSeries~stacked~false~region~'us-east-2~stat~'p99.99~period~60~start~'-PT24H~end~'P0D)&query=~'*7bUniswap*2cService*7d*20RPC_GATEWAY_43114_QUIKNODE_evaluated_0_latency_call)).
Hope this change will improve those spikes.
Timeout metric is already logged through rpc failure rate.