### PR TITLE
chore(unirpc): Mainnet from `50% -> 75%`

### DIFF
--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -77,7 +77,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0,
     "healthCheckSampleProb": 0,
-    "providerInitialWeights": [0.5, 0.5, 0],
+    "providerInitialWeights": [0.25, 0.75, 0],
     "providerUrls": ["QUICKNODE_1", "UNIRPC_0", "QUICKNODERETH_1"],
     "providerNames": ["QUICKNODE", "UNIRPC", "QUICKNODERETH"]
   },


### PR DESCRIPTION
Moving `Mainnet` from 50% -> 75% to unirpc. 

`Base` is at `30%`
All other chains are onboarded `100%`