### PR TITLE
Fix Comment Mismatch Update cache-config.ts

### DIFF
--- a/lib/cron/cache-config.ts
+++ b/lib/cron/cache-config.ts
@@ -78,7 +78,7 @@ export const v3TrackedEthThreshold = 0.01 // Pools need at least 0.01 of tracked
 const v3UntrackedUsdThreshold = 25000 // Pools need at least 25K USD (untracked) to be selected (for metrics only)
 
 export const v2TrackedEthThreshold = 0.025 // Pairs need at least 0.025 of trackedEth to be selected
-const v2UntrackedUsdThreshold = Number.MAX_VALUE // Pairs need at least 1K USD (untracked) to be selected (for metrics only)
+const v2UntrackedUsdThreshold = Number.MAX_VALUE // Pairs are effectively excluded due to an untracked USD threshold of Number.MAX_VALUE
 
 export const chainProtocols = [
   // V3.


### PR DESCRIPTION
In the code, there was a mismatch between the comment and the actual value used for the `v2UntrackedUsdThreshold`. The comment stated:

```javascript
// Pairs need at least 1K USD (untracked) to be selected (for metrics only)
```

However, the value assigned to `v2UntrackedUsdThreshold` is:

```javascript
const v2UntrackedUsdThreshold = Number.MAX_VALUE
```

This discrepancy creates confusion, as `Number.MAX_VALUE` is effectively an extremely large value, not 1K USD. To resolve this and accurately reflect the code's behavior, the comment has been updated to:

```javascript
// Pairs are effectively excluded due to an untracked USD threshold of Number.MAX_VALUE
```

This update aligns the comment with the actual functionality and makes the code clearer.