### PR TITLE
fix(alerts): adjust noisy very low volume traffic alerts

### DIFF
--- a/bin/stacks/routing-api-stack.ts
+++ b/bin/stacks/routing-api-stack.ts
@@ -438,9 +438,10 @@ export class RoutingAPIStack extends cdk.Stack {
         return
       }
       const alarmName = `RoutingAPI-SEV2-SuccessRate-Alarm-ChainId: ${chainId.toString()}`
+      // We only want to alert if the volume besides 400 errors is high enough over default period (5m) for 5xx errors.
       const invocationsThreshold = 50
       const metric = new MathExpression({
-        expression: `IF((invocations - response400) > ${invocationsThreshold}, 100*(response200/(invocations-response400)), 0)`,
+        expression: `IF((invocations - response400) > ${invocationsThreshold}, 100*(response200/(invocations-response400)), 100)`,
         usingMetrics: {
           invocations: new aws_cloudwatch.Metric({
             namespace: 'Uniswap',
@@ -482,9 +483,10 @@ export class RoutingAPIStack extends cdk.Stack {
         return
       }
       const alarmName = `RoutingAPI-SEV2-SuccessRate-Alarm-RequestSource: ${requestSource.toString()}`
+      // We only want to alert if the volume besides 400 errors is high enough over default period (5m) for 5xx errors.
       const invocationsThreshold = 50
       const metric = new MathExpression({
-        expression: `IF((invocations - response400) > ${invocationsThreshold}, 100*(response200/(invocations-response400)), 0)`,
+        expression: `IF((invocations - response400) > ${invocationsThreshold}, 100*(response200/(invocations-response400)), 100)`,
         usingMetrics: {
           invocations: new aws_cloudwatch.Metric({
             namespace: 'Uniswap',
@@ -531,9 +533,10 @@ export class RoutingAPIStack extends cdk.Stack {
           return
         }
         const alarmName = `RoutingAPI-SEV3-SuccessRate-Alarm-RequestSource-ChainId: ${requestSource.toString()} ${chainId}`
+        // We only want to alert if the volume besides 400 errors is high enough over default period (5m) for 5xx errors.
         const invocationsThreshold = 50
         const metric = new MathExpression({
-          expression: `IF((invocations - response400) > ${invocationsThreshold}, 100*(response200/(invocations-response400)), 0)`,
+          expression: `IF((invocations - response400) > ${invocationsThreshold}, 100*(response200/(invocations-response400)), 100)`,
           usingMetrics: {
             invocations: new aws_cloudwatch.Metric({
               namespace: 'Uniswap',

--- a/bin/stacks/routing-api-stack.ts
+++ b/bin/stacks/routing-api-stack.ts
@@ -438,8 +438,9 @@ export class RoutingAPIStack extends cdk.Stack {
         return
       }
       const alarmName = `RoutingAPI-SEV2-SuccessRate-Alarm-ChainId: ${chainId.toString()}`
+      const invocationsThreshold = 50
       const metric = new MathExpression({
-        expression: '100*(response200/(invocations-response400))',
+        expression: `IF((invocations - response400) > ${invocationsThreshold}, 100*(response200/(invocations-response400)), 0)`,
         usingMetrics: {
           invocations: new aws_cloudwatch.Metric({
             namespace: 'Uniswap',
@@ -481,8 +482,9 @@ export class RoutingAPIStack extends cdk.Stack {
         return
       }
       const alarmName = `RoutingAPI-SEV2-SuccessRate-Alarm-RequestSource: ${requestSource.toString()}`
+      const invocationsThreshold = 50
       const metric = new MathExpression({
-        expression: '100*(response200/(invocations-response400))',
+        expression: `IF((invocations - response400) > ${invocationsThreshold}, 100*(response200/(invocations-response400)), 0)`,
         usingMetrics: {
           invocations: new aws_cloudwatch.Metric({
             namespace: 'Uniswap',
@@ -529,8 +531,9 @@ export class RoutingAPIStack extends cdk.Stack {
           return
         }
         const alarmName = `RoutingAPI-SEV3-SuccessRate-Alarm-RequestSource-ChainId: ${requestSource.toString()} ${chainId}`
+        const invocationsThreshold = 50
         const metric = new MathExpression({
-          expression: '100*(response200/(invocations-response400))',
+          expression: `IF((invocations - response400) > ${invocationsThreshold}, 100*(response200/(invocations-response400)), 0)`,
           usingMetrics: {
             invocations: new aws_cloudwatch.Metric({
               namespace: 'Uniswap',


### PR DESCRIPTION
Some 5xx alerts are very noisy because of very low traffic, or because most traffic is no liquidity errors so denominator is very small.
Adjusting with an if condition to alert only if real traffic (excluding 4xx errors) is above 50 requests over 5 mins.