### PR TITLE
fix: upgrade hardhat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -96,7 +96,7 @@
         "ethereum-waffle": "^3.4.0",
         "ethers": "^5.5.1",
         "fishery": "^2.2.2",
-        "hardhat": "2.20.0",
+        "hardhat": "2.22.15",
         "jest": "^29.5.0",
         "json-schema-to-ts": "^1.6.4",
         "mocha": "^8.4.0",
@@ -2846,84 +2846,77 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@nomicfoundation/ethereumjs-block": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-block/-/ethereumjs-block-5.0.4.tgz",
-      "integrity": "sha512-AcyacJ9eX/uPEvqsPiB+WO1ymE+kyH48qGGiGV+YTojdtas8itUTW5dehDSOXEEItWGbbzEJ4PRqnQZlWaPvDw==",
+    "node_modules/@nomicfoundation/edr": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr/-/edr-0.6.4.tgz",
+      "integrity": "sha512-YgrSuT3yo5ZQkbvBGqQ7hG+RDvz3YygSkddg4tb1Z0Y6pLXFzwrcEwWaJCFAVeeZxdxGfCgGMUYgRVneK+WXkw==",
       "dependencies": {
-        "@nomicfoundation/ethereumjs-common": "4.0.4",
-        "@nomicfoundation/ethereumjs-rlp": "5.0.4",
-        "@nomicfoundation/ethereumjs-trie": "6.0.4",
-        "@nomicfoundation/ethereumjs-tx": "5.0.4",
-        "@nomicfoundation/ethereumjs-util": "9.0.4",
-        "ethereum-cryptography": "0.1.3"
+        "@nomicfoundation/edr-darwin-arm64": "0.6.4",
+        "@nomicfoundation/edr-darwin-x64": "0.6.4",
+        "@nomicfoundation/edr-linux-arm64-gnu": "0.6.4",
+        "@nomicfoundation/edr-linux-arm64-musl": "0.6.4",
+        "@nomicfoundation/edr-linux-x64-gnu": "0.6.4",
+        "@nomicfoundation/edr-linux-x64-musl": "0.6.4",
+        "@nomicfoundation/edr-win32-x64-msvc": "0.6.4"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">= 18"
       }
     },
-    "node_modules/@nomicfoundation/ethereumjs-block/node_modules/ethereum-cryptography": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-      "dependencies": {
-        "@types/pbkdf2": "^3.0.0",
-        "@types/secp256k1": "^4.0.1",
-        "blakejs": "^1.1.0",
-        "browserify-aes": "^1.2.0",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "hash.js": "^1.1.7",
-        "keccak": "^3.0.0",
-        "pbkdf2": "^3.0.17",
-        "randombytes": "^2.1.0",
-        "safe-buffer": "^5.1.2",
-        "scrypt-js": "^3.0.0",
-        "secp256k1": "^4.0.1",
-        "setimmediate": "^1.0.5"
-      }
-    },
-    "node_modules/@nomicfoundation/ethereumjs-blockchain": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-blockchain/-/ethereumjs-blockchain-7.0.4.tgz",
-      "integrity": "sha512-jYsd/kwzbmpnxx86tXsYV8wZ5xGvFL+7/P0c6OlzpClHsbFzeF41KrYA9scON8Rg6bZu3ZTv6JOAgj3t7USUfg==",
-      "dependencies": {
-        "@nomicfoundation/ethereumjs-block": "5.0.4",
-        "@nomicfoundation/ethereumjs-common": "4.0.4",
-        "@nomicfoundation/ethereumjs-ethash": "3.0.4",
-        "@nomicfoundation/ethereumjs-rlp": "5.0.4",
-        "@nomicfoundation/ethereumjs-trie": "6.0.4",
-        "@nomicfoundation/ethereumjs-tx": "5.0.4",
-        "@nomicfoundation/ethereumjs-util": "9.0.4",
-        "debug": "^4.3.3",
-        "ethereum-cryptography": "0.1.3",
-        "lru-cache": "^10.0.0"
-      },
+    "node_modules/@nomicfoundation/edr-darwin-arm64": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-arm64/-/edr-darwin-arm64-0.6.4.tgz",
+      "integrity": "sha512-QNQErISLgssV9+qia8sIjRANqtbW8snSDvjspixT/kSQ5ZSGxxctTg7x72wPSrcu8+EBEveIe5uqENIp5GH8HQ==",
       "engines": {
-        "node": ">=18"
+        "node": ">= 18"
       }
     },
