### PR TITLE
Fix typo in gas limit comments Update gasLimit.ts

### DIFF
--- a/lib/util/gasLimit.ts
+++ b/lib/util/gasLimit.ts
@@ -4,9 +4,9 @@ import { ChainId } from '@uniswap/sdk-core'
 export const ZKSYNC_UPPER_SWAP_GAS_LIMIT = BigNumber.from(6000000)
 // CELO high gas limit from SOR https://github.com/Uniswap/smart-order-router/blob/main/src/routers/alpha-router/alpha-router.ts#L670
 export const CELO_UPPER_SWAP_GAS_LIMIT = BigNumber.from(5000000)
-// https://github.com/Uniswap/routing-api/blob/fe410751985995cb2904837e24f22da7dca1f518/lib/util/onChainQuoteProviderConfigs.ts#L340 divivde by 10
+// https://github.com/Uniswap/routing-api/blob/fe410751985995cb2904837e24f22da7dca1f518/lib/util/onChainQuoteProviderConfigs.ts#L340 divide by 10
 export const WORLDCHAIN_UPPER_SWAP_GAS_LIMIT = BigNumber.from(300000)
-// https://github.com/Uniswap/routing-api/blob/fe410751985995cb2904837e24f22da7dca1f518/lib/util/onChainQuoteProviderConfigs.ts#L344 divivde by 10
+// https://github.com/Uniswap/routing-api/blob/fe410751985995cb2904837e24f22da7dca1f518/lib/util/onChainQuoteProviderConfigs.ts#L344 divide by 10
 export const ASTROCHAIN_SEPOLIA_UPPER_SWAP_GAS_LIMIT = BigNumber.from(300000)
 
 export const CHAIN_TO_GAS_LIMIT_MAP: { [chainId: number]: BigNumber } = {


### PR DESCRIPTION
### Description:  
This update addresses a minor typo in the comments for `WORLDCHAIN_UPPER_SWAP_GAS_LIMIT` and `ASTROCHAIN_SEPOLIA_UPPER_SWAP_GAS_LIMIT`. The word "divivde" has been corrected to "**divide**".  

While the typo does not affect functionality, maintaining accurate and professional documentation is essential for code clarity and developer communication. Small fixes like this contribute to a cleaner, more reliable codebase and ensure that future contributors can easily understand the context without distractions.  

No code functionality has been altered in this change.