### PR TITLE
Revert "chore(unirpc): Mainnet from `50% -> 75%`"

### DIFF
--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -77,7 +77,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0,
     "healthCheckSampleProb": 0,
-    "providerInitialWeights": [0.25, 0.75, 0],
+    "providerInitialWeights": [0.5, 0.5, 0],
     "providerUrls": ["QUICKNODE_1", "UNIRPC_0", "QUICKNODERETH_1"],
     "providerNames": ["QUICKNODE", "UNIRPC", "QUICKNODERETH"]
   },


### PR DESCRIPTION
This change didn't go through due to flake e2e tests in pipeline.

Want to investigate some unirpc timeouts in mainnet last night before further increasing here.

Reverts Uniswap/routing-api#905