-    "node_modules/@nomicfoundation/ethereumjs-blockchain/node_modules/ethereum-cryptography": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-      "dependencies": {
-        "@types/pbkdf2": "^3.0.0",
-        "@types/secp256k1": "^4.0.1",
-        "blakejs": "^1.1.0",
-        "browserify-aes": "^1.2.0",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "hash.js": "^1.1.7",
-        "keccak": "^3.0.0",
-        "pbkdf2": "^3.0.17",
-        "randombytes": "^2.1.0",
-        "safe-buffer": "^5.1.2",
-        "scrypt-js": "^3.0.0",
-        "secp256k1": "^4.0.1",
-        "setimmediate": "^1.0.5"
+    "node_modules/@nomicfoundation/edr-darwin-x64": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-x64/-/edr-darwin-x64-0.6.4.tgz",
+      "integrity": "sha512-cjVmREiwByyc9+oGfvAh49IAw+oVJHF9WWYRD+Tm/ZlSpnEVWxrGNBak2bd/JSYjn+mZE7gmWS4SMRi4nKaLUg==",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@nomicfoundation/edr-linux-arm64-gnu": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-gnu/-/edr-linux-arm64-gnu-0.6.4.tgz",
+      "integrity": "sha512-96o9kRIVD6W5VkgKvUOGpWyUGInVQ5BRlME2Fa36YoNsRQMaKtmYJEU0ACosYES6ZTpYC8U5sjMulvPtVoEfOA==",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@nomicfoundation/edr-linux-arm64-musl": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-musl/-/edr-linux-arm64-musl-0.6.4.tgz",
+      "integrity": "sha512-+JVEW9e5plHrUfQlSgkEj/UONrIU6rADTEk+Yp9pbe+mzNkJdfJYhs5JYiLQRP4OjxH4QOrXI97bKU6FcEbt5Q==",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@nomicfoundation/edr-linux-x64-gnu": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-gnu/-/edr-linux-x64-gnu-0.6.4.tgz",
+      "integrity": "sha512-nzYWW+fO3EZItOeP4CrdMgDXfaGBIBkKg0Y/7ySpUxLqzut40O4Mb0/+quqLAFkacUSWMlFp8nsmypJfOH5zoA==",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@nomicfoundation/edr-linux-x64-musl": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-musl/-/edr-linux-x64-musl-0.6.4.tgz",
+      "integrity": "sha512-QFRoE9qSQ2boRrVeQ1HdzU+XN7NUgwZ1SIy5DQt4d7jCP+5qTNsq8LBNcqhRBOATgO63nsweNUhxX/Suj5r1Sw==",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@nomicfoundation/edr-win32-x64-msvc": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-win32-x64-msvc/-/edr-win32-x64-msvc-0.6.4.tgz",
+      "integrity": "sha512-2yopjelNkkCvIjUgBGhrn153IBPLwnsDeNiq6oA0WkeM8tGmQi4td+PGi9jAriUDAkc59Yoi2q9hYA6efiY7Zw==",
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-common": {
@@ -2932,83 +2925,6 @@
       "integrity": "sha512-9Rgb658lcWsjiicr5GzNCjI1llow/7r0k50dLL95OJ+6iZJcVbi15r3Y0xh2cIO+zgX0WIHcbzIu6FeQf9KPrg==",
       "dependencies": {
         "@nomicfoundation/ethereumjs-util": "9.0.4"
-      }
-    },
-    "node_modules/@nomicfoundation/ethereumjs-ethash": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-ethash/-/ethereumjs-ethash-3.0.4.tgz",
-      "integrity": "sha512-xvIrwIMl9sSaiYKRem68+O7vYdj7Q2XWv5P7JXiIkn83918QzWHvqbswTRsH7+r6X1UEvdsURRnZbvZszEjAaQ==",
-      "dependencies": {
-        "@nomicfoundation/ethereumjs-block": "5.0.4",
-        "@nomicfoundation/ethereumjs-rlp": "5.0.4",
-        "@nomicfoundation/ethereumjs-util": "9.0.4",
-        "bigint-crypto-utils": "^3.2.2",
-        "ethereum-cryptography": "0.1.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@nomicfoundation/ethereumjs-ethash/node_modules/ethereum-cryptography": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-      "dependencies": {
-        "@types/pbkdf2": "^3.0.0",
-        "@types/secp256k1": "^4.0.1",
-        "blakejs": "^1.1.0",
-        "browserify-aes": "^1.2.0",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "hash.js": "^1.1.7",
-        "keccak": "^3.0.0",
-        "pbkdf2": "^3.0.17",
-        "randombytes": "^2.1.0",
-        "safe-buffer": "^5.1.2",
-        "scrypt-js": "^3.0.0",
-        "secp256k1": "^4.0.1",
-        "setimmediate": "^1.0.5"
-      }
-    },
-    "node_modules/@nomicfoundation/ethereumjs-evm": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-evm/-/ethereumjs-evm-2.0.4.tgz",
-      "integrity": "sha512-lTyZZi1KpeMHzaO6cSVisR2tjiTTedjo7PcmhI/+GNFo9BmyY6QYzGeSti0sFttmjbEMioHgXxl5yrLNRg6+1w==",
-      "dependencies": {
-        "@nomicfoundation/ethereumjs-common": "4.0.4",
-        "@nomicfoundation/ethereumjs-statemanager": "2.0.4",
-        "@nomicfoundation/ethereumjs-tx": "5.0.4",
-        "@nomicfoundation/ethereumjs-util": "9.0.4",
-        "@types/debug": "^4.1.9",
-        "debug": "^4.3.3",
-        "ethereum-cryptography": "0.1.3",
-        "rustbn-wasm": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@nomicfoundation/ethereumjs-evm/node_modules/ethereum-cryptography": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-      "dependencies": {
-        "@types/pbkdf2": "^3.0.0",
-        "@types/secp256k1": "^4.0.1",
-        "blakejs": "^1.1.0",
-        "browserify-aes": "^1.2.0",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "hash.js": "^1.1.7",
-        "keccak": "^3.0.0",
-        "pbkdf2": "^3.0.17",
-        "randombytes": "^2.1.0",
-        "safe-buffer": "^5.1.2",
-        "scrypt-js": "^3.0.0",
-        "secp256k1": "^4.0.1",
-        "setimmediate": "^1.0.5"
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-rlp": {
@@ -3020,89 +2936,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@nomicfoundation/ethereumjs-statemanager": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-statemanager/-/ethereumjs-statemanager-2.0.4.tgz",
-      "integrity": "sha512-HPDjeFrxw6llEi+BzqXkZ+KkvFnTOPczuHBtk21hRlDiuKuZz32dPzlhpRsDBGV1b5JTmRDUVqCS1lp3Gghw4Q==",
-      "dependencies": {
-        "@nomicfoundation/ethereumjs-common": "4.0.4",
-        "@nomicfoundation/ethereumjs-rlp": "5.0.4",
-        "@nomicfoundation/ethereumjs-trie": "6.0.4",
-        "@nomicfoundation/ethereumjs-util": "9.0.4",
-        "debug": "^4.3.3",
-        "ethereum-cryptography": "0.1.3",
-        "js-sdsl": "^4.1.4",
-        "lru-cache": "^10.0.0"
-      },
-      "peerDependencies": {
-        "@nomicfoundation/ethereumjs-verkle": "0.0.2"
-      },
-      "peerDependenciesMeta": {
-        "@nomicfoundation/ethereumjs-verkle": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@nomicfoundation/ethereumjs-statemanager/node_modules/ethereum-cryptography": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-      "dependencies": {
-        "@types/pbkdf2": "^3.0.0",
-        "@types/secp256k1": "^4.0.1",
-        "blakejs": "^1.1.0",
-        "browserify-aes": "^1.2.0",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "hash.js": "^1.1.7",
-        "keccak": "^3.0.0",
-        "pbkdf2": "^3.0.17",
-        "randombytes": "^2.1.0",
-        "safe-buffer": "^5.1.2",
-        "scrypt-js": "^3.0.0",
-        "secp256k1": "^4.0.1",
-        "setimmediate": "^1.0.5"
-      }
-    },
-    "node_modules/@nomicfoundation/ethereumjs-trie": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-trie/-/ethereumjs-trie-6.0.4.tgz",
-      "integrity": "sha512-3nSwQiFMvr2VFe/aZUyinuohYvtytUqZCUCvIWcPJ/BwJH6oQdZRB42aNFBJ/8nAh2s3OcroWpBLskzW01mFKA==",
-      "dependencies": {
-        "@nomicfoundation/ethereumjs-rlp": "5.0.4",
-        "@nomicfoundation/ethereumjs-util": "9.0.4",
-        "@types/readable-stream": "^2.3.13",
-        "ethereum-cryptography": "0.1.3",
-        "lru-cache": "^10.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@nomicfoundation/ethereumjs-trie/node_modules/ethereum-cryptography": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-      "dependencies": {
-        "@types/pbkdf2": "^3.0.0",
-        "@types/secp256k1": "^4.0.1",
-        "blakejs": "^1.1.0",
-        "browserify-aes": "^1.2.0",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "hash.js": "^1.1.7",
-        "keccak": "^3.0.0",
-        "pbkdf2": "^3.0.17",
-        "randombytes": "^2.1.0",
-        "safe-buffer": "^5.1.2",
-        "scrypt-js": "^3.0.0",
-        "secp256k1": "^4.0.1",
-        "setimmediate": "^1.0.5"
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-tx": {
@@ -3170,63 +3003,6 @@
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-util/node_modules/ethereum-cryptography": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-      "dependencies": {
-        "@types/pbkdf2": "^3.0.0",
-        "@types/secp256k1": "^4.0.1",
-        "blakejs": "^1.1.0",
-        "browserify-aes": "^1.2.0",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "hash.js": "^1.1.7",
-        "keccak": "^3.0.0",
-        "pbkdf2": "^3.0.17",
-        "randombytes": "^2.1.0",
-        "safe-buffer": "^5.1.2",
-        "scrypt-js": "^3.0.0",
-        "secp256k1": "^4.0.1",
-        "setimmediate": "^1.0.5"
-      }
-    },
-    "node_modules/@nomicfoundation/ethereumjs-verkle": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-verkle/-/ethereumjs-verkle-0.0.2.tgz",
-      "integrity": "sha512-bjnfZElpYGK/XuuVRmLS3yDvr+cDs85D9oonZ0YUa5A3lgFgokWMp76zXrxX2jVQ0BfHaw12y860n1+iOi6yFQ==",
-      "dependencies": {
-        "@nomicfoundation/ethereumjs-rlp": "5.0.4",
-        "@nomicfoundation/ethereumjs-util": "9.0.4",
-        "lru-cache": "^10.0.0",
-        "rust-verkle-wasm": "^0.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@nomicfoundation/ethereumjs-vm": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-vm/-/ethereumjs-vm-7.0.4.tgz",
-      "integrity": "sha512-gsA4IhmtWHI4BofKy3kio9W+dqZQs5Ji5mLjLYxHCkat+JQBUt5szjRKra2F9nGDJ2XcI/wWb0YWUFNgln4zRQ==",
-      "dependencies": {
-        "@nomicfoundation/ethereumjs-block": "5.0.4",
-        "@nomicfoundation/ethereumjs-blockchain": "7.0.4",
-        "@nomicfoundation/ethereumjs-common": "4.0.4",
-        "@nomicfoundation/ethereumjs-evm": "2.0.4",
-        "@nomicfoundation/ethereumjs-rlp": "5.0.4",
-        "@nomicfoundation/ethereumjs-statemanager": "2.0.4",
-        "@nomicfoundation/ethereumjs-trie": "6.0.4",
-        "@nomicfoundation/ethereumjs-tx": "5.0.4",
-        "@nomicfoundation/ethereumjs-util": "9.0.4",
-        "debug": "^4.3.3",
-        "ethereum-cryptography": "0.1.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@nomicfoundation/ethereumjs-vm/node_modules/ethereum-cryptography": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
       "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
@@ -4171,14 +3947,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/debug": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
-      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
-      "dependencies": {
-        "@types/ms": "*"
-      }
-    },
     "node_modules/@types/expect": {
       "version": "24.3.0",
       "resolved": "https://registry.npmjs.org/@types/expect/-/expect-24.3.0.tgz",
@@ -4311,11 +4079,6 @@
       "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
       "dev": true
     },
-    "node_modules/@types/ms": {
-      "version": "0.7.34",
-      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
-      "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
-    },
     "node_modules/@types/mysql": {
       "version": "2.15.21",
       "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.21.tgz",
@@ -4385,20 +4148,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
-    },
-    "node_modules/@types/readable-stream": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.15.tgz",
-      "integrity": "sha512-oM5JSKQCcICF1wvGgmecmHldZ48OZamtMxcGGVICOJA8o8cahXC1zEVAif8iwoc5j8etxFaRFnf095+CDsuoFQ==",
-      "dependencies": {
-        "@types/node": "*",
-        "safe-buffer": "~5.1.1"
-      }
-    },
-    "node_modules/@types/readable-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/@types/resolve": {
       "version": "0.0.8",
@@ -6067,14 +5816,6 @@
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/bigint-crypto-utils": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/bigint-crypto-utils/-/bigint-crypto-utils-3.3.0.tgz",
-      "integrity": "sha512-jOTSb+drvEDxEq6OuUybOAv/xxoh3cuYRUIPyu8sSHQNKM303UQ2R1DAo45o1AkcIXw6fzbaFI1+xGGdaXs2lg==",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/bignumber.js": {
@@ -17761,23 +17502,16 @@
       "dev": true
     },
     "node_modules/hardhat": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.20.0.tgz",
