### PR TITLE
chore: bump sor to 4.8.6 - fix: pass latest to tenderly node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.14.0",
         "@uniswap/sdk-core": "^5.9.0",
-        "@uniswap/smart-order-router": "4.8.5",
+        "@uniswap/smart-order-router": "4.8.6",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^4.6.1",
         "@uniswap/v2-sdk": "^4.6.1",
@@ -4508,9 +4508,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.8.5.tgz",
-      "integrity": "sha512-XFLgQgkSB0mUkWijgTaNm9Mb5IEhqZJMpZ+33Gj6AcJnEwKmN8XA02owaZlVw/YH272Tx2Vn4+2CxCfwOZJ6wA==",
+      "version": "4.8.6",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.8.6.tgz",
+      "integrity": "sha512-yp3sQHAVlon3Q2oQQS1KXQM6X8jpU8Usop9F8oakg1EpsgXPHtMstEQ6DqYIYy7IPkWhLbagRAcftkAb3S81Tg==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -27959,9 +27959,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.8.5.tgz",
-      "integrity": "sha512-XFLgQgkSB0mUkWijgTaNm9Mb5IEhqZJMpZ+33Gj6AcJnEwKmN8XA02owaZlVw/YH272Tx2Vn4+2CxCfwOZJ6wA==",
+      "version": "4.8.6",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.8.6.tgz",
+      "integrity": "sha512-yp3sQHAVlon3Q2oQQS1KXQM6X8jpU8Usop9F8oakg1EpsgXPHtMstEQ6DqYIYy7IPkWhLbagRAcftkAb3S81Tg==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@uniswap/permit2-sdk": "^1.3.0",
     "@uniswap/router-sdk": "^1.14.0",
     "@uniswap/sdk-core": "^5.9.0",
-    "@uniswap/smart-order-router": "4.8.5",
+    "@uniswap/smart-order-router": "4.8.6",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^4.6.1",
     "@uniswap/v2-sdk": "^4.6.1",


### PR DESCRIPTION
Release https://github.com/Uniswap/smart-order-router/pull/779