### PR TITLE
fix: tenderly sim system down as sev2

### DIFF
--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -512,6 +512,9 @@ export class QuoteHandler extends APIGLambdaHandler<
       metric.putMetric('SimulationNotApproved', 1, MetricLoggerUnit.Count)
     } else if (simulationStatus == SimulationStatus.NotSupported) {
       metric.putMetric('SimulationNotSupported', 1, MetricLoggerUnit.Count)
+    } else if (simulationStatus == SimulationStatus.SystemDown) {
+      metric.putMetric('SimulationSystemDown', 1, MetricLoggerUnit.Count)
+      metric.putMetric(`SimulationSystemDownChainId${chainId}`, 1, MetricLoggerUnit.Count)
     }
 
     const routeResponse: Array<SupportedPoolInRoute[]> = []


### PR DESCRIPTION
tenderly simulation system down is swap blocking. we need to get alerted as sev2, and escalate to tenderly team asap.

also we need to add per-chain tenderly system down sev2, so that we can quickly comm to tenderly team, which chain(s) affected.

tested on personal aws account:

![Screenshot 2024-11-07 at 3.52.55 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/d9d30568-37e1-45d5-b3e7-6467a252663e.png)

![Screenshot 2024-11-07 at 3.53.01 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/f9e3be0d-3f7c-4c8a-ba64-0b0dc07674aa.png)

