### PR TITLE
chore: bump sor 4.17.11 - enable unichain support for mixed routes

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -532,7 +532,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
             ChainId.MAINNET,
           ]
 
-          const mixedSupported = [ChainId.MAINNET, ChainId.SEPOLIA, ChainId.GOERLI, ChainId.BASE]
+          const mixedSupported = [ChainId.MAINNET, ChainId.SEPOLIA, ChainId.GOERLI, ChainId.BASE, ChainId.UNICHAIN]
 
           const cachedRoutesCacheInvalidationFixRolloutPercentage = NEW_CACHED_ROUTES_ROLLOUT_PERCENT[chainId]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.22.1",
         "@uniswap/sdk-core": "^7.5.0",
-        "@uniswap/smart-order-router": "4.17.10",
+        "@uniswap/smart-order-router": "4.17.11",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^4.17.0",
         "@uniswap/v2-sdk": "^4.13.0",
@@ -4508,9 +4508,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.17.10.tgz",
-      "integrity": "sha512-5X6r6lFGzjFFWuCBIBHTOv+qv9XnuWy4BEKuh/LSbPFj3OZkJ//6WbbqCjXyN30pF08UiqUcjClRGCA2RUtEiA==",
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.17.11.tgz",
+      "integrity": "sha512-l4J4wap6w8+qmaPph0H/lZbEpxJ4OlJ2/FUCfk7gV5I7uZ5gyKMoQ7HwVIRZrRfoMWCzyijFVCwQIESG9UCkYg==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -27936,9 +27936,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.17.10.tgz",
-      "integrity": "sha512-5X6r6lFGzjFFWuCBIBHTOv+qv9XnuWy4BEKuh/LSbPFj3OZkJ//6WbbqCjXyN30pF08UiqUcjClRGCA2RUtEiA==",
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.17.11.tgz",
+      "integrity": "sha512-l4J4wap6w8+qmaPph0H/lZbEpxJ4OlJ2/FUCfk7gV5I7uZ5gyKMoQ7HwVIRZrRfoMWCzyijFVCwQIESG9UCkYg==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@uniswap/permit2-sdk": "^1.3.0",
     "@uniswap/router-sdk": "^1.22.1",
     "@uniswap/sdk-core": "^7.5.0",
-    "@uniswap/smart-order-router": "4.17.10",
+    "@uniswap/smart-order-router": "4.17.11",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^4.17.0",
     "@uniswap/v2-sdk": "^4.13.0",


### PR DESCRIPTION
Release https://github.com/Uniswap/smart-order-router/pull/822
