### PR TITLE
chore(unirpc): increase Base from 30% -> 50%

### DIFF
--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -68,7 +68,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0,
     "healthCheckSampleProb": 0,
-    "providerInitialWeights": [0.7, 0.3],
+    "providerInitialWeights": [0.5, 0.5],
     "providerUrls": ["QUICKNODE_8453", "UNIRPC_0"],
     "providerNames": ["QUICKNODE", "UNIRPC"]
   },


### PR DESCRIPTION
Sending more traffic for base to unirpc now that we
- improved backend VPC setup with more EIPs
- improved Base quote search space reducing #rpc calls