### PR TITLE
chore(unirpc): Base traffic 50% -> 75%

### DIFF
--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -68,7 +68,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0,
     "healthCheckSampleProb": 0,
-    "providerInitialWeights": [0.5, 0.5],
+    "providerInitialWeights": [0.25, 0.75],
     "providerUrls": ["QUICKNODE_8453", "UNIRPC_0"],
     "providerNames": ["QUICKNODE", "UNIRPC"]
   },


### PR DESCRIPTION
Attempting to increase traffic again for Base on unirpc (after eips increase on backend).
Going from 50% to 75%