### PR TITLE
feat: enable worldchain v2 routing

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -497,6 +497,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
             ChainId.BNB,
             ChainId.AVALANCHE,
             ChainId.BLAST,
+            ChainId.WORLDCHAIN,
           ]
 
           const v4Supported = [ChainId.SEPOLIA]


### PR DESCRIPTION
we should re-enable worldchain v2 routing, now that swap v2 router02 is re-deployed correctly.