### PR TITLE
chore: bump sor to 4.10.1 - fix: ID_TO_NETWORK_NAME add unichain and monad testnet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.14.0",
         "@uniswap/sdk-core": "^6.1.1",
-        "@uniswap/smart-order-router": "4.10.0",
+        "@uniswap/smart-order-router": "4.10.1",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^4.8.0",
         "@uniswap/v2-sdk": "^4.6.1",
@@ -4508,9 +4508,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.10.0.tgz",
-      "integrity": "sha512-a9pZKEA5GOAdczB5ba8y381005eNZtDwyGzVPfZM2rvOpEsfLD9/M9olOeI+BxzHYeIrwxjv2sUL47jbg2YqWg==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.10.1.tgz",
+      "integrity": "sha512-reDRrdCufABJzgy4o9SXFg2Hfn2IehQAjbXAk/vF2ZzrDOQ9vJEzOfR4bqlm3Xao4nZbSMvz6QQzOxtrkQd4QA==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -27941,9 +27941,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.10.0.tgz",
-      "integrity": "sha512-a9pZKEA5GOAdczB5ba8y381005eNZtDwyGzVPfZM2rvOpEsfLD9/M9olOeI+BxzHYeIrwxjv2sUL47jbg2YqWg==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.10.1.tgz",
+      "integrity": "sha512-reDRrdCufABJzgy4o9SXFg2Hfn2IehQAjbXAk/vF2ZzrDOQ9vJEzOfR4bqlm3Xao4nZbSMvz6QQzOxtrkQd4QA==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@uniswap/permit2-sdk": "^1.3.0",
     "@uniswap/router-sdk": "^1.14.0",
     "@uniswap/sdk-core": "^6.1.1",
-    "@uniswap/smart-order-router": "4.10.0",
+    "@uniswap/smart-order-router": "4.10.1",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^4.8.0",
     "@uniswap/v2-sdk": "^4.6.1",


### PR DESCRIPTION
release https://github.com/Uniswap/smart-order-router/pull/790