### PR TITLE
fix: bump SOR to 4.18.0 - fix: properly use global cache + mixed routes fix

### DIFF
--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -287,6 +287,12 @@ export class QuoteHandler extends APIGLambdaHandler<
         errorCode: 'INVALID_PROTOCOL',
         detail: `Invalid protocol specified. Supported protocols: ${JSON.stringify(Object.values(Protocol))}`,
       }
+    } else if (protocols.length === 1 && protocols[0] === Protocol.MIXED) {
+      return {
+        statusCode: 400,
+        errorCode: 'INVALID_PROTOCOL',
+        detail: `Mixed protocol cannot be specified explicitly`,
+      }
     }
 
     // Parse user provided token address/symbol to Currency object.

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.22.1",
         "@uniswap/sdk-core": "^7.5.0",
-        "@uniswap/smart-order-router": "4.17.14",
+        "@uniswap/smart-order-router": "file:/tmp/uniswap-smart-order-router-4.18.0-tmp1.tgz",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^4.17.0",
         "@uniswap/v2-sdk": "^4.13.0",
@@ -4508,9 +4508,10 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.17.14.tgz",
-      "integrity": "sha512-l5ieH7OsfFFa4kd/InRjTWESk78qaJizA6jGZnAYeQZFItxpsy4lPFPhRkPooyoZUmCIbnH4cEodKa45N6bKjw==",
+      "version": "4.18.0",
+      "resolved": "file:../../../../../tmp/uniswap-smart-order-router-4.18.0-tmp1.tgz",
+      "integrity": "sha512-3bw4lhVSWwiwegmTLPGnHFY7T20TyEXsD7GBAQTVz0jV2rjL7zcSCJ7Ei+Gj5KBQAAcrSmBm6yb/2fyweCok3g==",
+      "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -27936,9 +27937,8 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.17.14.tgz",
-      "integrity": "sha512-l5ieH7OsfFFa4kd/InRjTWESk78qaJizA6jGZnAYeQZFItxpsy4lPFPhRkPooyoZUmCIbnH4cEodKa45N6bKjw==",
+      "version": "file:/tmp/uniswap-smart-order-router-4.18.0-tmp1.tgz",
+      "integrity": "sha512-3bw4lhVSWwiwegmTLPGnHFY7T20TyEXsD7GBAQTVz0jV2rjL7zcSCJ7Ei+Gj5KBQAAcrSmBm6yb/2fyweCok3g==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@uniswap/permit2-sdk": "^1.3.0",
     "@uniswap/router-sdk": "^1.22.1",
     "@uniswap/sdk-core": "^7.5.0",
-    "@uniswap/smart-order-router": "4.17.14",
+    "@uniswap/smart-order-router": "file:/tmp/uniswap-smart-order-router-4.18.0-tmp1.tgz",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^4.17.0",
     "@uniswap/v2-sdk": "^4.13.0",

--- a/test/mocha/e2e/quote.test.ts
+++ b/test/mocha/e2e/quote.test.ts
@@ -453,13 +453,13 @@ describe('quote', function () {
               slippageTolerance: SLIPPAGE,
               deadline: '360',
               algorithm,
-              protocols: ALL_PROTOCOLS,
+              protocols: "v2,v3,mixed",
             }
 
             const queryParams = qs.stringify(quoteReq)
 
             const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(`${API}?${queryParams}`, {
-              headers: HEADERS_2_0,
+              headers: HEADERS_1_2,
             })
             const {
               data: { quote, quoteDecimals, quoteGasAdjustedDecimals, methodParameters },
@@ -1376,10 +1376,14 @@ describe('quote', function () {
 
               expect(methodParameters).to.not.be.undefined
 
+              let hasV4Pool = false
               let hasV3Pool = false
               let hasV2Pool = false
               for (const r of route) {
                 for (const pool of r) {
+                  if (pool.type == 'v4-pool') {
+                    hasV4Pool = true
+                  }
                   if (pool.type == 'v3-pool') {
                     hasV3Pool = true
                   }
@@ -1389,7 +1393,7 @@ describe('quote', function () {
                 }
               }
 
-              expect(hasV3Pool && hasV2Pool).to.be.true
+              expect((hasV3Pool && hasV2Pool) || (hasV4Pool && hasV2Pool) || (hasV4Pool && hasV3Pool)).to.be.true
 
               const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
                 response.data.methodParameters!,
@@ -1491,7 +1495,7 @@ describe('quote', function () {
                   deadline: '360',
                   algorithm: 'alpha',
                   forceMixedRoutes: true,
-                  protocols: 'mixed',
+                  protocols: ALL_PROTOCOLS,
                   enableUniversalRouter: true,
                 }
 
@@ -1534,7 +1538,7 @@ describe('quote', function () {
                   deadline: '360',
                   algorithm: 'alpha',
                   forceMixedRoutes: true,
-                  protocols: 'mixed',
+                  protocols: ALL_PROTOCOLS,
                   enableUniversalRouter: true,
                 }
 
@@ -1630,7 +1634,7 @@ describe('quote', function () {
                         tokenOutChainId: tokenOut.chainId,
                         amount: amount,
                         type: type,
-                        protocols: 'v2,v3,mixed',
+                        protocols: ALL_PROTOCOLS,
                         // TODO: ROUTE-86 remove enableFeeOnTransferFeeFetching once we are ready to enable this by default
                         enableFeeOnTransferFeeFetching: enableFeeOnTransferFeeFetching,
                         recipient: alice.address,
@@ -1883,13 +1887,13 @@ describe('quote', function () {
                 deadline: '360',
                 algorithm,
                 simulateFromAddress: '0xf584f8728b874a6a5c7a8d4d387c9aae9172d621',
-                protocols: ALL_PROTOCOLS,
+                protocols: "v2,v3,mixed",
               }
 
               const queryParams = qs.stringify(quoteReq)
 
               const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(`${API}?${queryParams}`, {
-                headers: HEADERS_2_0,
+                headers: HEADERS_1_2,
               })
               const {
                 data: { quote, quoteDecimals, quoteGasAdjustedDecimals, methodParameters, simulationError },
@@ -2393,7 +2397,7 @@ describe('quote', function () {
                     tokenOutChainId: tokenOut.chainId,
                     amount: amount,
                     type: type,
-                    protocols: 'v2,v3,mixed',
+                    protocols: ALL_PROTOCOLS,
                     recipient: alice.address,
                     slippageTolerance: SLIPPAGE,
                     deadline: '360',


### PR DESCRIPTION
Changes
- Release https://github.com/Uniswap/smart-order-router/pull/820
- update all e2e tests to match new cache/mixed logic
- passing `protocols=mixed` is now invalid and will return `400, INVALID_PROTOCOL`

Tested e2e tests against personal aws account
` 235 passing (9m)`