### PR TITLE
fix: bump sor to 4.14.3 - fix: tenderly doesn't support monad testnet

### DIFF
--- a/lib/util/gasLimit.ts
+++ b/lib/util/gasLimit.ts
@@ -12,6 +12,7 @@ export const UNICHAIN_SEPOLIA_UPPER_SWAP_GAS_LIMIT = BigNumber.from(300000)
 export const BNB_UPPER_SWAP_GAS_LIMIT = BigNumber.from(200000)
 // https://github.com/Uniswap/smart-order-router/blob/c77d04d334cc1c6694bd74d88287cc5b6e3a7425/src/util/onchainQuoteProviderConfigs.ts#L83 divide by 10
 export const ZORA_UPPER_SWAP_GAS_LIMIT = BigNumber.from(200000)
+export const MONAD_UPPER_SWAP_GAS_LIMIT = BigNumber.from(4000000)
 
 export const CHAIN_TO_GAS_LIMIT_MAP: { [chainId: number]: BigNumber } = {
   [ChainId.ZKSYNC]: ZKSYNC_UPPER_SWAP_GAS_LIMIT,
@@ -20,4 +21,5 @@ export const CHAIN_TO_GAS_LIMIT_MAP: { [chainId: number]: BigNumber } = {
   [ChainId.UNICHAIN_SEPOLIA]: UNICHAIN_SEPOLIA_UPPER_SWAP_GAS_LIMIT,
   [ChainId.BNB]: BNB_UPPER_SWAP_GAS_LIMIT,
   [ChainId.ZORA]: ZORA_UPPER_SWAP_GAS_LIMIT,
+  [ChainId.MONAD_TESTNET]: MONAD_UPPER_SWAP_GAS_LIMIT,
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.18.0",
         "@uniswap/sdk-core": "^7.1.0",
-        "@uniswap/smart-order-router": "4.14.2",
+        "@uniswap/smart-order-router": "4.14.3",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^4.10.0",
         "@uniswap/v2-sdk": "^4.9.0",
@@ -4508,9 +4508,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.14.2.tgz",
-      "integrity": "sha512-agBoMI965W810wHwLF4GqaE9ZCBi+dR6sny3TVkhGM26UtetM40aXl6hSLbmYcGfjodEAKj/wyFHbg4Lf3Kgaw==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.14.3.tgz",
+      "integrity": "sha512-vE0B1zZh3y1VhMqLYGwrle0WEBaeBvFGz0AGbBzunAzn08GrBDZ9T2LJ6KktwtZ6Lebta1OL0Pcm2q9ApMgYHA==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -27936,9 +27936,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.14.2.tgz",
-      "integrity": "sha512-agBoMI965W810wHwLF4GqaE9ZCBi+dR6sny3TVkhGM26UtetM40aXl6hSLbmYcGfjodEAKj/wyFHbg4Lf3Kgaw==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.14.3.tgz",
+      "integrity": "sha512-vE0B1zZh3y1VhMqLYGwrle0WEBaeBvFGz0AGbBzunAzn08GrBDZ9T2LJ6KktwtZ6Lebta1OL0Pcm2q9ApMgYHA==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@uniswap/permit2-sdk": "^1.3.0",
     "@uniswap/router-sdk": "^1.18.0",
     "@uniswap/sdk-core": "^7.1.0",
-    "@uniswap/smart-order-router": "4.14.2",
+    "@uniswap/smart-order-router": "4.14.3",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^4.10.0",
     "@uniswap/v2-sdk": "^4.9.0",

--- a/test/jest/unit/handlers/util/estimateGasUsed.test.ts
+++ b/test/jest/unit/handlers/util/estimateGasUsed.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect } from '@jest/globals'
 import { ChainId } from '@uniswap/sdk-core'
 import { adhocCorrectGasUsed } from '../../../../../lib/util/estimateGasUsed'
 import { BigNumber } from '@ethersproject/bignumber'
-import { CELO_UPPER_SWAP_GAS_LIMIT, ZKSYNC_UPPER_SWAP_GAS_LIMIT } from '../../../../../lib/util/gasLimit'
+import {
+  CELO_UPPER_SWAP_GAS_LIMIT,
+  MONAD_UPPER_SWAP_GAS_LIMIT,
+  ZKSYNC_UPPER_SWAP_GAS_LIMIT,
+} from '../../../../../lib/util/gasLimit'
 
 describe('estimateGasUsed', () => {
   it('returns normal gas for mainnet', () => {
@@ -48,5 +52,10 @@ describe('estimateGasUsed', () => {
   it('returns normal gas for celo on extension', () => {
     const estimatedGasUsed = CELO_UPPER_SWAP_GAS_LIMIT.add(1)
     expect(adhocCorrectGasUsed(estimatedGasUsed, ChainId.CELO)).toBe(estimatedGasUsed)
+  })
+
+  it('returns upper limit gas for monad', () => {
+    const estimatedGasUsed = MONAD_UPPER_SWAP_GAS_LIMIT.sub(1)
+    expect(adhocCorrectGasUsed(estimatedGasUsed, ChainId.MONAD_TESTNET)).toBe(MONAD_UPPER_SWAP_GAS_LIMIT)
   })
 })


### PR DESCRIPTION
reelase https://github.com/Uniswap/smart-order-router/pull/800