-      "integrity": "sha512-TtWZ4mKOH5YA+PCDAGAjG7Gub2NA+egAX7RIHq5XnGrEALNXAbyP3S0I9vOE1MWCgZhn+XOFUNfDuHgkBOPoRw==",
+      "version": "2.22.15",
+      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.22.15.tgz",
+      "integrity": "sha512-BpTGa9PE/sKAaHi4s/S1e9WGv63DR1m7Lzfd60C8gSEchDPfAJssVRSq0MZ2v2k76ig9m0kHAwVLf5teYwu/Mw==",
       "dependencies": {
         "@ethersproject/abi": "^5.1.2",
         "@metamask/eth-sig-util": "^4.0.0",
-        "@nomicfoundation/ethereumjs-block": "5.0.4",
-        "@nomicfoundation/ethereumjs-blockchain": "7.0.4",
+        "@nomicfoundation/edr": "^0.6.4",
         "@nomicfoundation/ethereumjs-common": "4.0.4",
-        "@nomicfoundation/ethereumjs-evm": "2.0.4",
-        "@nomicfoundation/ethereumjs-rlp": "5.0.4",
-        "@nomicfoundation/ethereumjs-statemanager": "2.0.4",
-        "@nomicfoundation/ethereumjs-trie": "6.0.4",
         "@nomicfoundation/ethereumjs-tx": "5.0.4",
         "@nomicfoundation/ethereumjs-util": "9.0.4",
-        "@nomicfoundation/ethereumjs-verkle": "0.0.2",
-        "@nomicfoundation/ethereumjs-vm": "7.0.4",
         "@nomicfoundation/solidity-analyzer": "^0.1.0",
         "@sentry/node": "^5.18.1",
         "@types/bn.js": "^5.1.0",
@@ -17787,7 +17521,7 @@
         "ansi-escapes": "^4.3.0",
         "boxen": "^5.1.2",
         "chalk": "^2.4.2",
-        "chokidar": "^3.4.0",
+        "chokidar": "^4.0.0",
         "ci-info": "^2.0.0",
         "debug": "^4.1.1",
         "enquirer": "^2.3.0",
@@ -17800,6 +17534,7 @@
         "glob": "7.2.0",
         "immutable": "^4.0.0-rc.12",
         "io-ts": "1.10.4",
+        "json-stream-stringify": "^3.1.4",
         "keccak": "^3.0.2",
         "lodash": "^4.17.11",
         "mnemonist": "^0.38.0",
@@ -17808,7 +17543,7 @@
         "raw-body": "^2.4.1",
         "resolve": "1.17.0",
         "semver": "^6.3.0",
-        "solc": "0.7.3",
+        "solc": "0.8.26",
         "source-map-support": "^0.5.13",
         "stacktrace-parser": "^0.1.10",
         "tsort": "0.0.1",
@@ -17896,6 +17631,20 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/hardhat/node_modules/chokidar": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
+      "integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/hardhat/node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -17910,9 +17659,12 @@
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/hardhat/node_modules/commander": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-      "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/hardhat/node_modules/fp-ts": {
       "version": "1.19.3",
@@ -17936,14 +17688,6 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/hardhat/node_modules/jsonfile": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-      "integrity": "sha512-PKllAqbgLgxHaj8TElYymKCAgrASebJrWpTnEkOaTowt23VKXXN0sUeriJ+eh7y6ufb/CC5ap11pz71/cM0hUw==",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/hardhat/node_modules/locate-path": {
@@ -18082,6 +17826,32 @@
         "url": "https://opencollective.com/mochajs"
       }
     },
