### PR TITLE
fix: also persist the plain text cached routes

### DIFF
--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -385,6 +385,7 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
             blockNumber: cachedRoutes.blockNumber,
             protocol: route.protocol.toString(),
             item: binaryCachedRoutes,
+            plainRoutes: jsonCachedRoutes,
             ttl: ttl,
           },
         },


### PR DESCRIPTION
we want to be able to understand what each cached routes entry item is in plain text. tried on my local:

![Screenshot 2024-10-31 at 4.45.27 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/acfbcc54-fd18-49d6-a05b-2b61ba12b3a2.png)

