### PR TITLE
fix: bump sor to 4.16.1 - fix: add stateview and v4 quoter addresses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.20.0",
         "@uniswap/sdk-core": "^7.3.0",
-        "@uniswap/smart-order-router": "4.16.0",
+        "@uniswap/smart-order-router": "4.16.1",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^4.13.0",
         "@uniswap/v2-sdk": "^4.11.0",
@@ -4508,9 +4508,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.16.0.tgz",
-      "integrity": "sha512-jIvzbIO5iki3uK1bU6r2sDzqYa4X4KTdAzNitBZzoM0+lKeUcQ1lo92l1qApYllYX182IAGW8IeXEoBXW6/Tzw==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.16.1.tgz",
+      "integrity": "sha512-NyuVEjsNULde1MA0qAHf5+qcG7mpkr05iV5DYL24rp8gauwU/4bayUYDCI0TVi9nFLmnKQ5NPUS8xAEsN4Vu0w==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -27936,9 +27936,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.16.0.tgz",
-      "integrity": "sha512-jIvzbIO5iki3uK1bU6r2sDzqYa4X4KTdAzNitBZzoM0+lKeUcQ1lo92l1qApYllYX182IAGW8IeXEoBXW6/Tzw==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.16.1.tgz",
+      "integrity": "sha512-NyuVEjsNULde1MA0qAHf5+qcG7mpkr05iV5DYL24rp8gauwU/4bayUYDCI0TVi9nFLmnKQ5NPUS8xAEsN4Vu0w==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@uniswap/permit2-sdk": "^1.3.0",
     "@uniswap/router-sdk": "^1.20.0",
     "@uniswap/sdk-core": "^7.3.0",
-    "@uniswap/smart-order-router": "4.16.0",
+    "@uniswap/smart-order-router": "4.16.1",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^4.13.0",
     "@uniswap/v2-sdk": "^4.11.0",


### PR DESCRIPTION
Release https://github.com/Uniswap/smart-order-router/pull/803