### PR TITLE
chore: bump sor to 4.14.1 - add bytes32 non-null terminator logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.18.0",
         "@uniswap/sdk-core": "^7.1.0",
-        "@uniswap/smart-order-router": "4.14.0",
+        "@uniswap/smart-order-router": "4.14.1",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^4.10.0",
         "@uniswap/v2-sdk": "^4.9.0",
@@ -4508,9 +4508,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.14.0.tgz",
-      "integrity": "sha512-qd1ZHcYbbx6Qyqb9XV6AXsx/LIZtMCoN7hmFMBAY8t0lpvv/X3VIrPiZAR1BdxlYpj91HqsvnuaeuPiMlW4sJg==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.14.1.tgz",
+      "integrity": "sha512-neYcP6C5s2FZi6yNnCOK7RkfMW37j6zo/qxwq2A2/B/i8q6M9THOBlLos5OB1LtpV1bwCU1ob/TZadfJtqJfzQ==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -27936,9 +27936,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.14.0.tgz",
-      "integrity": "sha512-qd1ZHcYbbx6Qyqb9XV6AXsx/LIZtMCoN7hmFMBAY8t0lpvv/X3VIrPiZAR1BdxlYpj91HqsvnuaeuPiMlW4sJg==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.14.1.tgz",
+      "integrity": "sha512-neYcP6C5s2FZi6yNnCOK7RkfMW37j6zo/qxwq2A2/B/i8q6M9THOBlLos5OB1LtpV1bwCU1ob/TZadfJtqJfzQ==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@uniswap/permit2-sdk": "^1.3.0",
     "@uniswap/router-sdk": "^1.18.0",
     "@uniswap/sdk-core": "^7.1.0",
-    "@uniswap/smart-order-router": "4.14.0",
+    "@uniswap/smart-order-router": "4.14.1",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^4.10.0",
     "@uniswap/v2-sdk": "^4.9.0",


### PR DESCRIPTION
release https://github.com/Uniswap/smart-order-router/pull/798