+    "node_modules/hardhat/node_modules/mocha/node_modules/chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/hardhat/node_modules/mocha/node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -18095,6 +17865,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/hardhat/node_modules/mocha/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
       }
     },
     "node_modules/hardhat/node_modules/mocha/node_modules/supports-color": {
@@ -18163,6 +17944,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/hardhat/node_modules/readdirp": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
+      "integrity": "sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==",
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/hardhat/node_modules/resolve": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
@@ -18172,17 +17965,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hardhat/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
       }
     },
     "node_modules/hardhat/node_modules/semver": {
@@ -18202,43 +17984,29 @@
       }
     },
     "node_modules/hardhat/node_modules/solc": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/solc/-/solc-0.7.3.tgz",
-      "integrity": "sha512-GAsWNAjGzIDg7VxzP6mPjdurby3IkGCjQcM8GFYZT6RyaoUZKmMU6Y7YwG+tFGhv7dwZ8rmR4iwFDrrD99JwqA==",
+      "version": "0.8.26",
+      "resolved": "https://registry.npmjs.org/solc/-/solc-0.8.26.tgz",
+      "integrity": "sha512-yiPQNVf5rBFHwN6SIf3TUUvVAFKcQqmSUFeq+fb6pNRCo0ZCgpYOZDi3BVoezCPIAcKrVYd/qXlBLUP9wVrZ9g==",
       "dependencies": {
         "command-exists": "^1.2.8",
-        "commander": "3.0.2",
+        "commander": "^8.1.0",
         "follow-redirects": "^1.12.1",
-        "fs-extra": "^0.30.0",
         "js-sha3": "0.8.0",
         "memorystream": "^0.3.1",
-        "require-from-string": "^2.0.0",
         "semver": "^5.5.0",
         "tmp": "0.0.33"
       },
       "bin": {
-        "solcjs": "solcjs"
+        "solcjs": "solc.js"
       },
       "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/hardhat/node_modules/solc/node_modules/fs-extra": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-      "integrity": "sha512-UvSPKyhMn6LEd/WpUaV9C9t3zATuqoqfWc3QdPhPLb58prN9tqYPlPWi8Krxi44loBoUzlobqZ3+8tGpxxSzwA==",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^2.1.0",
-        "klaw": "^1.0.0",
-        "path-is-absolute": "^1.0.0",
-        "rimraf": "^2.2.8"
+        "node": ">=10.0.0"
       }
     },
     "node_modules/hardhat/node_modules/solc/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "bin": {
         "semver": "bin/semver"
       }
@@ -19964,15 +19732,6 @@
         "node": ">= 0.6.0"
       }
     },
-    "node_modules/js-sdsl": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.2.tgz",
-      "integrity": "sha512-dwXFwByc/ajSV6m5bcKAPwe4yDDF6D614pxmIi5odytzxRlwqF6nwoiCek80Ixc7Cvma5awClxrzFtxCQvcM8w==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/js-sdsl"
-      }
-    },
     "node_modules/js-sha3": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
@@ -20064,6 +19823,14 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
+    "node_modules/json-stream-stringify": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/json-stream-stringify/-/json-stream-stringify-3.1.6.tgz",
+      "integrity": "sha512-x7fpwxOkbhFCaJDJ8vb1fBY3DdSa4AlITaz+HHILQJzdPMnHEFjxPwVUi1ALIbcIxDE0PNe/0i7frnY8QnBQog==",
+      "engines": {
+        "node": ">=7.10.1"
+      }
+    },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -20143,6 +19910,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha512-TED5xi9gGQjGpNnvRWknrwAB1eL5GciPfVFOt3Vk1OJCVDQbzuSfrF3hkUQKlsgKrG1F+0t5W0m+Fje1jIt8rw==",
+      "dev": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.9"
       }
@@ -23137,19 +22905,6 @@
       ],
       "dependencies": {
         "queue-microtask": "^1.2.2"
-      }
-    },
-    "node_modules/rust-verkle-wasm": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/rust-verkle-wasm/-/rust-verkle-wasm-0.0.1.tgz",
-      "integrity": "sha512-BN6fiTsxcd2dCECz/cHtGTt9cdLJR925nh7iAuRcj8ymKw7OOaPmCneQZ7JePOJ/ia27TjEL91VdOi88Yf+mcA=="
-    },
-    "node_modules/rustbn-wasm": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/rustbn-wasm/-/rustbn-wasm-0.2.0.tgz",
-      "integrity": "sha512-FThvYFNTqrEKGqXuseeg0zR7yROh/6U1617mCHF68OVqrN1tNKRN7Tdwy4WayPVsCmmK+eMxtIZX1qL6JxTkMg==",
-      "dependencies": {
-        "@scure/base": "^1.1.1"
       }
     },
     "node_modules/safe-buffer": {
@@ -26935,83 +26690,54 @@
         "fastq": "^1.6.0"
       }
     },
