### PR TITLE
fix(cache): bump sor-4.17.4 - cache skip when not all protocols provided

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.21.0",
         "@uniswap/sdk-core": "^7.5.0",
-        "@uniswap/smart-order-router": "4.17.3",
+        "@uniswap/smart-order-router": "4.17.4",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^4.14.0",
         "@uniswap/v2-sdk": "^4.13.0",
@@ -4508,9 +4508,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "4.17.3",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.17.3.tgz",
-      "integrity": "sha512-f+Y8RA04vAWxaA2Dkg1EYvbPlp+51b2n9PVsqF/g3zvhSGCYjWpEQgI6UrNj8Icvbig276MHneBbJzQFTu1CaA==",
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.17.4.tgz",
+      "integrity": "sha512-fcaNgkPJP5FpFN17wbQd9TZr3oePgea6+vhB6H+rceFp7d+tv91FtOA3Bm+xYP5AijFbvELrWvKkNksHqeYcfw==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -27936,9 +27936,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "4.17.3",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.17.3.tgz",
-      "integrity": "sha512-f+Y8RA04vAWxaA2Dkg1EYvbPlp+51b2n9PVsqF/g3zvhSGCYjWpEQgI6UrNj8Icvbig276MHneBbJzQFTu1CaA==",
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.17.4.tgz",
+      "integrity": "sha512-fcaNgkPJP5FpFN17wbQd9TZr3oePgea6+vhB6H+rceFp7d+tv91FtOA3Bm+xYP5AijFbvELrWvKkNksHqeYcfw==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@uniswap/permit2-sdk": "^1.3.0",
     "@uniswap/router-sdk": "^1.21.0",
     "@uniswap/sdk-core": "^7.5.0",
-    "@uniswap/smart-order-router": "4.17.3",
+    "@uniswap/smart-order-router": "4.17.4",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^4.14.0",
     "@uniswap/v2-sdk": "^4.13.0",


### PR DESCRIPTION
Release https://github.com/Uniswap/smart-order-router/pull/809