### PR TITLE
chore(unirpc): Base traffic 75% -> 100%

### DIFF
--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -68,7 +68,7 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0,
     "healthCheckSampleProb": 0,
-    "providerInitialWeights": [0.25, 0.75],
+    "providerInitialWeights": [0, 1],
     "providerUrls": ["QUICKNODE_8453", "UNIRPC_0"],
     "providerNames": ["QUICKNODE", "UNIRPC"]
   },


### PR DESCRIPTION
Attempting to increase traffic again for Base on unirpc (after eips increase on backend + move to dedicated cluster).
Going from 75% to 100% and will monitor