-    "@nomicfoundation/ethereumjs-block": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-block/-/ethereumjs-block-5.0.4.tgz",
-      "integrity": "sha512-AcyacJ9eX/uPEvqsPiB+WO1ymE+kyH48qGGiGV+YTojdtas8itUTW5dehDSOXEEItWGbbzEJ4PRqnQZlWaPvDw==",
+    "@nomicfoundation/edr": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr/-/edr-0.6.4.tgz",
+      "integrity": "sha512-YgrSuT3yo5ZQkbvBGqQ7hG+RDvz3YygSkddg4tb1Z0Y6pLXFzwrcEwWaJCFAVeeZxdxGfCgGMUYgRVneK+WXkw==",
       "requires": {
-        "@nomicfoundation/ethereumjs-common": "4.0.4",
-        "@nomicfoundation/ethereumjs-rlp": "5.0.4",
-        "@nomicfoundation/ethereumjs-trie": "6.0.4",
-        "@nomicfoundation/ethereumjs-tx": "5.0.4",
-        "@nomicfoundation/ethereumjs-util": "9.0.4",
-        "ethereum-cryptography": "0.1.3"
-      },
-      "dependencies": {
-        "ethereum-cryptography": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-          "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-          "requires": {
-            "@types/pbkdf2": "^3.0.0",
-            "@types/secp256k1": "^4.0.1",
-            "blakejs": "^1.1.0",
-            "browserify-aes": "^1.2.0",
-            "bs58check": "^2.1.2",
-            "create-hash": "^1.2.0",
-            "create-hmac": "^1.1.7",
-            "hash.js": "^1.1.7",
-            "keccak": "^3.0.0",
-            "pbkdf2": "^3.0.17",
-            "randombytes": "^2.1.0",
-            "safe-buffer": "^5.1.2",
-            "scrypt-js": "^3.0.0",
-            "secp256k1": "^4.0.1",
-            "setimmediate": "^1.0.5"
-          }
-        }
+        "@nomicfoundation/edr-darwin-arm64": "0.6.4",
+        "@nomicfoundation/edr-darwin-x64": "0.6.4",
+        "@nomicfoundation/edr-linux-arm64-gnu": "0.6.4",
+        "@nomicfoundation/edr-linux-arm64-musl": "0.6.4",
+        "@nomicfoundation/edr-linux-x64-gnu": "0.6.4",
+        "@nomicfoundation/edr-linux-x64-musl": "0.6.4",
+        "@nomicfoundation/edr-win32-x64-msvc": "0.6.4"
       }
     },
-    "@nomicfoundation/ethereumjs-blockchain": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-blockchain/-/ethereumjs-blockchain-7.0.4.tgz",
-      "integrity": "sha512-jYsd/kwzbmpnxx86tXsYV8wZ5xGvFL+7/P0c6OlzpClHsbFzeF41KrYA9scON8Rg6bZu3ZTv6JOAgj3t7USUfg==",
-      "requires": {
-        "@nomicfoundation/ethereumjs-block": "5.0.4",
-        "@nomicfoundation/ethereumjs-common": "4.0.4",
-        "@nomicfoundation/ethereumjs-ethash": "3.0.4",
-        "@nomicfoundation/ethereumjs-rlp": "5.0.4",
-        "@nomicfoundation/ethereumjs-trie": "6.0.4",
-        "@nomicfoundation/ethereumjs-tx": "5.0.4",
-        "@nomicfoundation/ethereumjs-util": "9.0.4",
-        "debug": "^4.3.3",
-        "ethereum-cryptography": "0.1.3",
-        "lru-cache": "^10.0.0"
-      },
-      "dependencies": {
-        "ethereum-cryptography": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-          "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-          "requires": {
-            "@types/pbkdf2": "^3.0.0",
-            "@types/secp256k1": "^4.0.1",
-            "blakejs": "^1.1.0",
-            "browserify-aes": "^1.2.0",
-            "bs58check": "^2.1.2",
-            "create-hash": "^1.2.0",
-            "create-hmac": "^1.1.7",
-            "hash.js": "^1.1.7",
-            "keccak": "^3.0.0",
-            "pbkdf2": "^3.0.17",
-            "randombytes": "^2.1.0",
-            "safe-buffer": "^5.1.2",
-            "scrypt-js": "^3.0.0",
-            "secp256k1": "^4.0.1",
-            "setimmediate": "^1.0.5"
-          }
-        }
-      }
+    "@nomicfoundation/edr-darwin-arm64": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-arm64/-/edr-darwin-arm64-0.6.4.tgz",
+      "integrity": "sha512-QNQErISLgssV9+qia8sIjRANqtbW8snSDvjspixT/kSQ5ZSGxxctTg7x72wPSrcu8+EBEveIe5uqENIp5GH8HQ=="
+    },
+    "@nomicfoundation/edr-darwin-x64": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-x64/-/edr-darwin-x64-0.6.4.tgz",
+      "integrity": "sha512-cjVmREiwByyc9+oGfvAh49IAw+oVJHF9WWYRD+Tm/ZlSpnEVWxrGNBak2bd/JSYjn+mZE7gmWS4SMRi4nKaLUg=="
+    },
+    "@nomicfoundation/edr-linux-arm64-gnu": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-gnu/-/edr-linux-arm64-gnu-0.6.4.tgz",
+      "integrity": "sha512-96o9kRIVD6W5VkgKvUOGpWyUGInVQ5BRlME2Fa36YoNsRQMaKtmYJEU0ACosYES6ZTpYC8U5sjMulvPtVoEfOA=="
+    },
+    "@nomicfoundation/edr-linux-arm64-musl": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-musl/-/edr-linux-arm64-musl-0.6.4.tgz",
+      "integrity": "sha512-+JVEW9e5plHrUfQlSgkEj/UONrIU6rADTEk+Yp9pbe+mzNkJdfJYhs5JYiLQRP4OjxH4QOrXI97bKU6FcEbt5Q=="
+    },
+    "@nomicfoundation/edr-linux-x64-gnu": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-gnu/-/edr-linux-x64-gnu-0.6.4.tgz",
+      "integrity": "sha512-nzYWW+fO3EZItOeP4CrdMgDXfaGBIBkKg0Y/7ySpUxLqzut40O4Mb0/+quqLAFkacUSWMlFp8nsmypJfOH5zoA=="
+    },
+    "@nomicfoundation/edr-linux-x64-musl": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-musl/-/edr-linux-x64-musl-0.6.4.tgz",
+      "integrity": "sha512-QFRoE9qSQ2boRrVeQ1HdzU+XN7NUgwZ1SIy5DQt4d7jCP+5qTNsq8LBNcqhRBOATgO63nsweNUhxX/Suj5r1Sw=="
+    },
+    "@nomicfoundation/edr-win32-x64-msvc": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-win32-x64-msvc/-/edr-win32-x64-msvc-0.6.4.tgz",
+      "integrity": "sha512-2yopjelNkkCvIjUgBGhrn153IBPLwnsDeNiq6oA0WkeM8tGmQi4td+PGi9jAriUDAkc59Yoi2q9hYA6efiY7Zw=="
     },
     "@nomicfoundation/ethereumjs-common": {
       "version": "4.0.4",
@@ -27021,161 +26747,10 @@
         "@nomicfoundation/ethereumjs-util": "9.0.4"
       }
     },
