### PR TITLE
feat(unirpc): gradual traffic increase for unirpc - step 4

### DIFF
--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -20,9 +20,9 @@
   {
     "chainId": 56,
     "useMultiProviderProb": 1,
-    "latencyEvaluationSampleProb": 0.01,
-    "healthCheckSampleProb": 0.01,
-    "providerInitialWeights": [0.3, 0.7],
+    "latencyEvaluationSampleProb": 0,
+    "healthCheckSampleProb": 0,
+    "providerInitialWeights": [0, 1],
     "providerUrls": ["QUICKNODE_56", "UNIRPC_0"],
     "providerNames": ["QUICKNODE", "UNIRPC"]
   },
@@ -57,9 +57,9 @@
   {
     "chainId": 42161,
     "useMultiProviderProb": 1,
-    "latencyEvaluationSampleProb": 0.1,
-    "healthCheckSampleProb": 0.002,
-    "providerInitialWeights": [0.3, 0.7],
+    "latencyEvaluationSampleProb": 0,
+    "healthCheckSampleProb": 0,
+    "providerInitialWeights": [0, 1],
     "providerUrls": ["QUICKNODE_42161", "UNIRPC_0"],
     "providerNames": ["QUICKNODE", "UNIRPC"]
   },


### PR DESCRIPTION
Continue unirpc onboarding for routing API for all chains

This PR updates unirpc traffic for all chains (except Mainnet) **more conservatively** as follows:
- **Binance** chain from `70%` to `100%`
- **Mainnet**  remains at `10%` 
- **Base** remains at `30%`
- **Arbitrum** remains at `70%`
- Rest chains are already at `100%`

Plan to monitor, then keep gradual conservative onboarding.