### PR TITLE
fix: enable v4 for arb base polygon bnb op avax world

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -514,7 +514,16 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
             ChainId.MONAD_TESTNET,
           ]
 
-          const v4Supported = [ChainId.SEPOLIA]
+          const v4Supported = [
+            ChainId.SEPOLIA,
+            ChainId.ARBITRUM_ONE,
+            ChainId.BASE,
+            ChainId.POLYGON,
+            ChainId.BNB,
+            ChainId.OPTIMISM,
+            ChainId.AVALANCHE,
+            ChainId.WORLDCHAIN,
+          ]
 
           const mixedSupported = [ChainId.MAINNET, ChainId.SEPOLIA, ChainId.GOERLI]
 


### PR DESCRIPTION
forgot to enable v4 for arb base polygon bnb op avax world.

Now I can see base quote on my local - https://app.warp.dev/block/kWwQmnuWlGeTCZWXFgK3iB