-    "@nomicfoundation/ethereumjs-ethash": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-ethash/-/ethereumjs-ethash-3.0.4.tgz",
-      "integrity": "sha512-xvIrwIMl9sSaiYKRem68+O7vYdj7Q2XWv5P7JXiIkn83918QzWHvqbswTRsH7+r6X1UEvdsURRnZbvZszEjAaQ==",
-      "requires": {
-        "@nomicfoundation/ethereumjs-block": "5.0.4",
-        "@nomicfoundation/ethereumjs-rlp": "5.0.4",
-        "@nomicfoundation/ethereumjs-util": "9.0.4",
-        "bigint-crypto-utils": "^3.2.2",
-        "ethereum-cryptography": "0.1.3"
-      },
-      "dependencies": {
-        "ethereum-cryptography": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-          "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-          "requires": {
-            "@types/pbkdf2": "^3.0.0",
-            "@types/secp256k1": "^4.0.1",
-            "blakejs": "^1.1.0",
-            "browserify-aes": "^1.2.0",
-            "bs58check": "^2.1.2",
-            "create-hash": "^1.2.0",
-            "create-hmac": "^1.1.7",
-            "hash.js": "^1.1.7",
-            "keccak": "^3.0.0",
-            "pbkdf2": "^3.0.17",
-            "randombytes": "^2.1.0",
-            "safe-buffer": "^5.1.2",
-            "scrypt-js": "^3.0.0",
-            "secp256k1": "^4.0.1",
-            "setimmediate": "^1.0.5"
-          }
-        }
-      }
-    },
-    "@nomicfoundation/ethereumjs-evm": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-evm/-/ethereumjs-evm-2.0.4.tgz",
-      "integrity": "sha512-lTyZZi1KpeMHzaO6cSVisR2tjiTTedjo7PcmhI/+GNFo9BmyY6QYzGeSti0sFttmjbEMioHgXxl5yrLNRg6+1w==",
-      "requires": {
-        "@nomicfoundation/ethereumjs-common": "4.0.4",
-        "@nomicfoundation/ethereumjs-statemanager": "2.0.4",
-        "@nomicfoundation/ethereumjs-tx": "5.0.4",
-        "@nomicfoundation/ethereumjs-util": "9.0.4",
-        "@types/debug": "^4.1.9",
-        "debug": "^4.3.3",
-        "ethereum-cryptography": "0.1.3",
-        "rustbn-wasm": "^0.2.0"
-      },
-      "dependencies": {
-        "ethereum-cryptography": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-          "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-          "requires": {
-            "@types/pbkdf2": "^3.0.0",
-            "@types/secp256k1": "^4.0.1",
-            "blakejs": "^1.1.0",
-            "browserify-aes": "^1.2.0",
-            "bs58check": "^2.1.2",
-            "create-hash": "^1.2.0",
-            "create-hmac": "^1.1.7",
-            "hash.js": "^1.1.7",
-            "keccak": "^3.0.0",
-            "pbkdf2": "^3.0.17",
-            "randombytes": "^2.1.0",
-            "safe-buffer": "^5.1.2",
-            "scrypt-js": "^3.0.0",
-            "secp256k1": "^4.0.1",
-            "setimmediate": "^1.0.5"
-          }
-        }
-      }
-    },
     "@nomicfoundation/ethereumjs-rlp": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-rlp/-/ethereumjs-rlp-5.0.4.tgz",
       "integrity": "sha512-8H1S3s8F6QueOc/X92SdrA4RDenpiAEqMg5vJH99kcQaCy/a3Q6fgseo75mgWlbanGJXSlAPtnCeG9jvfTYXlw=="
-    },
-    "@nomicfoundation/ethereumjs-statemanager": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-statemanager/-/ethereumjs-statemanager-2.0.4.tgz",
-      "integrity": "sha512-HPDjeFrxw6llEi+BzqXkZ+KkvFnTOPczuHBtk21hRlDiuKuZz32dPzlhpRsDBGV1b5JTmRDUVqCS1lp3Gghw4Q==",
-      "requires": {
-        "@nomicfoundation/ethereumjs-common": "4.0.4",
-        "@nomicfoundation/ethereumjs-rlp": "5.0.4",
-        "@nomicfoundation/ethereumjs-trie": "6.0.4",
-        "@nomicfoundation/ethereumjs-util": "9.0.4",
-        "debug": "^4.3.3",
-        "ethereum-cryptography": "0.1.3",
-        "js-sdsl": "^4.1.4",
-        "lru-cache": "^10.0.0"
-      },
-      "dependencies": {
-        "ethereum-cryptography": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-          "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-          "requires": {
-            "@types/pbkdf2": "^3.0.0",
-            "@types/secp256k1": "^4.0.1",
-            "blakejs": "^1.1.0",
-            "browserify-aes": "^1.2.0",
-            "bs58check": "^2.1.2",
-            "create-hash": "^1.2.0",
-            "create-hmac": "^1.1.7",
-            "hash.js": "^1.1.7",
-            "keccak": "^3.0.0",
-            "pbkdf2": "^3.0.17",
-            "randombytes": "^2.1.0",
-            "safe-buffer": "^5.1.2",
-            "scrypt-js": "^3.0.0",
-            "secp256k1": "^4.0.1",
-            "setimmediate": "^1.0.5"
-          }
-        }
-      }
-    },
-    "@nomicfoundation/ethereumjs-trie": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-trie/-/ethereumjs-trie-6.0.4.tgz",
-      "integrity": "sha512-3nSwQiFMvr2VFe/aZUyinuohYvtytUqZCUCvIWcPJ/BwJH6oQdZRB42aNFBJ/8nAh2s3OcroWpBLskzW01mFKA==",
-      "requires": {
-        "@nomicfoundation/ethereumjs-rlp": "5.0.4",
-        "@nomicfoundation/ethereumjs-util": "9.0.4",
-        "@types/readable-stream": "^2.3.13",
-        "ethereum-cryptography": "0.1.3",
-        "lru-cache": "^10.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "dependencies": {
-        "ethereum-cryptography": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-          "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-          "requires": {
-            "@types/pbkdf2": "^3.0.0",
-            "@types/secp256k1": "^4.0.1",
-            "blakejs": "^1.1.0",
-            "browserify-aes": "^1.2.0",
-            "bs58check": "^2.1.2",
-            "create-hash": "^1.2.0",
-            "create-hmac": "^1.1.7",
-            "hash.js": "^1.1.7",
-            "keccak": "^3.0.0",
-            "pbkdf2": "^3.0.17",
-            "randombytes": "^2.1.0",
-            "safe-buffer": "^5.1.2",
-            "scrypt-js": "^3.0.0",
-            "secp256k1": "^4.0.1",
-            "setimmediate": "^1.0.5"
-          }
-        }
-      }
     },
     "@nomicfoundation/ethereumjs-tx": {
       "version": "5.0.4",
@@ -27218,59 +26793,6 @@
       "integrity": "sha512-sLOzjnSrlx9Bb9EFNtHzK/FJFsfg2re6bsGqinFinH1gCqVfz9YYlXiMWwDM4C/L4ywuHFCYwfKTVr/QHQcU0Q==",
       "requires": {
         "@nomicfoundation/ethereumjs-rlp": "5.0.4",
-        "ethereum-cryptography": "0.1.3"
-      },
-      "dependencies": {
-        "ethereum-cryptography": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-          "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-          "requires": {
-            "@types/pbkdf2": "^3.0.0",
-            "@types/secp256k1": "^4.0.1",
-            "blakejs": "^1.1.0",
-            "browserify-aes": "^1.2.0",
-            "bs58check": "^2.1.2",
-            "create-hash": "^1.2.0",
-            "create-hmac": "^1.1.7",
-            "hash.js": "^1.1.7",
-            "keccak": "^3.0.0",
-            "pbkdf2": "^3.0.17",
-            "randombytes": "^2.1.0",
-            "safe-buffer": "^5.1.2",
-            "scrypt-js": "^3.0.0",
-            "secp256k1": "^4.0.1",
-            "setimmediate": "^1.0.5"
-          }
-        }
-      }
-    },
-    "@nomicfoundation/ethereumjs-verkle": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-verkle/-/ethereumjs-verkle-0.0.2.tgz",
-      "integrity": "sha512-bjnfZElpYGK/XuuVRmLS3yDvr+cDs85D9oonZ0YUa5A3lgFgokWMp76zXrxX2jVQ0BfHaw12y860n1+iOi6yFQ==",
-      "requires": {
-        "@nomicfoundation/ethereumjs-rlp": "5.0.4",
-        "@nomicfoundation/ethereumjs-util": "9.0.4",
-        "lru-cache": "^10.0.0",
-        "rust-verkle-wasm": "^0.0.1"
-      }
-    },
-    "@nomicfoundation/ethereumjs-vm": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-vm/-/ethereumjs-vm-7.0.4.tgz",
-      "integrity": "sha512-gsA4IhmtWHI4BofKy3kio9W+dqZQs5Ji5mLjLYxHCkat+JQBUt5szjRKra2F9nGDJ2XcI/wWb0YWUFNgln4zRQ==",
-      "requires": {
-        "@nomicfoundation/ethereumjs-block": "5.0.4",
-        "@nomicfoundation/ethereumjs-blockchain": "7.0.4",
-        "@nomicfoundation/ethereumjs-common": "4.0.4",
-        "@nomicfoundation/ethereumjs-evm": "2.0.4",
-        "@nomicfoundation/ethereumjs-rlp": "5.0.4",
-        "@nomicfoundation/ethereumjs-statemanager": "2.0.4",
-        "@nomicfoundation/ethereumjs-trie": "6.0.4",
-        "@nomicfoundation/ethereumjs-tx": "5.0.4",
-        "@nomicfoundation/ethereumjs-util": "9.0.4",
-        "debug": "^4.3.3",
         "ethereum-cryptography": "0.1.3"
       },
       "dependencies": {
@@ -27957,14 +27479,6 @@
         "@types/node": "*"
       }
     },
