### PR TITLE
fix: bnb and zora hardcoded gas estimate

### DIFF
--- a/lib/util/gasLimit.ts
+++ b/lib/util/gasLimit.ts
@@ -8,10 +8,16 @@ export const CELO_UPPER_SWAP_GAS_LIMIT = BigNumber.from(5000000)
 export const WORLDCHAIN_UPPER_SWAP_GAS_LIMIT = BigNumber.from(300000)
 // https://github.com/Uniswap/routing-api/blob/fe410751985995cb2904837e24f22da7dca1f518/lib/util/onChainQuoteProviderConfigs.ts#L344 divivde by 10
 export const ASTROCHAIN_SEPOLIA_UPPER_SWAP_GAS_LIMIT = BigNumber.from(300000)
+// https://github.com/Uniswap/smart-order-router/blob/c77d04d334cc1c6694bd74d88287cc5b6e3a7425/src/util/onchainQuoteProviderConfigs.ts#L83 divide by 10
+export const BNB_UPPER_SWAP_GAS_LIMIT = BigNumber.from(200000)
+// https://github.com/Uniswap/smart-order-router/blob/c77d04d334cc1c6694bd74d88287cc5b6e3a7425/src/util/onchainQuoteProviderConfigs.ts#L83 divide by 10
+export const ZORA_UPPER_SWAP_GAS_LIMIT = BigNumber.from(200000)
 
 export const CHAIN_TO_GAS_LIMIT_MAP: { [chainId: number]: BigNumber } = {
   [ChainId.ZKSYNC]: ZKSYNC_UPPER_SWAP_GAS_LIMIT,
   [ChainId.CELO]: CELO_UPPER_SWAP_GAS_LIMIT,
   [ChainId.CELO_ALFAJORES]: CELO_UPPER_SWAP_GAS_LIMIT,
   [ChainId.ASTROCHAIN_SEPOLIA]: ASTROCHAIN_SEPOLIA_UPPER_SWAP_GAS_LIMIT,
+  [ChainId.BNB]: BNB_UPPER_SWAP_GAS_LIMIT,
+  [ChainId.ZORA]: ZORA_UPPER_SWAP_GAS_LIMIT,
 }


### PR DESCRIPTION
forgot to hardcode the gas estimate for BNB and ZORA, when I move both to tenderly not supported chains in https://github.com/Uniswap/smart-order-router/pull/782