### PR TITLE
chore: bump sor to 4.9.1 - fix: arb tenderly node endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.14.0",
         "@uniswap/sdk-core": "^5.9.0",
-        "@uniswap/smart-order-router": "4.9.0",
+        "@uniswap/smart-order-router": "4.9.1",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^4.6.1",
         "@uniswap/v2-sdk": "^4.6.1",
@@ -4508,9 +4508,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.9.0.tgz",
-      "integrity": "sha512-todAPEom+30luGA0Xxt+zOey36iCEWbls8pu487h/Ltzg5F57DH0dTsdOus+HCXIvUvnb1En8Ed5SESug86ylg==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.9.1.tgz",
+      "integrity": "sha512-S4lU+THbOdIZMZht9ykyuBNCYHdL2LXtfCiVxOC6znRxpaGHSiY/CWM60bWxNcT8GgJVZaeC3yEqz5tnjZIvzw==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -27959,9 +27959,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.9.0.tgz",
-      "integrity": "sha512-todAPEom+30luGA0Xxt+zOey36iCEWbls8pu487h/Ltzg5F57DH0dTsdOus+HCXIvUvnb1En8Ed5SESug86ylg==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.9.1.tgz",
+      "integrity": "sha512-S4lU+THbOdIZMZht9ykyuBNCYHdL2LXtfCiVxOC6znRxpaGHSiY/CWM60bWxNcT8GgJVZaeC3yEqz5tnjZIvzw==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@uniswap/permit2-sdk": "^1.3.0",
     "@uniswap/router-sdk": "^1.14.0",
     "@uniswap/sdk-core": "^5.9.0",
-    "@uniswap/smart-order-router": "4.9.0",
+    "@uniswap/smart-order-router": "4.9.1",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^4.6.1",
     "@uniswap/v2-sdk": "^4.6.1",


### PR DESCRIPTION
Release https://github.com/Uniswap/smart-order-router/pull/783