-    "@types/debug": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
-      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
-      "requires": {
-        "@types/ms": "*"
-      }
-    },
     "@types/expect": {
       "version": "24.3.0",
       "resolved": "https://registry.npmjs.org/@types/expect/-/expect-24.3.0.tgz",
@@ -28096,11 +27610,6 @@
       "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
       "dev": true
     },
-    "@types/ms": {
-      "version": "0.7.34",
-      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
-      "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
-    },
     "@types/mysql": {
       "version": "2.15.21",
       "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.21.tgz",
@@ -28169,22 +27678,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
-    },
-    "@types/readable-stream": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.15.tgz",
-      "integrity": "sha512-oM5JSKQCcICF1wvGgmecmHldZ48OZamtMxcGGVICOJA8o8cahXC1zEVAif8iwoc5j8etxFaRFnf095+CDsuoFQ==",
-      "requires": {
-        "@types/node": "*",
-        "safe-buffer": "~5.1.1"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        }
-      }
     },
     "@types/resolve": {
       "version": "0.0.8",
@@ -29417,11 +28910,6 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
-    },
-    "bigint-crypto-utils": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/bigint-crypto-utils/-/bigint-crypto-utils-3.3.0.tgz",
-      "integrity": "sha512-jOTSb+drvEDxEq6OuUybOAv/xxoh3cuYRUIPyu8sSHQNKM303UQ2R1DAo45o1AkcIXw6fzbaFI1+xGGdaXs2lg=="
     },
     "bignumber.js": {
       "version": "9.1.2",
@@ -38401,23 +37889,16 @@
       }
     },
     "hardhat": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.20.0.tgz",
-      "integrity": "sha512-TtWZ4mKOH5YA+PCDAGAjG7Gub2NA+egAX7RIHq5XnGrEALNXAbyP3S0I9vOE1MWCgZhn+XOFUNfDuHgkBOPoRw==",
+      "version": "2.22.15",
+      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.22.15.tgz",
+      "integrity": "sha512-BpTGa9PE/sKAaHi4s/S1e9WGv63DR1m7Lzfd60C8gSEchDPfAJssVRSq0MZ2v2k76ig9m0kHAwVLf5teYwu/Mw==",
       "requires": {
         "@ethersproject/abi": "^5.1.2",
         "@metamask/eth-sig-util": "^4.0.0",
-        "@nomicfoundation/ethereumjs-block": "5.0.4",
-        "@nomicfoundation/ethereumjs-blockchain": "7.0.4",
+        "@nomicfoundation/edr": "^0.6.4",
         "@nomicfoundation/ethereumjs-common": "4.0.4",
-        "@nomicfoundation/ethereumjs-evm": "2.0.4",
-        "@nomicfoundation/ethereumjs-rlp": "5.0.4",
-        "@nomicfoundation/ethereumjs-statemanager": "2.0.4",
-        "@nomicfoundation/ethereumjs-trie": "6.0.4",
         "@nomicfoundation/ethereumjs-tx": "5.0.4",
         "@nomicfoundation/ethereumjs-util": "9.0.4",
-        "@nomicfoundation/ethereumjs-verkle": "0.0.2",
-        "@nomicfoundation/ethereumjs-vm": "7.0.4",
         "@nomicfoundation/solidity-analyzer": "^0.1.0",
         "@sentry/node": "^5.18.1",
         "@types/bn.js": "^5.1.0",
@@ -38427,7 +37908,7 @@
         "ansi-escapes": "^4.3.0",
         "boxen": "^5.1.2",
         "chalk": "^2.4.2",
-        "chokidar": "^3.4.0",
+        "chokidar": "^4.0.0",
         "ci-info": "^2.0.0",
         "debug": "^4.1.1",
         "enquirer": "^2.3.0",
@@ -38440,6 +37921,7 @@
         "glob": "7.2.0",
         "immutable": "^4.0.0-rc.12",
         "io-ts": "1.10.4",
+        "json-stream-stringify": "^3.1.4",
         "keccak": "^3.0.2",
         "lodash": "^4.17.11",
         "mnemonist": "^0.38.0",
@@ -38448,7 +37930,7 @@
         "raw-body": "^2.4.1",
         "resolve": "1.17.0",
         "semver": "^6.3.0",
-        "solc": "0.7.3",
+        "solc": "0.8.26",
         "source-map-support": "^0.5.13",
         "stacktrace-parser": "^0.1.10",
         "tsort": "0.0.1",
@@ -38500,6 +37982,14 @@
             }
           }
         },
