### PR TITLE
chore: bump to 4.7.8 - fix: return a new tenderly simulation status in case of tenderly downtime

### DIFF
--- a/lib/handlers/quote/util/simulation.ts
+++ b/lib/handlers/quote/util/simulation.ts
@@ -8,6 +8,7 @@ export enum RoutingApiSimulationStatus {
   INSUFFICIENT_BALANCE = 'INSUFFICIENT_BALANCE',
   NOT_SUPPORTED = 'NOT_SUPPORTED',
   NOT_APPROVED = 'NOT_APPROVED',
+  SYSTEM_DOWN = 'SYSTEM_DOWN',
   UNKNOWN = '',
 }
 
@@ -28,6 +29,8 @@ export const simulationStatusTranslation = (
       return RoutingApiSimulationStatus.NOT_SUPPORTED
     case SimulationStatus.NotApproved:
       return RoutingApiSimulationStatus.NOT_APPROVED
+    case SimulationStatus.SystemDown:
+      return RoutingApiSimulationStatus.SYSTEM_DOWN
     default:
       log.error(`Unknown simulation status ${simulationStatus}`)
       return RoutingApiSimulationStatus.UNKNOWN

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.14.0",
         "@uniswap/sdk-core": "^5.9.0",
-        "@uniswap/smart-order-router": "4.7.6",
+        "@uniswap/smart-order-router": "4.7.8",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^4.6.1",
         "@uniswap/v2-sdk": "^4.6.1",
@@ -4750,9 +4750,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "4.7.6",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.7.6.tgz",
-      "integrity": "sha512-P191SqV13rlzoy922qY+1h/JT4j8OwcfrUG1ebVOBUHjYScDenX/bFNsuaqDEX3f4ykSZu9jhiPsvP2FVx3n4A==",
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.7.8.tgz",
+      "integrity": "sha512-rMVpBL7oqPU2z6RWR4V9QToT2l6pJgeGI/JRd/rowFltnjh0VOsW/cAkWrSi6wVeEnxG7pwT+8GcxkyA0qhudQ==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -28449,9 +28449,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "4.7.6",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.7.6.tgz",
-      "integrity": "sha512-P191SqV13rlzoy922qY+1h/JT4j8OwcfrUG1ebVOBUHjYScDenX/bFNsuaqDEX3f4ykSZu9jhiPsvP2FVx3n4A==",
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.7.8.tgz",
+      "integrity": "sha512-rMVpBL7oqPU2z6RWR4V9QToT2l6pJgeGI/JRd/rowFltnjh0VOsW/cAkWrSi6wVeEnxG7pwT+8GcxkyA0qhudQ==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@uniswap/router-sdk": "^1.14.0",
     "@uniswap/sdk-core": "^5.9.0",
     "@types/semver": "^7.5.8",
-    "@uniswap/smart-order-router": "4.7.6",
+    "@uniswap/smart-order-router": "4.7.8",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^4.6.1",
     "@uniswap/v2-sdk": "^4.6.1",

--- a/test/jest/unit/handlers/util/simulation.test.ts
+++ b/test/jest/unit/handlers/util/simulation.test.ts
@@ -35,4 +35,9 @@ describe('simulation', () => {
     const status = simulationStatusTranslation(SimulationStatus.NotApproved, log)
     expect(status).toStrictEqual(RoutingApiSimulationStatus.NOT_APPROVED)
   })
+
+  it('returns system down for system down simulation status', () => {
+    const status = simulationStatusTranslation(SimulationStatus.SystemDown, log)
+    expect(status).toStrictEqual(RoutingApiSimulationStatus.SYSTEM_DOWN)
+  })
 })

--- a/test/mocha/e2e/quote.test.ts
+++ b/test/mocha/e2e/quote.test.ts
@@ -2401,7 +2401,6 @@ describe('quote', function () {
           }
 
           const queryParams = qs.stringify(quoteReq)
-          console.log(queryParams)
 
           const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(`${API}?${queryParams}`)
 

--- a/test/mocha/e2e/quote.test.ts
+++ b/test/mocha/e2e/quote.test.ts
@@ -2401,6 +2401,7 @@ describe('quote', function () {
           }
 
           const queryParams = qs.stringify(quoteReq)
+          console.log(queryParams)
 
           const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(`${API}?${queryParams}`)
 


### PR DESCRIPTION
Release https://github.com/Uniswap/smart-order-router/pull/759