### PR TITLE
chore: bump sor-4.17.6 - fix: don't explore split routes with native&wrappedNative

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.21.0",
         "@uniswap/sdk-core": "^7.5.0",
-        "@uniswap/smart-order-router": "4.17.5",
+        "@uniswap/smart-order-router": "4.17.6",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^4.14.0",
         "@uniswap/v2-sdk": "^4.13.0",
@@ -4508,9 +4508,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "4.17.5",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.17.5.tgz",
-      "integrity": "sha512-5agza5Hk+A8pqBz3GYVtpzD287XX2AHIcV2dy4Awe44M4ROxUvjgiZlMQwVYK1ZHM4bxK9jwWgUQg3dC5UKJJw==",
+      "version": "4.17.6",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.17.6.tgz",
+      "integrity": "sha512-GLvj2Qv8tEF99LghrAFs7r5DOjAM0CNYEMAanErIIBptyoIa8QjiN5n83Jqo1VWNiYnQO7tekxvYuHIwvts1iw==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -27936,9 +27936,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "4.17.5",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.17.5.tgz",
-      "integrity": "sha512-5agza5Hk+A8pqBz3GYVtpzD287XX2AHIcV2dy4Awe44M4ROxUvjgiZlMQwVYK1ZHM4bxK9jwWgUQg3dC5UKJJw==",
+      "version": "4.17.6",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.17.6.tgz",
+      "integrity": "sha512-GLvj2Qv8tEF99LghrAFs7r5DOjAM0CNYEMAanErIIBptyoIa8QjiN5n83Jqo1VWNiYnQO7tekxvYuHIwvts1iw==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@uniswap/permit2-sdk": "^1.3.0",
     "@uniswap/router-sdk": "^1.21.0",
     "@uniswap/sdk-core": "^7.5.0",
-    "@uniswap/smart-order-router": "4.17.5",
+    "@uniswap/smart-order-router": "4.17.6",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^4.14.0",
     "@uniswap/v2-sdk": "^4.13.0",


### PR DESCRIPTION
Release https://github.com/Uniswap/smart-order-router/pull/812


E2E pass on personal aws

<img width="333" alt="image" src="https://github.com/user-attachments/assets/89a1acd3-3389-46a6-908a-1c959b2ad89b" />