+        "chokidar": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
+          "integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
+          "requires": {
+            "readdirp": "^4.0.1"
+          }
+        },
         "color-convert": {
           "version": "1.9.3",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -38514,9 +38004,9 @@
           "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
         },
         "commander": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-          "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+          "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
         },
         "fp-ts": {
           "version": "1.19.3",
@@ -38537,14 +38027,6 @@
           "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
           "requires": {
             "argparse": "^2.0.1"
-          }
-        },
-        "jsonfile": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-          "integrity": "sha512-PKllAqbgLgxHaj8TElYymKCAgrASebJrWpTnEkOaTowt23VKXXN0sUeriJ+eh7y6ufb/CC5ap11pz71/cM0hUw==",
-          "requires": {
-            "graceful-fs": "^4.1.6"
           }
         },
         "locate-path": {
@@ -38641,6 +38123,21 @@
             "yargs-unparser": "2.0.0"
           },
           "dependencies": {
+            "chokidar": {
+              "version": "3.5.3",
+              "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+              "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+              "requires": {
+                "anymatch": "~3.1.2",
+                "braces": "~3.0.2",
+                "fsevents": "~2.3.2",
+                "glob-parent": "~5.1.2",
+                "is-binary-path": "~2.1.0",
+                "is-glob": "~4.0.1",
+                "normalize-path": "~3.0.0",
+                "readdirp": "~3.6.0"
+              }
+            },
             "find-up": {
               "version": "5.0.0",
               "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -38648,6 +38145,14 @@
               "requires": {
                 "locate-path": "^6.0.0",
                 "path-exists": "^4.0.0"
+              }
+            },
+            "readdirp": {
+              "version": "3.6.0",
+              "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+              "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+              "requires": {
+                "picomatch": "^2.2.1"
               }
             },
             "supports-color": {
@@ -38691,20 +38196,17 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
           "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
         },
+        "readdirp": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
+          "integrity": "sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA=="
+        },
         "resolve": {
           "version": "1.17.0",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
           "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
           "requires": {
             "path-parse": "^1.0.6"
-          }
-        },
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "requires": {
-            "glob": "^7.1.3"
           }
         },
         "semver": {
@@ -38721,37 +38223,23 @@
           }
         },
         "solc": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/solc/-/solc-0.7.3.tgz",
-          "integrity": "sha512-GAsWNAjGzIDg7VxzP6mPjdurby3IkGCjQcM8GFYZT6RyaoUZKmMU6Y7YwG+tFGhv7dwZ8rmR4iwFDrrD99JwqA==",
+          "version": "0.8.26",
+          "resolved": "https://registry.npmjs.org/solc/-/solc-0.8.26.tgz",
+          "integrity": "sha512-yiPQNVf5rBFHwN6SIf3TUUvVAFKcQqmSUFeq+fb6pNRCo0ZCgpYOZDi3BVoezCPIAcKrVYd/qXlBLUP9wVrZ9g==",
           "requires": {
             "command-exists": "^1.2.8",
-            "commander": "3.0.2",
+            "commander": "^8.1.0",
             "follow-redirects": "^1.12.1",
-            "fs-extra": "^0.30.0",
             "js-sha3": "0.8.0",
             "memorystream": "^0.3.1",
-            "require-from-string": "^2.0.0",
             "semver": "^5.5.0",
             "tmp": "0.0.33"
           },
           "dependencies": {
-            "fs-extra": {
-              "version": "0.30.0",
-              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-              "integrity": "sha512-UvSPKyhMn6LEd/WpUaV9C9t3zATuqoqfWc3QdPhPLb58prN9tqYPlPWi8Krxi44loBoUzlobqZ3+8tGpxxSzwA==",
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "jsonfile": "^2.1.0",
-                "klaw": "^1.0.0",
-                "path-is-absolute": "^1.0.0",
-                "rimraf": "^2.2.8"
-              }
-            },
             "semver": {
-              "version": "5.7.1",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+              "version": "5.7.2",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+              "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
             }
           }
         },
@@ -40025,11 +39513,6 @@
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
       "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw=="
     },
-    "js-sdsl": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.2.tgz",
-      "integrity": "sha512-dwXFwByc/ajSV6m5bcKAPwe4yDDF6D614pxmIi5odytzxRlwqF6nwoiCek80Ixc7Cvma5awClxrzFtxCQvcM8w=="
-    },
     "js-sha3": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
@@ -40112,6 +39595,11 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
+    "json-stream-stringify": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/json-stream-stringify/-/json-stream-stringify-3.1.6.tgz",
+      "integrity": "sha512-x7fpwxOkbhFCaJDJ8vb1fBY3DdSa4AlITaz+HHILQJzdPMnHEFjxPwVUi1ALIbcIxDE0PNe/0i7frnY8QnBQog=="
+    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -40181,6 +39669,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha512-TED5xi9gGQjGpNnvRWknrwAB1eL5GciPfVFOt3Vk1OJCVDQbzuSfrF3hkUQKlsgKrG1F+0t5W0m+Fje1jIt8rw==",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.9"
       }
@@ -42403,19 +41892,6 @@
       "dev": true,
       "requires": {
         "queue-microtask": "^1.2.2"
-      }
-    },
-    "rust-verkle-wasm": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/rust-verkle-wasm/-/rust-verkle-wasm-0.0.1.tgz",
-      "integrity": "sha512-BN6fiTsxcd2dCECz/cHtGTt9cdLJR925nh7iAuRcj8ymKw7OOaPmCneQZ7JePOJ/ia27TjEL91VdOi88Yf+mcA=="
-    },
-    "rustbn-wasm": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/rustbn-wasm/-/rustbn-wasm-0.2.0.tgz",
-      "integrity": "sha512-FThvYFNTqrEKGqXuseeg0zR7yROh/6U1617mCHF68OVqrN1tNKRN7Tdwy4WayPVsCmmK+eMxtIZX1qL6JxTkMg==",
-      "requires": {
-        "@scure/base": "^1.1.1"
       }
     },
     "safe-buffer": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "ethereum-waffle": "^3.4.0",
     "ethers": "^5.5.1",
     "fishery": "^2.2.2",
-    "hardhat": "2.20.0",
+    "hardhat": "2.22.15",
     "jest": "^29.5.0",
     "json-schema-to-ts": "^1.6.4",
     "mocha": "^8.4.0",


### PR DESCRIPTION
Latest GETH client upgrade removes `totalDifficulty` https://github.com/ethereum/go-ethereum/releases. Hardhat released a fix to handle that https://github.com/NomicFoundation/hardhat/releases.