### PR TITLE
feat: migrate 10% of base traffic to new tenderly sim endpoint

### DIFF
--- a/lib/util/tenderlyNewEndpointRolloutPercent.ts
+++ b/lib/util/tenderlyNewEndpointRolloutPercent.ts
@@ -19,7 +19,7 @@ export const TENDERLY_NEW_ENDPOINT_ROLLOUT_PERCENT: { [chain in ChainId]: number
   [ChainId.BNB]: 0,
   [ChainId.AVALANCHE]: 0,
   [ChainId.BASE_GOERLI]: 0,
-  [ChainId.BASE]: 1,
+  [ChainId.BASE]: 10,
   [ChainId.ZORA]: 0,
   [ChainId.ZORA_SEPOLIA]: 0,
   [ChainId.ROOTSTOCK]: 0,


### PR DESCRIPTION
1 percent looks good. mostly successful:

![Screenshot 2024-11-08 at 11.40.26 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/07cd2861-5860-417a-87f9-2ff95a6a9ee2.png)

2 instances of timeouts:

![Screenshot 2024-11-08 at 11.40.34 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/afbff971-a639-4b1e-843a-ecc7584b885f.png)

