### PR TITLE
chore: bump sor to 4.8.5 - fix: Use syntheticGasCostInTermsOfQuoteToken only if within 30% of gasCostInTermsOfQuoteToken

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.14.0",
         "@uniswap/sdk-core": "^5.9.0",
-        "@uniswap/smart-order-router": "4.8.4",
+        "@uniswap/smart-order-router": "4.8.5",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^4.6.1",
         "@uniswap/v2-sdk": "^4.6.1",
@@ -4508,9 +4508,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.8.4.tgz",
-      "integrity": "sha512-HpfC8G5CyiNKKtBffiInZOrnqxe2YszC1H8Q8hh89vgUJAsxt606ibAwrj8OFSx8W+Jb6BAw5wRUi7qF8SYNFQ==",
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.8.5.tgz",
+      "integrity": "sha512-XFLgQgkSB0mUkWijgTaNm9Mb5IEhqZJMpZ+33Gj6AcJnEwKmN8XA02owaZlVw/YH272Tx2Vn4+2CxCfwOZJ6wA==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -27959,9 +27959,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.8.4.tgz",
-      "integrity": "sha512-HpfC8G5CyiNKKtBffiInZOrnqxe2YszC1H8Q8hh89vgUJAsxt606ibAwrj8OFSx8W+Jb6BAw5wRUi7qF8SYNFQ==",
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.8.5.tgz",
+      "integrity": "sha512-XFLgQgkSB0mUkWijgTaNm9Mb5IEhqZJMpZ+33Gj6AcJnEwKmN8XA02owaZlVw/YH272Tx2Vn4+2CxCfwOZJ6wA==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@uniswap/permit2-sdk": "^1.3.0",
     "@uniswap/router-sdk": "^1.14.0",
     "@uniswap/sdk-core": "^5.9.0",
-    "@uniswap/smart-order-router": "4.8.4",
+    "@uniswap/smart-order-router": "4.8.5",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^4.6.1",
     "@uniswap/v2-sdk": "^4.6.1",


### PR DESCRIPTION
Release https://github.com/Uniswap/smart-order-router/pull/776
