### PR TITLE
fix: Environmental variable ALCHEMY_1301 isn't defined

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -242,6 +242,7 @@ export class RoutingAPIPipeline extends Stack {
       'QUICKNODE_480',
       // Unichain Sepolia,
       'QUICKNODE_1301',
+      'ALCHEMY_1301',
       // unirpc - serves all chains
       'UNIRPC_0',
     ]
@@ -418,6 +419,7 @@ const jsonRpcProviders = {
   QUICKNODE_480: process.env.QUICKNODE_480!,
   // Unichain Sepolia,
   QUICKNODE_1301: process.env.QUICKNODE_1301!,
+  ALCHEMY_1301: process.env.ALCHEMY_1301!,
   // unirpc - serves all chains
   UNIRPC_0: process.env.UNIRPC_0!,
 }


### PR DESCRIPTION
>Error: Environmental variable ALCHEMY_1301 isn't defined!
    at Function.validateProdConfig (/lib/rpc/GlobalRpcProviders.ts:36:17)
    at Function.getGlobalUniRpcProviders (/lib/rpc/GlobalRpcProviders.ts:132:43)
    at <anonymous> (/lib/handlers/injector-sor.ts:200:35)
    at h (/node_modules/lodash/lodash.js:653:23)
    at Function.mC (/node_modules/lodash/lodash.js:9622:14)
    at oie.buildContainerInjected (/lib/handlers/injector-sor.ts:198:11)
    at oie.build (/lib/handlers/handler.ts:51:41)
    at Object.<anonymous> (/lib/handlers/index.ts:13:74)
    at Module._compile (node:internal/modules/cjs/loader:1364:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1422:10)
