### PR TITLE
chore: bump sor to 4.8.3 - fix(subgraph): include top 20 VIRTUAL/* pools in V2 Base subgraph

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.14.0",
         "@uniswap/sdk-core": "^5.9.0",
-        "@uniswap/smart-order-router": "4.8.2",
+        "@uniswap/smart-order-router": "4.8.3",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^4.6.1",
         "@uniswap/v2-sdk": "^4.6.1",
@@ -4508,9 +4508,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.8.2.tgz",
-      "integrity": "sha512-JqK9aKQXWQIweO0nkvskV1flnlvQnB0rZ9OTyf+kXKZfrWNrAMGDDO6yjEcrWAGfxi/m/1ThxTcKj9FvVw/RBA==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.8.3.tgz",
+      "integrity": "sha512-/w6RKFXhgniw4/CpI1V34QoAdxGFFiPXHqCumtILGELXaRrUdHWS+U1ZfjI3wqcQbjwz3MNuhuY/5AhM025jDg==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -27959,9 +27959,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.8.2.tgz",
-      "integrity": "sha512-JqK9aKQXWQIweO0nkvskV1flnlvQnB0rZ9OTyf+kXKZfrWNrAMGDDO6yjEcrWAGfxi/m/1ThxTcKj9FvVw/RBA==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.8.3.tgz",
+      "integrity": "sha512-/w6RKFXhgniw4/CpI1V34QoAdxGFFiPXHqCumtILGELXaRrUdHWS+U1ZfjI3wqcQbjwz3MNuhuY/5AhM025jDg==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@uniswap/permit2-sdk": "^1.3.0",
     "@uniswap/router-sdk": "^1.14.0",
     "@uniswap/sdk-core": "^5.9.0",
-    "@uniswap/smart-order-router": "4.8.2",
+    "@uniswap/smart-order-router": "4.8.3",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^4.6.1",
     "@uniswap/v2-sdk": "^4.6.1",


### PR DESCRIPTION
Release https://github.com/Uniswap/smart-order-router/pull/771