### PR TITLE
chore: bump sor to 4.8.1 - fix: Don't force add direct swap AMPL pools for V3 in candidate pools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.14.0",
         "@uniswap/sdk-core": "^5.9.0",
-        "@uniswap/smart-order-router": "4.8.0",
+        "@uniswap/smart-order-router": "4.8.1",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^4.6.1",
         "@uniswap/v2-sdk": "^4.6.1",
@@ -4508,9 +4508,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.8.0.tgz",
-      "integrity": "sha512-NtJXZlBSIjwreooYOgcTWUaE5ajp68P2oEyJxu/7xf57MwuVbUnIrOw2oSzAPw6/I5xPjRNu1VGZCQxDqtfpsQ==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.8.1.tgz",
+      "integrity": "sha512-AeKoX3iAG7oSkXKiyaODwMw6lpEUNncY+TJJJaJwaw+8K6VTVNQ4dIfK8Bzlm5VzMwSRag8jXkIaKSUlhSGKog==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -27959,9 +27959,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.8.0.tgz",
-      "integrity": "sha512-NtJXZlBSIjwreooYOgcTWUaE5ajp68P2oEyJxu/7xf57MwuVbUnIrOw2oSzAPw6/I5xPjRNu1VGZCQxDqtfpsQ==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.8.1.tgz",
+      "integrity": "sha512-AeKoX3iAG7oSkXKiyaODwMw6lpEUNncY+TJJJaJwaw+8K6VTVNQ4dIfK8Bzlm5VzMwSRag8jXkIaKSUlhSGKog==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@uniswap/permit2-sdk": "^1.3.0",
     "@uniswap/router-sdk": "^1.14.0",
     "@uniswap/sdk-core": "^5.9.0",
-    "@uniswap/smart-order-router": "4.8.0",
+    "@uniswap/smart-order-router": "4.8.1",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^4.6.1",
     "@uniswap/v2-sdk": "^4.6.1",


### PR DESCRIPTION
Bump SOR version to 4.8.1
Releases https://github.com/Uniswap/smart-order-router/pull/765