### PR TITLE
feat: manually allowlist flaunch hooks

### DIFF
--- a/lib/util/hooksAddressesAllowlist.ts
+++ b/lib/util/hooksAddressesAllowlist.ts
@@ -2,6 +2,7 @@ import { ChainId } from '@uniswap/sdk-core'
 import { ADDRESS_ZERO } from '@uniswap/router-sdk'
 
 export const extraHooksAddressesOnSepolia = '0x0000000000000000000000000000000000000020'
+export const FLAUNCH_HOOKS_ADDRESS_ON_BASE = '0x51Bba15255406Cfe7099a42183302640ba7dAFDC'
 
 // we do not allow v4 pools with non-zero hook address to be routed through in the initial v4 launch.
 // this is the ultimate safeguard in the routing subgraph pool cron job.
@@ -25,7 +26,7 @@ export const HOOKS_ADDRESSES_ALLOWLIST: { [chain in ChainId]: Array<string> } = 
   [ChainId.AVALANCHE]: [ADDRESS_ZERO],
   [ChainId.BASE_GOERLI]: [ADDRESS_ZERO],
   [ChainId.BASE_SEPOLIA]: [ADDRESS_ZERO],
-  [ChainId.BASE]: [ADDRESS_ZERO],
+  [ChainId.BASE]: [ADDRESS_ZERO, FLAUNCH_HOOKS_ADDRESS_ON_BASE],
   [ChainId.ZORA]: [ADDRESS_ZERO],
   [ChainId.ZORA_SEPOLIA]: [ADDRESS_ZERO],
   [ChainId.ROOTSTOCK]: [ADDRESS_ZERO],

--- a/test/jest/unit/handlers/util/v4HooksPoolsFiltering.test.ts
+++ b/test/jest/unit/handlers/util/v4HooksPoolsFiltering.test.ts
@@ -1,8 +1,32 @@
 import { describe, expect } from '@jest/globals'
 import { v4HooksPoolsFiltering } from '../../../../../lib/util/v4HooksPoolsFiltering'
 import { V4SubgraphPool } from '@uniswap/smart-order-router'
+import { ChainId } from '@uniswap/sdk-core'
 
 describe('v4HooksPoolsFiltering', () => {
+  it('flaunch hooks included', () => {
+    const flaunchHookAddress = '0x51Bba15255406Cfe7099a42183302640ba7dAFDC'
+    const v4Pools: Array<V4SubgraphPool> = [
+      {
+        id: '0',
+        feeTier: '0',
+        tickSpacing: '0',
+        hooks: flaunchHookAddress,
+        liquidity: '0',
+        token0: {
+          id: '0',
+        },
+        token1: {
+          id: '0',
+        },
+        tvlETH: 0,
+        tvlUSD: 0,
+      },
+    ]
+
+    expect(v4HooksPoolsFiltering(ChainId.BASE, v4Pools)).toEqual(v4Pools)
+  })
+
   it('before swap hooks pool is filtered out', () => {
     const beforeSwapHookAddress = '0x0000000000000000000000000000000000000080'
     const v4Pools: Array<V4SubgraphPool> = [


### PR DESCRIPTION
flaunch hooks manually audited internally. we can manually allowlist non-upgradable hooks for beforeSwaps and afterSwaps, if it gains traction