### PR TITLE
chore: include cache misses e2e tests

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -330,7 +330,7 @@ export class RoutingAPIPipeline extends Stack {
       projectName: `IntegTests-${routingAPIStage.stageName}`,
       input: sourceArtifact,
       envFromCfnOutputs: {
-        UNISWAP_ROUTING_API: routingAPIStage.url,
+        UNISWAP_ROUTING_API: routingAPIStage.url
       },
       buildEnvironment: {
         environmentVariables: {
@@ -342,12 +342,17 @@ export class RoutingAPIPipeline extends Stack {
             value: 'archive-node-rpc-url-default-kms',
             type: BuildEnvironmentVariableType.SECRETS_MANAGER,
           },
+          UNICORN_SECRETS: {
+            value: 'debug-config-unicornsecrets',
+            type: BuildEnvironmentVariableType.SECRETS_MANAGER,
+          }
         },
       },
       commands: [
         'echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc && npm ci',
         'echo "UNISWAP_ROUTING_API=${UNISWAP_ROUTING_API}" > .env',
         'echo "ARCHIVE_NODE_RPC=${ARCHIVE_NODE_RPC}" >> .env',
+        'echo "UNICORN_SECRET=${UNICORN_SECRETS}" >> .env',
         'npm install',
         'npm run build',
         'set NODE_OPTIONS=--max-old-space-size=4096 && npm run test:e2e',

--- a/bin/app.ts
+++ b/bin/app.ts
@@ -330,7 +330,7 @@ export class RoutingAPIPipeline extends Stack {
       projectName: `IntegTests-${routingAPIStage.stageName}`,
       input: sourceArtifact,
       envFromCfnOutputs: {
-        UNISWAP_ROUTING_API: routingAPIStage.url
+        UNISWAP_ROUTING_API: routingAPIStage.url,
       },
       buildEnvironment: {
         environmentVariables: {
@@ -345,7 +345,7 @@ export class RoutingAPIPipeline extends Stack {
           UNICORN_SECRETS: {
             value: 'debug-config-unicornsecrets',
             type: BuildEnvironmentVariableType.SECRETS_MANAGER,
-          }
+          },
         },
       },
       commands: [

--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -342,8 +342,8 @@ export class QuoteHandler extends APIGLambdaHandler<
       ...(forceMixedRoutes ? { forceMixedRoutes } : {}),
       protocols,
       ...(quoteSpeed ? QUOTE_SPEED_CONFIG[quoteSpeed] : {}),
-      ...parsedDebugRoutingConfig,
       ...(intent ? INTENT_SPECIFIC_CONFIG[intent] : {}),
+      ...parsedDebugRoutingConfig,
       // Only when enableFeeOnTransferFeeFetching is explicitly set to true, then we
       // override usedCachedRoutes to false. This is to ensure that we don't use
       // accidentally override usedCachedRoutes in the normal path.

--- a/test/mocha/e2e/quote.test.ts
+++ b/test/mocha/e2e/quote.test.ts
@@ -364,15 +364,15 @@ describe('quote', function () {
   for (const algorithm of ['alpha']) {
     for (const type of TRADE_TYPES) {
       describe(`${ID_TO_NETWORK_NAME(1)} ${algorithm} ${type} 2xx`, () => {
-        const hitsCachedRoutes = [true, false]
+        describe(`+ Execute Swap`, () => {
+          for (const uraVersion of [UniversalRouterVersion.V1_2, UniversalRouterVersion.V2_0]) {
+            describe(`erc20 -> erc20 (uraVersion:${uraVersion})`, async () => {
+              const hitsCachedRoutes = [true, false]
 
-        hitsCachedRoutes.forEach((hitsCachedRoutes) => {
-          describe(`should hit cached routes ${hitsCachedRoutes}`, () => {
-            const useCachedRoutes = { useCachedRoutes: hitsCachedRoutes }
+              hitsCachedRoutes.forEach((hitsCachedRoutes) => {
+                it(`should hit cached routes ${hitsCachedRoutes}`, async () => {
+                  const useCachedRoutes = { useCachedRoutes: hitsCachedRoutes }
 
-            describe(`+ Execute Swap`, () => {
-              for (const uraVersion of [UniversalRouterVersion.V1_2, UniversalRouterVersion.V2_0]) {
-                it(`erc20 -> erc20 (uraVersion:${uraVersion})`, async () => {
                   let protocols = ALL_PROTOCOLS
                   let headers = HEADERS_2_0
                   if (uraVersion === UniversalRouterVersion.V1_2) {
@@ -453,1513 +453,7 @@ describe('quote', function () {
                   // and native for v4 pool routes
                   expect(response.data.hitsCachedRoutes).to.equal(hitsCachedRoutes)
                 })
-              }
-
-              it(`erc20 -> erc20 swaprouter02`, async () => {
-                const quoteReq: QuoteQueryParams = {
-                  tokenInAddress: 'USDC',
-                  tokenInChainId: 1,
-                  tokenOutAddress: 'USDT',
-                  tokenOutChainId: 1,
-                  amount: await getAmount(1, type, 'USDC', 'USDT', '100'),
-                  type,
-                  recipient: alice.address,
-                  slippageTolerance: SLIPPAGE,
-                  deadline: '360',
-                  algorithm,
-                  protocols: ALL_PROTOCOLS,
-                  debugRoutingConfig: JSON.stringify(useCachedRoutes),
-                  unicornSecret: unicornSecret,
-                }
-
-                const queryParams = qs.stringify(quoteReq)
-
-                const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(`${API}?${queryParams}`, {
-                  headers: HEADERS_2_0,
-                })
-                const {
-                  data: { quote, quoteDecimals, quoteGasAdjustedDecimals, methodParameters },
-                  status,
-                } = response
-
-                expect(status).to.equal(200)
-                expect(parseFloat(quoteDecimals)).to.be.greaterThan(90)
-                expect(parseFloat(quoteDecimals)).to.be.lessThan(110)
-
-                if (type == 'exactIn') {
-                  expect(parseFloat(quoteGasAdjustedDecimals)).to.be.lessThanOrEqual(parseFloat(quoteDecimals))
-                } else {
-                  expect(parseFloat(quoteGasAdjustedDecimals)).to.be.greaterThanOrEqual(parseFloat(quoteDecimals))
-                }
-
-                expect(methodParameters).to.not.be.undefined
-                expect(methodParameters?.to).to.equal(SWAP_ROUTER_02_ADDRESSES(ChainId.MAINNET))
-
-                const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
-                  methodParameters!,
-                  USDC_MAINNET,
-                  USDT_MAINNET
-                )
-
-                if (type == 'exactIn') {
-                  expect(tokenInBefore.subtract(tokenInAfter).toExact()).to.equal('100')
-                  checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(USDT_MAINNET, quote))
-                } else {
-                  expect(tokenOutAfter.subtract(tokenOutBefore).toExact()).to.equal('100')
-                  checkQuoteToken(tokenInBefore, tokenInAfter, CurrencyAmount.fromRawAmount(USDC_MAINNET, quote))
-                }
-
-                // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
-                // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
-                // if it's exactOut quote, we should always hit the cached routes.
-                // this is regardless of protocol version.
-                // the reason is because exact in quote always runs before exact out
-                // along with the native or wrapped native pool token address assertions previously
-                // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
-                // and native for v4 pool routes
-                expect(response.data.hitsCachedRoutes).to.equal(hitsCachedRoutes)
               })
-
-              it(`erc20 -> erc20 with permit`, async () => {
-                const amount = await getAmount(1, type, 'USDC', 'USDT', '10')
-
-                const nonce = nextPermitNonce()
-
-                const permit: PermitSingle = {
-                  details: {
-                    token: USDC_MAINNET.address,
-                    amount: '15000000', // For exact out we don't know the exact amount needed to permit, so just specify a large amount.
-                    expiration: Math.floor(new Date().getTime() / 1000 + 10000000).toString(),
-                    nonce,
-                  },
-                  spender: UNIVERSAL_ROUTER_ADDRESS,
-                  sigDeadline: Math.floor(new Date().getTime() / 1000 + 10000000).toString(),
-                }
-
-                const { domain, types, values } = AllowanceTransfer.getPermitData(permit, PERMIT2_ADDRESS, 1)
-
-                const signature = await alice._signTypedData(domain, types, values)
-
-                const quoteReq: QuoteQueryParams = {
-                  tokenInAddress: 'USDC',
-                  tokenInChainId: 1,
-                  tokenOutAddress: 'USDT',
-                  tokenOutChainId: 1,
-                  amount,
-                  type,
-                  recipient: alice.address,
-                  slippageTolerance: SLIPPAGE,
-                  deadline: '360',
-                  algorithm,
-                  permitSignature: signature,
-                  permitAmount: permit.details.amount.toString(),
-                  permitExpiration: permit.details.expiration.toString(),
-                  permitSigDeadline: permit.sigDeadline.toString(),
-                  permitNonce: permit.details.nonce.toString(),
-                  enableUniversalRouter: true,
-                  protocols: ALL_PROTOCOLS,
-                  debugRoutingConfig: JSON.stringify(useCachedRoutes),
-                  unicornSecret: unicornSecret,
-                }
-
-                const queryParams = qs.stringify(quoteReq)
-
-                const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(`${API}?${queryParams}`, {
-                  headers: HEADERS_2_0,
-                })
-                const {
-                  data: { quote, quoteDecimals, quoteGasAdjustedDecimals, methodParameters },
-                  status,
-                } = response
-
-                expect(status).to.equal(200)
-                expect(parseFloat(quoteDecimals)).to.be.greaterThan(9)
-                expect(parseFloat(quoteDecimals)).to.be.lessThan(11)
-
-                if (type == 'exactIn') {
-                  expect(parseFloat(quoteGasAdjustedDecimals)).to.be.lessThanOrEqual(parseFloat(quoteDecimals))
-                } else {
-                  expect(parseFloat(quoteGasAdjustedDecimals)).to.be.greaterThanOrEqual(parseFloat(quoteDecimals))
-                }
-
-                expect(methodParameters).to.not.be.undefined
-                expect(methodParameters?.to).to.equal(UNIVERSAL_ROUTER_ADDRESS)
-
-                const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
-                  methodParameters!,
-                  USDC_MAINNET,
-                  USDT_MAINNET,
-                  true
-                )
-
-                if (type == 'exactIn') {
-                  expect(tokenInBefore.subtract(tokenInAfter).toExact()).to.equal('10')
-                  checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(USDT_MAINNET, quote))
-                } else {
-                  expect(tokenOutAfter.subtract(tokenOutBefore).toExact()).to.equal('10')
-                  checkQuoteToken(tokenInBefore, tokenInAfter, CurrencyAmount.fromRawAmount(USDC_MAINNET, quote))
-                }
-
-                // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
-                // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
-                // if it's exactOut quote, we should always hit the cached routes.
-                // this is regardless of protocol version.
-                // the reason is because exact in quote always runs before exact out
-                // along with the native or wrapped native pool token address assertions previously
-                // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
-                // and native for v4 pool routes
-                expect(response.data.hitsCachedRoutes).to.equal(hitsCachedRoutes)
-              })
-
-              it(`erc20 -> eth`, async () => {
-                const quoteReq: QuoteQueryParams = {
-                  tokenInAddress: 'USDC',
-                  tokenInChainId: 1,
-                  tokenOutAddress: 'ETH',
-                  tokenOutChainId: 1,
-                  amount: await getAmount(1, type, 'USDC', 'ETH', type == 'exactIn' ? '1000000' : '10'),
-                  type,
-                  recipient: alice.address,
-                  slippageTolerance: SLIPPAGE,
-                  deadline: '360',
-                  algorithm,
-                  enableUniversalRouter: true,
-                  protocols: ALL_PROTOCOLS,
-                  debugRoutingConfig: JSON.stringify(useCachedRoutes),
-                  unicornSecret: unicornSecret,
-                }
-
-                const queryParams = qs.stringify(quoteReq)
-
-                const response = await axios.get<QuoteResponse>(`${API}?${queryParams}`, { headers: HEADERS_2_0 })
-                const {
-                  data: { quote, methodParameters },
-                  status,
-                } = response
-
-                expect(status).to.equal(200)
-                expect(methodParameters).to.not.be.undefined
-
-                const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
-                  methodParameters!,
-                  USDC_MAINNET,
-                  Ether.onChain(1)
-                )
-
-                if (type == 'exactIn') {
-                  expect(tokenInBefore.subtract(tokenInAfter).toExact()).to.equal('1000000')
-                  checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(Ether.onChain(1), quote))
-                } else {
-                  // Hard to test ETH balance due to gas costs for approval and swap. Just check tokenIn changes
-                  checkQuoteToken(tokenInBefore, tokenInAfter, CurrencyAmount.fromRawAmount(USDC_MAINNET, quote))
-                }
-
-                // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
-                // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
-                // if it's exactOut quote, we should always hit the cached routes.
-                // this is regardless of protocol version.
-                // the reason is because exact in quote always runs before exact out
-                // along with the native or wrapped native pool token address assertions previously
-                // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
-                // and native for v4 pool routes
-                expect(response.data.hitsCachedRoutes).to.equal(hitsCachedRoutes)
-              })
-
-              it(`erc20 -> eth large trade`, async () => {
-                // Trade of this size almost always results in splits.
-                const quoteReq: QuoteQueryParams = {
-                  tokenInAddress: 'USDC',
-                  tokenInChainId: 1,
-                  tokenOutAddress: 'ETH',
-                  tokenOutChainId: 1,
-                  amount:
-                    type == 'exactIn'
-                      ? await getAmount(1, type, 'USDC', 'ETH', '1000000')
-                      : await getAmount(1, type, 'USDC', 'ETH', '100'),
-                  type,
-                  recipient: alice.address,
-                  slippageTolerance: LARGE_SLIPPAGE,
-                  deadline: '360',
-                  algorithm,
-                  enableUniversalRouter: true,
-                  protocols: ALL_PROTOCOLS,
-                  debugRoutingConfig: JSON.stringify(useCachedRoutes),
-                  unicornSecret: unicornSecret,
-                }
-
-                const queryParams = qs.stringify(quoteReq)
-
-                const response = await axios.get<QuoteResponse>(`${API}?${queryParams}`, { headers: HEADERS_2_0 })
-                const { data, status } = response
-
-                expect(status).to.equal(200)
-                expect(data.methodParameters).to.not.be.undefined
-
-                expect(data.route).to.not.be.undefined
-
-                const amountInEdgesTotal = _(data.route)
-                  .flatMap((route) => route[0]!)
-                  .filter((pool) => !!pool.amountIn)
-                  .map((pool) => BigNumber.from(pool.amountIn))
-                  .reduce((cur, total) => total.add(cur), BigNumber.from(0))
-                const amountIn = BigNumber.from(data.quote)
-                expect(amountIn.eq(amountInEdgesTotal))
-
-                const amountOutEdgesTotal = _(data.route)
-                  .flatMap((route) => route[0]!)
-                  .filter((pool) => !!pool.amountOut)
-                  .map((pool) => BigNumber.from(pool.amountOut))
-                  .reduce((cur, total) => total.add(cur), BigNumber.from(0))
-                const amountOut = BigNumber.from(data.quote)
-                expect(amountOut.eq(amountOutEdgesTotal))
-
-                const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
-                  data.methodParameters!,
-                  USDC_MAINNET,
-                  Ether.onChain(1)
-                )
-
-                if (type == 'exactIn') {
-                  expect(tokenInBefore.subtract(tokenInAfter).toExact()).to.equal('1000000')
-                  checkQuoteToken(
-                    tokenOutBefore,
-                    tokenOutAfter,
-                    CurrencyAmount.fromRawAmount(Ether.onChain(1), data.quote)
-                  )
-                } else {
-                  // Hard to test ETH balance due to gas costs for approval and swap. Just check tokenIn changes
-                  checkQuoteToken(tokenInBefore, tokenInAfter, CurrencyAmount.fromRawAmount(USDC_MAINNET, data.quote))
-                }
-
-                // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
-                // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
-                // if it's exactOut quote, we should always hit the cached routes.
-                // this is regardless of protocol version.
-                // the reason is because exact in quote always runs before exact out
-                // along with the native or wrapped native pool token address assertions previously
-                // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
-                // and native for v4 pool routes
-                expect(response.data.hitsCachedRoutes).to.equal(hitsCachedRoutes)
-              })
-
-              it(`erc20 -> eth large trade with permit`, async () => {
-                const nonce = nextPermitNonce()
-
-                const amount =
-                  type == 'exactIn'
-                    ? await getAmount(1, type, 'USDC', 'ETH', '1000000')
-                    : await getAmount(1, type, 'USDC', 'ETH', '100')
-
-                const permit: PermitSingle = {
-                  details: {
-                    token: USDC_MAINNET.address,
-                    amount: '1500000000000', // For exact out we don't know the exact amount needed to permit, so just specify a large amount.
-                    expiration: Math.floor(new Date().getTime() / 1000 + 10000000).toString(),
-                    nonce,
-                  },
-                  spender: UNIVERSAL_ROUTER_ADDRESS,
-                  sigDeadline: Math.floor(new Date().getTime() / 1000 + 10000000).toString(),
-                }
-
-                const { domain, types, values } = AllowanceTransfer.getPermitData(permit, PERMIT2_ADDRESS, 1)
-
-                const signature = await alice._signTypedData(domain, types, values)
-
-                // Trade of this size almost always results in splits.
-                const quoteReq: QuoteQueryParams = {
-                  tokenInAddress: 'USDC',
-                  tokenInChainId: 1,
-                  tokenOutAddress: 'ETH',
-                  tokenOutChainId: 1,
-                  amount,
-                  type,
-                  recipient: alice.address,
-                  slippageTolerance: LARGE_SLIPPAGE,
-                  deadline: '360',
-                  algorithm,
-                  permitSignature: signature,
-                  permitAmount: permit.details.amount.toString(),
-                  permitExpiration: permit.details.expiration.toString(),
-                  permitSigDeadline: permit.sigDeadline.toString(),
-                  permitNonce: permit.details.nonce.toString(),
-                  enableUniversalRouter: true,
-                  protocols: ALL_PROTOCOLS,
-                  debugRoutingConfig: JSON.stringify(useCachedRoutes),
-                  unicornSecret: unicornSecret,
-                }
-
-                const queryParams = qs.stringify(quoteReq)
-
-                const response = await axios.get<QuoteResponse>(`${API}?${queryParams}`, { headers: HEADERS_2_0 })
-                const { data, status } = response
-
-                expect(status).to.equal(200)
-                expect(data.methodParameters).to.not.be.undefined
-                expect(data.route).to.not.be.undefined
-
-                const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
-                  data.methodParameters!,
-                  USDC_MAINNET,
-                  Ether.onChain(1),
-                  true
-                )
-
-                if (type == 'exactIn') {
-                  expect(tokenInBefore.subtract(tokenInAfter).toExact()).to.equal('1000000')
-                  checkQuoteToken(
-                    tokenOutBefore,
-                    tokenOutAfter,
-                    CurrencyAmount.fromRawAmount(Ether.onChain(1), data.quote)
-                  )
-                } else {
-                  // Hard to test ETH balance due to gas costs for approval and swap. Just check tokenIn changes
-                  checkQuoteToken(tokenInBefore, tokenInAfter, CurrencyAmount.fromRawAmount(USDC_MAINNET, data.quote))
-                }
-
-                // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
-                // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
-                // if it's exactOut quote, we should always hit the cached routes.
-                // this is regardless of protocol version.
-                // the reason is because exact in quote always runs before exact out
-                // along with the native or wrapped native pool token address assertions previously
-                // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
-                // and native for v4 pool routes
-                expect(response.data.hitsCachedRoutes).to.equal(hitsCachedRoutes)
-              })
-
-              it(`eth -> erc20`, async () => {
-                const quoteReq: QuoteQueryParams = {
-                  tokenInAddress: 'ETH',
-                  tokenInChainId: 1,
-                  tokenOutAddress: 'UNI',
-                  tokenOutChainId: 1,
-                  amount:
-                    type == 'exactIn'
-                      ? await getAmount(1, type, 'ETH', 'UNI', '10')
-                      : await getAmount(1, type, 'ETH', 'UNI', '10000'),
-                  type,
-                  recipient: alice.address,
-                  slippageTolerance: SLIPPAGE,
-                  deadline: '360',
-                  algorithm,
-                  enableUniversalRouter: true,
-                  protocols: ALL_PROTOCOLS,
-                  debugRoutingConfig: JSON.stringify(useCachedRoutes),
-                  unicornSecret: unicornSecret,
-                }
-
-                const queryParams = qs.stringify(quoteReq)
-
-                const response = await axios.get<QuoteResponse>(`${API}?${queryParams}`, { headers: HEADERS_2_0 })
-                const { data, status } = response
-
-                expect(status).to.equal(200)
-                expect(data.methodParameters).to.not.be.undefined
-
-                const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
-                  data.methodParameters!,
-                  Ether.onChain(1),
-                  UNI_MAINNET
-                )
-
-                if (type == 'exactIn') {
-                  // We've swapped 10 ETH + gas costs
-                  expect(tokenInBefore.subtract(tokenInAfter).greaterThan(parseAmount('10', Ether.onChain(1)))).to.be
-                    .true
-                  checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(UNI_MAINNET, data.quote))
-                } else {
-                  checkAbsoluteDifference(tokenOutAfter.subtract(tokenOutBefore).toExact(), '10000', 0.0001)
-                  // Can't easily check slippage for ETH due to gas costs effecting ETH balance.
-                }
-
-                // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
-                // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
-                // if it's exactOut quote, we should always hit the cached routes.
-                // this is regardless of protocol version.
-                // the reason is because exact in quote always runs before exact out
-                // along with the native or wrapped native pool token address assertions previously
-                // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
-                // and native for v4 pool routes
-                expect(response.data.hitsCachedRoutes).to.equal(hitsCachedRoutes)
-              })
-
-              it(`eth -> erc20 swaprouter02`, async () => {
-                const quoteReq: QuoteQueryParams = {
-                  tokenInAddress: 'ETH',
-                  tokenInChainId: 1,
-                  tokenOutAddress: 'UNI',
-                  tokenOutChainId: 1,
-                  amount:
-                    type == 'exactIn'
-                      ? await getAmount(1, type, 'ETH', 'UNI', '10')
-                      : await getAmount(1, type, 'ETH', 'UNI', '10000'),
-                  type,
-                  recipient: alice.address,
-                  slippageTolerance: type == 'exactOut' ? LARGE_SLIPPAGE : SLIPPAGE,
-                  deadline: '360',
-                  algorithm,
-                  enableUniversalRouter: false,
-                  protocols: ALL_PROTOCOLS,
-                  debugRoutingConfig: JSON.stringify(useCachedRoutes),
-                  unicornSecret: unicornSecret,
-                }
-
-                const queryParams = qs.stringify(quoteReq)
-
-                const response = await axios.get<QuoteResponse>(`${API}?${queryParams}`, { headers: HEADERS_2_0 })
-                const { data, status } = response
-
-                expect(status).to.equal(200)
-                expect(data.methodParameters).to.not.be.undefined
-                expect(data.methodParameters?.to).to.equal(SWAP_ROUTER_02_ADDRESSES(ChainId.MAINNET))
-
-                const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
-                  data.methodParameters!,
-                  Ether.onChain(1),
-                  UNI_MAINNET
-                )
-
-                if (type == 'exactIn') {
-                  // We've swapped 10 ETH + gas costs
-                  expect(tokenInBefore.subtract(tokenInAfter).greaterThan(parseAmount('10', Ether.onChain(1)))).to.be
-                    .true
-                  checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(UNI_MAINNET, data.quote))
-                } else {
-                  checkAbsoluteDifference(tokenOutAfter.subtract(tokenOutBefore).toExact(), '10000', 0.0001)
-                  // Can't easily check slippage for ETH due to gas costs effecting ETH balance.
-                }
-
-                // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
-                // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
-                // if it's exactOut quote, we should always hit the cached routes.
-                // this is regardless of protocol version.
-                // the reason is because exact in quote always runs before exact out
-                // along with the native or wrapped native pool token address assertions previously
-                // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
-                // and native for v4 pool routes
-                expect(response.data.hitsCachedRoutes).to.equal(hitsCachedRoutes)
-              })
-
-              it(`weth -> erc20`, async () => {
-                const quoteReq: QuoteQueryParams = {
-                  tokenInAddress: 'WETH',
-                  tokenInChainId: 1,
-                  tokenOutAddress: 'DAI',
-                  tokenOutChainId: 1,
-                  amount: await getAmount(1, type, 'WETH', 'DAI', '100'),
-                  type,
-                  recipient: alice.address,
-                  slippageTolerance: SLIPPAGE,
-                  deadline: '360',
-                  algorithm,
-                  enableUniversalRouter: true,
-                  protocols: ALL_PROTOCOLS,
-                  debugRoutingConfig: JSON.stringify(useCachedRoutes),
-                  unicornSecret: unicornSecret,
-                }
-
-                const queryParams = qs.stringify(quoteReq)
-
-                const response = await axios.get<QuoteResponse>(`${API}?${queryParams}`, { headers: HEADERS_2_0 })
-                const { data, status } = response
-
-                expect(status).to.equal(200)
-                expect(data.methodParameters).to.not.be.undefined
-
-                const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
-                  data.methodParameters!,
-                  WETH9[1]!,
-                  DAI_MAINNET
-                )
-
-                if (type == 'exactIn') {
-                  expect(tokenInBefore.subtract(tokenInAfter).toExact()).to.equal('100')
-                  checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(DAI_MAINNET, data.quote))
-                } else {
-                  expect(tokenOutAfter.subtract(tokenOutBefore).toExact()).to.equal('100')
-                  checkQuoteToken(tokenInBefore, tokenInAfter, CurrencyAmount.fromRawAmount(WETH9[1]!, data.quote))
-                }
-
-                // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
-                // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
-                // if it's exactOut quote, we should always hit the cached routes.
-                // this is regardless of protocol version.
-                // the reason is because exact in quote always runs before exact out
-                // along with the native or wrapped native pool token address assertions previously
-                // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
-                // and native for v4 pool routes
-                expect(response.data.hitsCachedRoutes).to.equal(hitsCachedRoutes)
-              })
-
-              it(`erc20 -> weth`, async () => {
-                const quoteReq: QuoteQueryParams = {
-                  tokenInAddress: 'USDC',
-                  tokenInChainId: 1,
-                  tokenOutAddress: 'WETH',
-                  tokenOutChainId: 1,
-                  amount: await getAmount(1, type, 'USDC', 'WETH', '100'),
-                  type,
-                  recipient: alice.address,
-                  slippageTolerance: SLIPPAGE,
-                  deadline: '360',
-                  algorithm,
-                  enableUniversalRouter: true,
-                  protocols: ALL_PROTOCOLS,
-                  debugRoutingConfig: JSON.stringify(useCachedRoutes),
-                  unicornSecret: unicornSecret,
-                }
-
-                const queryParams = qs.stringify(quoteReq)
-
-                const response = await axios.get<QuoteResponse>(`${API}?${queryParams}`, { headers: HEADERS_2_0 })
-                const { data, status } = response
-
-                expect(status).to.equal(200)
-                expect(data.methodParameters).to.not.be.undefined
-
-                const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
-                  data.methodParameters!,
-                  USDC_MAINNET,
-                  WETH9[1]!
-                )
-
-                if (type == 'exactIn') {
-                  expect(tokenInBefore.subtract(tokenInAfter).toExact()).to.equal('100')
-                  checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(WETH9[1], data.quote))
-                } else {
-                  expect(tokenOutAfter.subtract(tokenOutBefore).toExact()).to.equal('100')
-                  checkQuoteToken(tokenInBefore, tokenInAfter, CurrencyAmount.fromRawAmount(USDC_MAINNET, data.quote))
-                }
-
-                // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
-                // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
-                // if it's exactOut quote, we should always hit the cached routes.
-                // this is regardless of protocol version.
-                // the reason is because exact in quote always runs before exact out
-                // along with the native or wrapped native pool token address assertions previously
-                // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
-                // and native for v4 pool routes
-                expect(response.data.hitsCachedRoutes).to.equal(hitsCachedRoutes)
-              })
-
-              it(`eth -> usdc v4 only protocol`, async () => {
-                const quoteReq: QuoteQueryParams = {
-                  tokenInAddress: 'ETH',
-                  tokenInChainId: 1,
-                  tokenOutAddress: 'USDC',
-                  tokenOutChainId: 1,
-                  amount: await getAmount(1, type, 'ETH', 'USDC', type == 'exactIn' ? '0.00001' : '0.1'),
-                  type,
-                  recipient: alice.address,
-                  slippageTolerance: LARGE_SLIPPAGE,
-                  deadline: '360',
-                  algorithm,
-                  protocols: 'v4',
-                  enableUniversalRouter: true,
-                  debugRoutingConfig: JSON.stringify(useCachedRoutes),
-                  unicornSecret: unicornSecret,
-                }
-
-                const queryParams = qs.stringify(quoteReq)
-
-                const response = await axios.get<QuoteResponse>(`${API}?${queryParams}`, { headers: HEADERS_2_0 })
-                const { data, status } = response
-
-                expect(status).to.equal(200)
-                expect(data.methodParameters).to.not.be.undefined
-                expect(data.route).to.not.be.undefined
-
-                // Verify only v4 pools are used
-                for (const r of data.route) {
-                  for (const pool of r) {
-                    expect(pool.type).to.equal('v4-pool')
-                  }
-                }
-
-                const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
-                  data.methodParameters!,
-                  Ether.onChain(1),
-                  USDC_MAINNET
-                )
-
-                if (type == 'exactIn') {
-                  expect(tokenInBefore.subtract(tokenInAfter).greaterThan(parseAmount('0.00001', Ether.onChain(1)))).to
-                    .be.true
-                  checkQuoteToken(
-                    tokenOutBefore,
-                    tokenOutAfter,
-                    CurrencyAmount.fromRawAmount(USDC_MAINNET, data.quote),
-                    LARGE_SLIPPAGE
-                  )
-                } else {
-                  expect(tokenOutAfter.subtract(tokenOutBefore).toExact()).to.equal('0.1')
-                }
-
-                expect(response.data.hitsCachedRoutes).to.be.false
-              })
-
-              it(`eth -> usdc v4 include (v2,v3,v4)`, async () => {
-                const quoteReq: QuoteQueryParams = {
-                  tokenInAddress: 'ETH',
-                  tokenInChainId: 1,
-                  tokenOutAddress: 'USDC',
-                  tokenOutChainId: 1,
-                  // Reducing amount as v4 ETH/USDC pool with very low liquidity might be selected, and liquidity changes often
-                  amount: await getAmount(1, type, 'ETH', 'USDC', type == 'exactIn' ? '0.00001' : '0.1'),
-                  type,
-                  recipient: alice.address,
-                  slippageTolerance: LARGE_SLIPPAGE,
-                  deadline: '360',
-                  algorithm,
-                  protocols: ALL_PROTOCOLS,
-                  enableUniversalRouter: true,
-                  debugRoutingConfig: JSON.stringify(useCachedRoutes),
-                  unicornSecret: unicornSecret,
-                }
-
-                const queryParams = qs.stringify(quoteReq)
-
-                const response = await axios.get<QuoteResponse>(`${API}?${queryParams}`, { headers: HEADERS_2_0 })
-                const { data, status } = response
-
-                expect(status).to.equal(200)
-                expect(data.methodParameters).to.not.be.undefined
-                expect(data.route).to.not.be.undefined
-
-                const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
-                  data.methodParameters!,
-                  Ether.onChain(1),
-                  USDC_MAINNET
-                )
-
-                if (type == 'exactIn') {
-                  expect(tokenInBefore.subtract(tokenInAfter).greaterThan(parseAmount('0.00001', Ether.onChain(1)))).to
-                    .be.true
-                  checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(USDC_MAINNET, data.quote))
-                } else {
-                  expect(tokenOutAfter.subtract(tokenOutBefore).toExact()).to.equal('0.1')
-                }
-
-                expect(response.data.hitsCachedRoutes).to.equal(hitsCachedRoutes)
-              })
-
-              it(`weth -> usdc v4 only protocol`, async () => {
-                const quoteReq: QuoteQueryParams = {
-                  tokenInAddress: 'WETH',
-                  tokenInChainId: 1,
-                  tokenOutAddress: 'USDC',
-                  tokenOutChainId: 1,
-                  amount: await getAmount(1, type, 'WETH', 'USDC', type == 'exactIn' ? '0.00001' : '0.01'),
-                  type,
-                  recipient: alice.address,
-                  slippageTolerance: LARGE_SLIPPAGE,
-                  deadline: '360',
-                  algorithm,
-                  protocols: 'v4',
-                  enableUniversalRouter: true,
-                  debugRoutingConfig: JSON.stringify(useCachedRoutes),
-                  unicornSecret: unicornSecret,
-                }
-
-                const queryParams = qs.stringify(quoteReq)
-
-                const response = await axios.get<QuoteResponse>(`${API}?${queryParams}`, { headers: HEADERS_2_0 })
-                const { data, status } = response
-
-                expect(status).to.equal(200)
-                expect(data.methodParameters).to.not.be.undefined
-                expect(data.route).to.not.be.undefined
-
-                // Verify only v4 pools are used
-                for (const r of data.route) {
-                  for (const pool of r) {
-                    expect(pool.type).to.equal('v4-pool')
-                  }
-                }
-
-                const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
-                  data.methodParameters!,
-                  WETH9[1]!,
-                  USDC_MAINNET
-                )
-
-                if (type == 'exactIn') {
-                  expect(tokenInBefore.subtract(tokenInAfter).toExact()).to.equal('0.00001')
-                  checkQuoteToken(
-                    tokenOutBefore,
-                    tokenOutAfter,
-                    CurrencyAmount.fromRawAmount(USDC_MAINNET, data.quote),
-                    LARGE_SLIPPAGE
-                  )
-                } else {
-                  expect(tokenOutAfter.subtract(tokenOutBefore).toExact()).to.equal('0.01')
-                  checkQuoteToken(
-                    tokenInBefore,
-                    tokenInAfter,
-                    CurrencyAmount.fromRawAmount(WETH9[1]!, data.quote),
-                    LARGE_SLIPPAGE
-                  )
-                }
-
-                expect(response.data.hitsCachedRoutes).to.be.false
-              })
-
-              it(`weth -> usdc v4 include (v2,v3,v4)`, async () => {
-                const quoteReq: QuoteQueryParams = {
-                  tokenInAddress: 'WETH',
-                  tokenInChainId: 1,
-                  tokenOutAddress: 'USDC',
-                  tokenOutChainId: 1,
-                  amount: await getAmount(1, type, 'WETH', 'USDC', type == 'exactIn' ? '0.1' : '100'),
-                  type,
-                  recipient: alice.address,
-                  slippageTolerance: LARGE_SLIPPAGE,
-                  deadline: '360',
-                  algorithm,
-                  protocols: ALL_PROTOCOLS,
-                  enableUniversalRouter: true,
-                  debugRoutingConfig: JSON.stringify(useCachedRoutes),
-                  unicornSecret: unicornSecret,
-                }
-
-                const queryParams = qs.stringify(quoteReq)
-
-                const response = await axios.get<QuoteResponse>(`${API}?${queryParams}`, { headers: HEADERS_2_0 })
-                const { data, status } = response
-
-                expect(status).to.equal(200)
-                expect(data.methodParameters).to.not.be.undefined
-                expect(data.route).to.not.be.undefined
-
-                const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
-                  data.methodParameters!,
-                  WETH9[1]!,
-                  USDC_MAINNET
-                )
-
-                if (type == 'exactIn') {
-                  expect(tokenInBefore.subtract(tokenInAfter).toExact()).to.equal('0.1')
-                  checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(USDC_MAINNET, data.quote))
-                } else {
-                  expect(tokenOutAfter.subtract(tokenOutBefore).toExact()).to.equal('100')
-                  checkQuoteToken(tokenInBefore, tokenInAfter, CurrencyAmount.fromRawAmount(WETH9[1]!, data.quote))
-                }
-
-                expect(response.data.hitsCachedRoutes).to.equal(hitsCachedRoutes)
-              })
-
-              if (algorithm == 'alpha') {
-                it(`erc20 -> erc20 v3 only`, async () => {
-                  const quoteReq: QuoteQueryParams = {
-                    tokenInAddress: 'USDC',
-                    tokenInChainId: 1,
-                    tokenOutAddress: 'USDT',
-                    tokenOutChainId: 1,
-                    amount: await getAmount(1, type, 'USDC', 'USDT', '100'),
-                    type,
-                    recipient: alice.address,
-                    slippageTolerance: SLIPPAGE,
-                    deadline: '360',
-                    algorithm: 'alpha',
-                    protocols: 'v3',
-                    enableUniversalRouter: true,
-                    debugRoutingConfig: JSON.stringify(useCachedRoutes),
-                    unicornSecret: unicornSecret,
-                  }
-
-                  const queryParams = qs.stringify(quoteReq)
-
-                  const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(
-                    `${API}?${queryParams}`,
-                    {
-                      headers: HEADERS_2_0,
-                    }
-                  )
-                  const {
-                    data: { quote, quoteDecimals, quoteGasAdjustedDecimals, methodParameters, route },
-                    status,
-                  } = response
-
-                  expect(status).to.equal(200)
-                  expect(parseFloat(quoteDecimals)).to.be.greaterThan(90)
-                  expect(parseFloat(quoteDecimals)).to.be.lessThan(110)
-
-                  if (type == 'exactIn') {
-                    expect(parseFloat(quoteGasAdjustedDecimals)).to.be.lessThanOrEqual(parseFloat(quoteDecimals))
-                  } else {
-                    expect(parseFloat(quoteGasAdjustedDecimals)).to.be.greaterThanOrEqual(parseFloat(quoteDecimals))
-                  }
-
-                  expect(methodParameters).to.not.be.undefined
-
-                  for (const r of route) {
-                    for (const pool of r) {
-                      expect(pool.type).to.equal('v3-pool')
-                    }
-                  }
-
-                  const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
-                    response.data.methodParameters!,
-                    USDC_MAINNET,
-                    USDT_MAINNET!
-                  )
-
-                  if (type == 'exactIn') {
-                    expect(tokenInBefore.subtract(tokenInAfter).toExact()).to.equal('100')
-                    checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(USDT_MAINNET, quote))
-                  } else {
-                    expect(tokenOutAfter.subtract(tokenOutBefore).toExact()).to.equal('100')
-                    checkQuoteToken(tokenInBefore, tokenInAfter, CurrencyAmount.fromRawAmount(USDC_MAINNET, quote))
-                  }
-
-                  // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
-                  // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
-                  // if it's exactOut quote, we should always hit the cached routes.
-                  // this is regardless of protocol version.
-                  // the reason is because exact in quote always runs before exact out
-                  // along with the native or wrapped native pool token address assertions previously
-                  // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
-                  // and native for v4 pool routes
-                  expect(response.data.hitsCachedRoutes).to.be.false
-                })
-
-                it(`erc20 -> erc20 v2 only`, async () => {
-                  const quoteReq: QuoteQueryParams = {
-                    tokenInAddress: 'USDC',
-                    tokenInChainId: 1,
-                    tokenOutAddress: 'USDT',
-                    tokenOutChainId: 1,
-                    amount: await getAmount(1, type, 'USDC', 'USDT', '100'),
-                    type,
-                    recipient: alice.address,
-                    slippageTolerance: SLIPPAGE,
-                    deadline: '360',
-                    algorithm: 'alpha',
-                    protocols: 'v2',
-                    enableUniversalRouter: true,
-                    debugRoutingConfig: JSON.stringify(useCachedRoutes),
-                    unicornSecret: unicornSecret,
-                  }
-
-                  const queryParams = qs.stringify(quoteReq)
-
-                  const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(
-                    `${API}?${queryParams}`,
-                    {
-                      headers: HEADERS_2_0,
-                    }
-                  )
-                  const {
-                    data: { quote, quoteDecimals, quoteGasAdjustedDecimals, methodParameters, route },
-                    status,
-                  } = response
-
-                  expect(status).to.equal(200)
-                  expect(parseFloat(quoteDecimals)).to.be.greaterThan(90)
-                  expect(parseFloat(quoteDecimals)).to.be.lessThan(110)
-
-                  if (type == 'exactIn') {
-                    expect(parseFloat(quoteGasAdjustedDecimals)).to.be.lessThanOrEqual(parseFloat(quoteDecimals))
-                  } else {
-                    expect(parseFloat(quoteGasAdjustedDecimals)).to.be.greaterThanOrEqual(parseFloat(quoteDecimals))
-                  }
-
-                  expect(methodParameters).to.not.be.undefined
-
-                  for (const r of route) {
-                    for (const pool of r) {
-                      expect(pool.type).to.equal('v2-pool')
-                    }
-                  }
-
-                  const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
-                    response.data.methodParameters!,
-                    USDC_MAINNET,
-                    USDT_MAINNET!
-                  )
-
-                  if (type == 'exactIn') {
-                    expect(tokenInBefore.subtract(tokenInAfter).toExact()).to.equal('100')
-                    checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(USDT_MAINNET, quote))
-                  } else {
-                    expect(tokenOutAfter.subtract(tokenOutBefore).toExact()).to.equal('100')
-                    checkQuoteToken(tokenInBefore, tokenInAfter, CurrencyAmount.fromRawAmount(USDC_MAINNET, quote))
-                  }
-
-                  // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
-                  // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
-                  // if it's exactOut quote, we should always hit the cached routes.
-                  // this is regardless of protocol version.
-                  // the reason is because exact in quote always runs before exact out
-                  // along with the native or wrapped native pool token address assertions previously
-                  // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
-                  // and native for v4 pool routes
-                  expect(response.data.hitsCachedRoutes).to.be.false
-                })
-
-                it(`erc20 -> erc20 forceCrossProtocol`, async () => {
-                  const quoteReq: QuoteQueryParams = {
-                    tokenInAddress: 'USDC',
-                    tokenInChainId: 1,
-                    tokenOutAddress: 'USDT',
-                    tokenOutChainId: 1,
-                    amount: await getAmount(1, type, 'USDC', 'USDT', '100'),
-                    type,
-                    recipient: alice.address,
-                    slippageTolerance: SLIPPAGE,
-                    deadline: '360',
-                    algorithm: 'alpha',
-                    forceCrossProtocol: true,
-                    enableUniversalRouter: true,
-                    protocols: ALL_PROTOCOLS,
-                    debugRoutingConfig: JSON.stringify(useCachedRoutes),
-                    unicornSecret: unicornSecret,
-                  }
-
-                  const queryParams = qs.stringify(quoteReq)
-
-                  const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(
-                    `${API}?${queryParams}`,
-                    {
-                      headers: HEADERS_2_0,
-                    }
-                  )
-                  const {
-                    data: { quote, quoteDecimals, quoteGasAdjustedDecimals, methodParameters, route },
-                    status,
-                  } = response
-
-                  expect(status).to.equal(200)
-                  expect(parseFloat(quoteDecimals)).to.be.greaterThan(90)
-                  expect(parseFloat(quoteDecimals)).to.be.lessThan(110)
-
-                  if (type == 'exactIn') {
-                    expect(parseFloat(quoteGasAdjustedDecimals)).to.be.lessThanOrEqual(parseFloat(quoteDecimals))
-                  } else {
-                    expect(parseFloat(quoteGasAdjustedDecimals)).to.be.greaterThanOrEqual(parseFloat(quoteDecimals))
-                  }
-
-                  expect(methodParameters).to.not.be.undefined
-
-                  let hasV3Pool = false
-                  let hasV2Pool = false
-                  for (const r of route) {
-                    for (const pool of r) {
-                      if (pool.type == 'v3-pool') {
-                        hasV3Pool = true
-                      }
-                      if (pool.type == 'v2-pool') {
-                        hasV2Pool = true
-                      }
-                    }
-                  }
-
-                  expect(hasV3Pool && hasV2Pool).to.be.true
-
-                  const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
-                    response.data.methodParameters!,
-                    USDC_MAINNET,
-                    USDT_MAINNET!
-                  )
-
-                  if (type == 'exactIn') {
-                    expect(tokenInBefore.subtract(tokenInAfter).toExact()).to.equal('100')
-                    checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(USDT_MAINNET, quote))
-                  } else {
-                    expect(tokenOutAfter.subtract(tokenOutBefore).toExact()).to.equal('100')
-                    checkQuoteToken(tokenInBefore, tokenInAfter, CurrencyAmount.fromRawAmount(USDC_MAINNET, quote))
-                  }
-                })
-
-                /// Tests for routes likely to result in MixedRoutes being returned
-                if (type === 'exactIn') {
-                  it.skip(`erc20 -> erc20 forceMixedRoutes not specified for v2,v3 does not return mixed route even when it is better`, async () => {
-                    const quoteReq: QuoteQueryParams = {
-                      tokenInAddress: 'BOND',
-                      tokenInChainId: 1,
-                      tokenOutAddress: 'APE',
-                      tokenOutChainId: 1,
-                      amount: await getAmount(1, type, 'BOND', 'APE', '10000'),
-                      type,
-                      recipient: alice.address,
-                      slippageTolerance: SLIPPAGE,
-                      deadline: '360',
-                      algorithm: 'alpha',
-                      protocols: 'v2,v3',
-                      enableUniversalRouter: true,
-                    }
-
-                    const queryParams = qs.stringify(quoteReq)
-
-                    const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(
-                      `${API}?${queryParams}`,
-                      {
-                        headers: HEADERS_2_0,
-                      }
-                    )
-                    const {
-                      data: { quoteDecimals, quoteGasAdjustedDecimals, methodParameters, routeString },
-                      status,
-                    } = response
-
-                    expect(status).to.equal(200)
-
-                    if (type == 'exactIn') {
-                      expect(parseFloat(quoteGasAdjustedDecimals)).to.be.lessThanOrEqual(parseFloat(quoteDecimals))
-                    } else {
-                      expect(parseFloat(quoteGasAdjustedDecimals)).to.be.greaterThanOrEqual(parseFloat(quoteDecimals))
-                    }
-
-                    expect(methodParameters).to.not.be.undefined
-
-                    expect(!routeString.includes('[V2 + V3]'))
-                  })
-
-                  it(`erc20 -> erc20 forceMixedRoutes true for v2,v3`, async () => {
-                    const quoteReq: QuoteQueryParams = {
-                      tokenInAddress: 'BOND',
-                      tokenInChainId: 1,
-                      tokenOutAddress: 'APE',
-                      tokenOutChainId: 1,
-                      amount: await getAmount(1, type, 'BOND', 'APE', '10000'),
-                      type,
-                      recipient: alice.address,
-                      slippageTolerance: SLIPPAGE,
-                      deadline: '360',
-                      algorithm: 'alpha',
-                      forceMixedRoutes: true,
-                      protocols: 'v2,v3',
-                      enableUniversalRouter: true,
-                    }
-
-                    await callAndExpectFail(quoteReq, {
-                      status: 404,
-                      data: {
-                        detail: 'No route found',
-                        errorCode: 'NO_ROUTE',
-                      },
-                    })
-                  })
-
-                  it('USDC -> mockA forceMixedRoutes true for mixed protocol on Base with request source', async () => {
-                    if (type != 'exactIn') {
-                      // mixed route only works for exactIn
-                      return
-                    }
-
-                    const quoteReq: QuoteQueryParams = {
-                      tokenInAddress: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
-                      tokenInChainId: 8453,
-                      tokenOutAddress: '0x878784f7ebf6e57d17c81d82ddf53f117a5e2988',
-                      tokenOutChainId: 8453,
-                      amount: '1000000',
-                      type,
-                      recipient: alice.address,
-                      slippageTolerance: SLIPPAGE,
-                      deadline: '360',
-                      algorithm: 'alpha',
-                      forceMixedRoutes: true,
-                      protocols: 'mixed',
-                      enableUniversalRouter: true,
-                    }
-
-                    const queryParams = qs.stringify(quoteReq)
-
-                    const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(
-                      `${API}?${queryParams}`,
-                      {
-                        headers: {
-                          ...HEADERS_2_0,
-                          'x-request-source': 'e2e-test',
-                        },
-                      }
-                    )
-                    const {
-                      data: { quoteDecimals, quoteGasAdjustedDecimals, methodParameters, routeString },
-                      status,
-                    } = response
-
-                    expect(status).to.equal(200)
-                    expect(parseFloat(quoteGasAdjustedDecimals)).to.be.lessThanOrEqual(parseFloat(quoteDecimals))
-                    expect(methodParameters).to.not.be.undefined
-
-                    /// since we only get the routeString back, we can check if there's V3 + V2
-                    expect(routeString.includes('[V2 + V3 + V4]'))
-                  })
-
-                  it('USDC -> mockA forceMixedRoutes true for mixed protocol on Base no request source', async () => {
-                    if (type != 'exactIn') {
-                      // mixed route only works for exactIn
-                      return
-                    }
-
-                    const quoteReq: QuoteQueryParams = {
-                      tokenInAddress: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
-                      tokenInChainId: 8453,
-                      tokenOutAddress: '0x878784f7ebf6e57d17c81d82ddf53f117a5e2988',
-                      tokenOutChainId: 8453,
-                      amount: '1000000',
-                      type,
-                      recipient: alice.address,
-                      slippageTolerance: SLIPPAGE,
-                      deadline: '360',
-                      algorithm: 'alpha',
-                      forceMixedRoutes: true,
-                      protocols: 'mixed',
-                      enableUniversalRouter: true,
-                    }
-
-                    const queryParams = qs.stringify(quoteReq)
-
-                    try {
-                      await axios.get<QuoteResponse>(`${API}?${queryParams}`, {
-                        headers: HEADERS_2_0,
-                      })
-                    } catch (err) {
-                      if (err instanceof Error) {
-                        expect(err.message).to.contains('404')
-                      }
-                    }
-                  })
-
-                  it.skip(`erc20 -> erc20 forceMixedRoutes true for all protocols specified`, async () => {
-                    const quoteReq: QuoteQueryParams = {
-                      tokenInAddress: 'BOND',
-                      tokenInChainId: 1,
-                      tokenOutAddress: 'APE',
-                      tokenOutChainId: 1,
-                      amount: await getAmount(1, type, 'BOND', 'APE', '10000'),
-                      type,
-                      recipient: alice.address,
-                      slippageTolerance: SLIPPAGE,
-                      deadline: '360',
-                      algorithm: 'alpha',
-                      forceMixedRoutes: true,
-                      protocols: 'v2,v3,mixed',
-                      enableUniversalRouter: true,
-                    }
-
-                    const queryParams = qs.stringify(quoteReq)
-
-                    const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(
-                      `${API}?${queryParams}`,
-                      {
-                        headers: HEADERS_2_0,
-                      }
-                    )
-                    const {
-                      data: { quoteDecimals, quoteGasAdjustedDecimals, methodParameters, routeString },
-                      status,
-                    } = response
-
-                    expect(status).to.equal(200)
-
-                    if (type == 'exactIn') {
-                      expect(parseFloat(quoteGasAdjustedDecimals)).to.be.lessThanOrEqual(parseFloat(quoteDecimals))
-                    } else {
-                      expect(parseFloat(quoteGasAdjustedDecimals)).to.be.greaterThanOrEqual(parseFloat(quoteDecimals))
-                    }
-
-                    expect(methodParameters).to.not.be.undefined
-
-                    /// since we only get the routeString back, we can check if there's V3 + V2
-                    expect(routeString.includes('[V2 + V3]'))
-                  })
-                }
-
-                // FOT swap only works for exact in
-                if (type === 'exactIn') {
-                  const tokenInAndTokenOut = [
-                    [BULLET, WETH9[ChainId.MAINNET]!],
-                    [WETH9[ChainId.MAINNET]!, BULLET],
-                    // TODO: re-enable - DFNDR FOT test is flaky right now, disabling to unblock pipeline
-                    // [WETH9[ChainId.MAINNET]!, DFNDR],
-                  ]
-
-                  tokenInAndTokenOut.forEach(([tokenIn, tokenOut]) => {
-                    // If this test fails sporadically, dev needs to investigate further
-                    // There could be genuine regressions in the form of race condition, due to complex layers of caching
-                    // See https://github.com/Uniswap/smart-order-router/pull/415#issue-1914604864 as an example race condition
-                    it(`fee-on-transfer ${tokenIn.symbol} -> ${tokenOut.symbol}`, async () => {
-                      const enableFeeOnTransferFeeFetching = [true, false, undefined]
-                      // we want to swap the tokenIn/tokenOut order so that we can test both sellFeeBps and buyFeeBps for exactIn vs exactOut
-                      const originalAmount = tokenIn.equals(WETH9[ChainId.MAINNET]!) ? '10' : '2924'
-                      const amount = await getAmountFromToken(type, tokenIn, tokenOut, originalAmount)
-
-                      // Parallelize the FOT quote requests, because we notice there might be tricky race condition that could cause quote to not include FOT tax
-                      const responses = await Promise.all(
-                        enableFeeOnTransferFeeFetching.map(async (enableFeeOnTransferFeeFetching) => {
-                          if (enableFeeOnTransferFeeFetching) {
-                            // if it's FOT flag enabled request, we delay it so that it's more likely to repro the race condition in
-                            // https://github.com/Uniswap/smart-order-router/pull/415#issue-1914604864
-                            await new Promise((f) => setTimeout(f, 1000))
-                          }
-                          const simulateFromAddress = tokenIn.equals(WETH9[ChainId.MAINNET]!)
-                            ? '0x6B44ba0a126a2A1a8aa6cD1AdeeD002e141Bcd44'
-                            : '0x171d311eAcd2206d21Cb462d661C33F0eddadC03'
-                          const quoteReq: QuoteQueryParams = {
-                            tokenInAddress: tokenIn.address,
-                            tokenInChainId: tokenIn.chainId,
-                            tokenOutAddress: tokenOut.address,
-                            tokenOutChainId: tokenOut.chainId,
-                            amount: amount,
-                            type: type,
-                            protocols: 'v2,v3,mixed',
-                            // TODO: ROUTE-86 remove enableFeeOnTransferFeeFetching once we are ready to enable this by default
-                            enableFeeOnTransferFeeFetching: enableFeeOnTransferFeeFetching,
-                            recipient: alice.address,
-                            // we have to use large slippage for FOT swap, because routing-api always forks at the latest block,
-                            // and the FOT swap can have large slippage, despite SOR already subtracted FOT tax
-                            slippageTolerance: LARGE_SLIPPAGE,
-                            deadline: '360',
-                            algorithm,
-                            enableUniversalRouter: true,
-                            // if fee-on-transfer flag is not enabled, most likely the simulation will fail due to quote not subtracting the tax
-                            simulateFromAddress: enableFeeOnTransferFeeFetching ? simulateFromAddress : undefined,
-                            portionBips: FLAT_PORTION.bips,
-                            portionRecipient: FLAT_PORTION.recipient,
-                            debugRoutingConfig: JSON.stringify(useCachedRoutes),
-                            unicornSecret: unicornSecret,
-                          }
-
-                          const queryParams = qs.stringify(quoteReq)
-
-                          const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(
-                            `${API}?${queryParams}`,
-                            { headers: HEADERS_2_0 }
-                          )
-
-                          // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
-                          // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
-                          // if it's exactOut quote, we should always hit the cached routes.
-                          // this is regardless of protocol version.
-                          // the reason is because exact in quote always runs before exact out
-                          // along with the native or wrapped native pool token address assertions previously
-                          // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
-                          // and native for v4 pool routes
-                          expect(response.data.hitsCachedRoutes).to.equal(hitsCachedRoutes)
-
-                          return { enableFeeOnTransferFeeFetching, ...response }
-                        })
-                      )
-
-                      const quoteWithFlagOn = responses.find((r) => r.enableFeeOnTransferFeeFetching === true)
-                      expect(quoteWithFlagOn).not.to.be.undefined
-
-                      // TODO: flaky assertions, re-enable after fixing (probably real prod issue due to flaky GQL data)
-                      // // in case of FOT token that should not take a portion/fee, we assert that all portion fields are undefined
-                      // if (!tokenOut?.equals(WETH9[ChainId.MAINNET])) {
-                      //   expect(quoteWithFlagOn!.data.portionAmount).to.be.undefined
-                      //   expect(quoteWithFlagOn!.data.portionBips).to.be.undefined
-                      //   expect(quoteWithFlagOn!.data.portionRecipient).to.be.undefined
-                      // } else {
-                      //   expect(quoteWithFlagOn!.data.portionAmount).to.be.not.undefined
-                      //   expect(quoteWithFlagOn!.data.portionBips).to.be.not.undefined
-                      //   expect(quoteWithFlagOn!.data.portionRecipient).to.be.not.undefined
-                      // }
-
-                      responses
-                        .filter((r) => r.enableFeeOnTransferFeeFetching !== true)
-                        .forEach((r) => {
-                          if (type === 'exactIn') {
-                            const quote = CurrencyAmount.fromRawAmount(tokenOut, r.data.quote)
-                            const quoteWithFlagon = CurrencyAmount.fromRawAmount(tokenOut, quoteWithFlagOn!.data.quote)
-
-                            // quote without fot flag must be greater than the quote with fot flag
-                            // this is to catch https://github.com/Uniswap/smart-order-router/pull/421
-                            expect(quote.greaterThan(quoteWithFlagon)).to.be.true
-
-                            // below is additional assertion to ensure the quote without fot tax vs quote with tax should be very roughly equal to the fot sell/buy tax rate
-                            const tokensDiff = quote.subtract(quoteWithFlagon)
-                            const percentDiff = tokensDiff.asFraction.divide(quote.asFraction)
-                            if (tokenIn?.equals(BULLET)) {
-                              expect(percentDiff.toFixed(3, undefined, Rounding.ROUND_HALF_UP)).equal(
-                                new Fraction(BigNumber.from(BULLET_WHT_TAX.sellFeeBps ?? 0).toString(), 10_000).toFixed(
-                                  3
-                                )
-                              )
-                            } else if (tokenOut?.equals(BULLET)) {
-                              expect(percentDiff.toFixed(3, undefined, Rounding.ROUND_HALF_UP)).equal(
-                                new Fraction(BigNumber.from(BULLET_WHT_TAX.buyFeeBps ?? 0).toString(), 10_000).toFixed(
-                                  3
-                                )
-                              )
-                            }
-                          }
-                        })
-
-                      for (const response of responses) {
-                        const {
-                          enableFeeOnTransferFeeFetching,
-                          data: {
-                            quote,
-                            quoteDecimals,
-                            quoteGasAdjustedDecimals,
-                            methodParameters,
-                            route,
-                            simulationStatus,
-                            simulationError,
-                          },
-                          status,
-                        } = response
-
-                        expect(status).to.equal(200)
-
-                        if (type == 'exactIn') {
-                          expect(parseFloat(quoteGasAdjustedDecimals)).to.be.lessThanOrEqual(parseFloat(quoteDecimals))
-                        } else {
-                          expect(parseFloat(quoteGasAdjustedDecimals)).to.be.greaterThanOrEqual(
-                            parseFloat(quoteDecimals)
-                          )
-                        }
-
-                        let hasV3Pool = false
-                        let hasV2Pool = false
-                        for (const r of route) {
-                          for (const pool of r) {
-                            if (pool.type == 'v3-pool') {
-                              hasV3Pool = true
-                            }
-                            if (pool.type == 'v2-pool') {
-                              hasV2Pool = true
-                              if (enableFeeOnTransferFeeFetching) {
-                                if (pool.tokenIn.address === BULLET.address) {
-                                  expect(pool.tokenIn.sellFeeBps).to.be.not.undefined
-                                  expect(pool.tokenIn.sellFeeBps).to.be.equals(BULLET_WHT_TAX.sellFeeBps?.toString())
-                                  expect(pool.tokenIn.buyFeeBps).to.be.not.undefined
-                                  expect(pool.tokenIn.buyFeeBps).to.be.equals(BULLET_WHT_TAX.buyFeeBps?.toString())
-                                }
-                                if (pool.tokenOut.address === BULLET.address) {
-                                  expect(pool.tokenOut.sellFeeBps).to.be.not.undefined
-                                  expect(pool.tokenOut.sellFeeBps).to.be.equals(BULLET_WHT_TAX.sellFeeBps?.toString())
-                                  expect(pool.tokenOut.buyFeeBps).to.be.not.undefined
-                                  expect(pool.tokenOut.buyFeeBps).to.be.equals(BULLET_WHT_TAX.buyFeeBps?.toString())
-                                }
-                                if (pool.reserve0.token.address === BULLET.address) {
-                                  expect(pool.reserve0.token.sellFeeBps).to.be.not.undefined
-                                  expect(pool.reserve0.token.sellFeeBps).to.be.equals(
-                                    BULLET_WHT_TAX.sellFeeBps?.toString()
-                                  )
-                                  expect(pool.reserve0.token.buyFeeBps).to.be.not.undefined
-                                  expect(pool.reserve0.token.buyFeeBps).to.be.equals(
-                                    BULLET_WHT_TAX.buyFeeBps?.toString()
-                                  )
-                                }
-                                if (pool.reserve1.token.address === BULLET.address) {
-                                  expect(pool.reserve1.token.sellFeeBps).to.be.not.undefined
-                                  expect(pool.reserve1.token.sellFeeBps).to.be.equals(
-                                    BULLET_WHT_TAX.sellFeeBps?.toString()
-                                  )
-                                  expect(pool.reserve1.token.buyFeeBps).to.be.not.undefined
-                                  expect(pool.reserve1.token.buyFeeBps).to.be.equals(
-                                    BULLET_WHT_TAX.buyFeeBps?.toString()
-                                  )
-                                }
-                              } else {
-                                expect(pool.tokenOut.sellFeeBps).to.be.undefined
-                                expect(pool.tokenOut.buyFeeBps).to.be.undefined
-                                expect(pool.reserve0.token.sellFeeBps).to.be.undefined
-                                expect(pool.reserve0.token.buyFeeBps).to.be.undefined
-                                expect(pool.reserve1.token.sellFeeBps).to.be.undefined
-                                expect(pool.reserve1.token.buyFeeBps).to.be.undefined
-                              }
-                            }
-                          }
-                        }
-
-                        expect(!hasV3Pool && hasV2Pool).to.be.true
-
-                        if (enableFeeOnTransferFeeFetching) {
-                          expect(simulationStatus).to.equal('SUCCESS')
-                          expect(simulationError).to.equal(false)
-                          expect(methodParameters).to.not.be.undefined
-
-                          // We don't have a bullet proof way to assert the fot-involved quote is post tax
-                          // so the best way is to execute the swap on hardhat mainnet fork,
-                          // and make sure the executed quote doesn't differ from callstatic simulated quote by over slippage tolerance
-                          const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
-                            response.data.methodParameters!,
-                            tokenIn,
-                            tokenOut
-                          )
-
-                          expect(tokenInBefore.subtract(tokenInAfter).toExact()).to.equal(originalAmount)
-                          checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(tokenOut, quote))
-                        }
-                      }
-                    })
-                  })
-                }
-              }
-            })
-          })
-        })
-
-        if (algorithm == 'alpha') {
-          describe(`+ Simulate Swap + Execute Swap`, () => {
-            it(`erc20 -> erc20`, async () => {
-              const quoteReq: QuoteQueryParams = {
-                tokenInAddress: 'USDC',
-                tokenInChainId: 1,
-                tokenOutAddress: 'USDT',
-                tokenOutChainId: 1,
-                amount: await getAmount(1, type, 'USDC', 'USDT', '100'),
-                type,
-                recipient: alice.address,
-                slippageTolerance: SLIPPAGE,
-                deadline: '360',
-                algorithm,
-                simulateFromAddress: '0xf584f8728b874a6a5c7a8d4d387c9aae9172d621',
-                enableUniversalRouter: true,
-                protocols: ALL_PROTOCOLS,
-              }
-
-              const queryParams = qs.stringify(quoteReq)
-
-              const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(`${API}?${queryParams}`, {
-                headers: HEADERS_2_0,
-              })
-              const {
-                data: { quote, quoteDecimals, quoteGasAdjustedDecimals, methodParameters, simulationError },
-                status,
-              } = response
-
-              expect(status).to.equal(200)
-              expect(simulationError).to.equal(false)
-              expect(parseFloat(quoteDecimals)).to.be.greaterThan(90)
-              expect(parseFloat(quoteDecimals)).to.be.lessThan(110)
-
-              if (type == 'exactIn') {
-                expect(parseFloat(quoteGasAdjustedDecimals)).to.be.lessThanOrEqual(parseFloat(quoteDecimals))
-              } else {
-                expect(parseFloat(quoteGasAdjustedDecimals)).to.be.greaterThanOrEqual(parseFloat(quoteDecimals))
-              }
-
-              expect(methodParameters).to.not.be.undefined
-
-              const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
-                methodParameters!,
-                USDC_MAINNET,
-                USDT_MAINNET
-              )
-
-              if (type == 'exactIn') {
-                expect(tokenInBefore.subtract(tokenInAfter).toExact()).to.equal('100')
-                checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(USDT_MAINNET, quote))
-              } else {
-                expect(tokenOutAfter.subtract(tokenOutBefore).toExact()).to.equal('100')
-                checkQuoteToken(tokenInBefore, tokenInAfter, CurrencyAmount.fromRawAmount(USDC_MAINNET, quote))
-              }
-
-              // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
-              // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
-              // if it's exactOut quote, we should always hit the cached routes.
-              // this is regardless of protocol version.
-              // the reason is because exact in quote always runs before exact out
-              // along with the native or wrapped native pool token address assertions previously
-              // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
-              // and native for v4 pool routes
-              expect(response.data.hitsCachedRoutes).to.be.true
             })
 
             it(`erc20 -> erc20 swaprouter02`, async () => {
@@ -1974,22 +468,20 @@ describe('quote', function () {
                 slippageTolerance: SLIPPAGE,
                 deadline: '360',
                 algorithm,
-                simulateFromAddress: '0xf584f8728b874a6a5c7a8d4d387c9aae9172d621',
-                protocols: 'v2,v3,mixed',
+                protocols: ALL_PROTOCOLS,
               }
 
               const queryParams = qs.stringify(quoteReq)
 
               const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(`${API}?${queryParams}`, {
-                headers: HEADERS_1_2,
+                headers: HEADERS_2_0,
               })
               const {
-                data: { quote, quoteDecimals, quoteGasAdjustedDecimals, methodParameters, simulationError },
+                data: { quote, quoteDecimals, quoteGasAdjustedDecimals, methodParameters },
                 status,
               } = response
 
               expect(status).to.equal(200)
-              expect(simulationError).to.equal(false)
               expect(parseFloat(quoteDecimals)).to.be.greaterThan(90)
               expect(parseFloat(quoteDecimals)).to.be.lessThan(110)
 
@@ -2000,7 +492,7 @@ describe('quote', function () {
               }
 
               expect(methodParameters).to.not.be.undefined
-              expect(methodParameters!.to).to.equal(SWAP_ROUTER_02_ADDRESSES(ChainId.MAINNET))
+              expect(methodParameters?.to).to.equal(SWAP_ROUTER_02_ADDRESSES(ChainId.MAINNET))
 
               const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
                 methodParameters!,
@@ -2024,90 +516,97 @@ describe('quote', function () {
               // along with the native or wrapped native pool token address assertions previously
               // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
               // and native for v4 pool routes
-              expect(response.data.hitsCachedRoutes).to.be.true
+              expect(response.data.hitsCachedRoutes).to.equal(true)
             })
 
-            if (isTesterPKEnvironmentSet()) {
-              it(`erc20 -> erc20 with permit with tester pk`, async () => {
-                // This test requires a private key with at least 10 USDC
-                // at FORK_BLOCK time.
-                const amount = await getAmount(1, type, 'USDC', 'USDT', '10')
+            it(`erc20 -> erc20 with permit`, async () => {
+              const amount = await getAmount(1, type, 'USDC', 'USDT', '10')
 
-                const nonce = '0'
+              const nonce = nextPermitNonce()
 
-                const permit: PermitSingle = {
-                  details: {
-                    token: USDC_MAINNET.address,
-                    amount: amount,
-                    expiration: Math.floor(new Date().getTime() / 1000 + 10000000).toString(),
-                    nonce,
-                  },
-                  spender: UNIVERSAL_ROUTER_ADDRESS,
-                  sigDeadline: Math.floor(new Date().getTime() / 1000 + 10000000).toString(),
-                }
+              const permit: PermitSingle = {
+                details: {
+                  token: USDC_MAINNET.address,
+                  amount: '15000000', // For exact out we don't know the exact amount needed to permit, so just specify a large amount.
+                  expiration: Math.floor(new Date().getTime() / 1000 + 10000000).toString(),
+                  nonce,
+                },
+                spender: UNIVERSAL_ROUTER_ADDRESS,
+                sigDeadline: Math.floor(new Date().getTime() / 1000 + 10000000).toString(),
+              }
 
-                const wallet = new Wallet(process.env.TESTER_PK!)
+              const { domain, types, values } = AllowanceTransfer.getPermitData(permit, PERMIT2_ADDRESS, 1)
 
-                const { domain, types, values } = AllowanceTransfer.getPermitData(permit, PERMIT2_ADDRESS, 1)
+              const signature = await alice._signTypedData(domain, types, values)
 
-                const signature = await wallet._signTypedData(domain, types, values)
+              const quoteReq: QuoteQueryParams = {
+                tokenInAddress: 'USDC',
+                tokenInChainId: 1,
+                tokenOutAddress: 'USDT',
+                tokenOutChainId: 1,
+                amount,
+                type,
+                recipient: alice.address,
+                slippageTolerance: SLIPPAGE,
+                deadline: '360',
+                algorithm,
+                permitSignature: signature,
+                permitAmount: permit.details.amount.toString(),
+                permitExpiration: permit.details.expiration.toString(),
+                permitSigDeadline: permit.sigDeadline.toString(),
+                permitNonce: permit.details.nonce.toString(),
+                enableUniversalRouter: true,
+                protocols: ALL_PROTOCOLS,
+              }
 
-                const quoteReq: QuoteQueryParams = {
-                  tokenInAddress: 'USDC',
-                  tokenInChainId: 1,
-                  tokenOutAddress: 'USDT',
-                  tokenOutChainId: 1,
-                  amount,
-                  type,
-                  recipient: wallet.address,
-                  slippageTolerance: SLIPPAGE,
-                  deadline: '360',
-                  algorithm,
-                  simulateFromAddress: wallet.address,
-                  permitSignature: signature,
-                  permitAmount: permit.details.amount.toString(),
-                  permitExpiration: permit.details.expiration.toString(),
-                  permitSigDeadline: permit.sigDeadline.toString(),
-                  permitNonce: permit.details.nonce.toString(),
-                  enableUniversalRouter: true,
-                  protocols: ALL_PROTOCOLS,
-                }
+              const queryParams = qs.stringify(quoteReq)
 
-                const queryParams = qs.stringify(quoteReq)
-
-                const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(`${API}?${queryParams}`, {
-                  headers: HEADERS_2_0,
-                })
-                const {
-                  data: { quoteDecimals, quoteGasAdjustedDecimals, methodParameters, simulationError },
-                  status,
-                } = response
-                expect(status).to.equal(200)
-
-                expect(simulationError).to.equal(false)
-
-                expect(parseFloat(quoteDecimals)).to.be.greaterThan(9)
-                expect(parseFloat(quoteDecimals)).to.be.lessThan(11)
-
-                if (type == 'exactIn') {
-                  expect(parseFloat(quoteGasAdjustedDecimals)).to.be.lessThanOrEqual(parseFloat(quoteDecimals))
-                } else {
-                  expect(parseFloat(quoteGasAdjustedDecimals)).to.be.greaterThanOrEqual(parseFloat(quoteDecimals))
-                }
-
-                expect(methodParameters).to.not.be.undefined
-
-                // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
-                // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
-                // if it's exactOut quote, we should always hit the cached routes.
-                // this is regardless of protocol version.
-                // the reason is because exact in quote always runs before exact out
-                // along with the native or wrapped native pool token address assertions previously
-                // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
-                // and native for v4 pool routes
-                expect(response.data.hitsCachedRoutes).to.be.true
+              const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(`${API}?${queryParams}`, {
+                headers: HEADERS_2_0,
               })
-            }
+              const {
+                data: { quote, quoteDecimals, quoteGasAdjustedDecimals, methodParameters },
+                status,
+              } = response
+
+              expect(status).to.equal(200)
+              expect(parseFloat(quoteDecimals)).to.be.greaterThan(9)
+              expect(parseFloat(quoteDecimals)).to.be.lessThan(11)
+
+              if (type == 'exactIn') {
+                expect(parseFloat(quoteGasAdjustedDecimals)).to.be.lessThanOrEqual(parseFloat(quoteDecimals))
+              } else {
+                expect(parseFloat(quoteGasAdjustedDecimals)).to.be.greaterThanOrEqual(parseFloat(quoteDecimals))
+              }
+
+              expect(methodParameters).to.not.be.undefined
+              expect(methodParameters?.to).to.equal(UNIVERSAL_ROUTER_ADDRESS)
+
+              const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
+                methodParameters!,
+                USDC_MAINNET,
+                USDT_MAINNET,
+                true
+              )
+
+              if (type == 'exactIn') {
+                expect(tokenInBefore.subtract(tokenInAfter).toExact()).to.equal('10')
+                checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(USDT_MAINNET, quote))
+              } else {
+                expect(tokenOutAfter.subtract(tokenOutBefore).toExact()).to.equal('10')
+                checkQuoteToken(tokenInBefore, tokenInAfter, CurrencyAmount.fromRawAmount(USDC_MAINNET, quote))
+              }
+
+              // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
+              // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
+              // if it's exactOut quote, we should always hit the cached routes.
+              // this is regardless of protocol version.
+              // the reason is because exact in quote always runs before exact out
+              // along with the native or wrapped native pool token address assertions previously
+              // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
+              // and native for v4 pool routes
+              expect(response.data.hitsCachedRoutes).to.equal(true)
+            })
 
             it(`erc20 -> eth`, async () => {
               const quoteReq: QuoteQueryParams = {
@@ -2121,7 +620,6 @@ describe('quote', function () {
                 slippageTolerance: SLIPPAGE,
                 deadline: '360',
                 algorithm,
-                simulateFromAddress: '0xf584f8728b874a6a5c7a8d4d387c9aae9172d621',
                 enableUniversalRouter: true,
                 protocols: ALL_PROTOCOLS,
               }
@@ -2130,12 +628,11 @@ describe('quote', function () {
 
               const response = await axios.get<QuoteResponse>(`${API}?${queryParams}`, { headers: HEADERS_2_0 })
               const {
-                data: { quote, methodParameters, simulationError },
+                data: { quote, methodParameters },
                 status,
               } = response
 
               expect(status).to.equal(200)
-              expect(simulationError).to.equal(false)
               expect(methodParameters).to.not.be.undefined
 
               const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
@@ -2160,7 +657,7 @@ describe('quote', function () {
               // along with the native or wrapped native pool token address assertions previously
               // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
               // and native for v4 pool routes
-              expect(response.data.hitsCachedRoutes).to.be.true
+              expect(response.data.hitsCachedRoutes).to.equal(true)
             })
 
             it(`erc20 -> eth large trade`, async () => {
@@ -2179,7 +676,6 @@ describe('quote', function () {
                 slippageTolerance: LARGE_SLIPPAGE,
                 deadline: '360',
                 algorithm,
-                simulateFromAddress: '0xf584f8728b874a6a5c7a8d4d387c9aae9172d621',
                 enableUniversalRouter: true,
                 protocols: ALL_PROTOCOLS,
               }
@@ -2190,7 +686,6 @@ describe('quote', function () {
               const { data, status } = response
 
               expect(status).to.equal(200)
-              expect(data.simulationError).to.equal(false)
               expect(data.methodParameters).to.not.be.undefined
 
               expect(data.route).to.not.be.undefined
@@ -2237,7 +732,90 @@ describe('quote', function () {
               // along with the native or wrapped native pool token address assertions previously
               // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
               // and native for v4 pool routes
-              expect(response.data.hitsCachedRoutes).to.be.true
+              expect(response.data.hitsCachedRoutes).to.equal(true)
+            })
+
+            it(`erc20 -> eth large trade with permit`, async () => {
+              const nonce = nextPermitNonce()
+
+              const amount =
+                type == 'exactIn'
+                  ? await getAmount(1, type, 'USDC', 'ETH', '1000000')
+                  : await getAmount(1, type, 'USDC', 'ETH', '100')
+
+              const permit: PermitSingle = {
+                details: {
+                  token: USDC_MAINNET.address,
+                  amount: '1500000000000', // For exact out we don't know the exact amount needed to permit, so just specify a large amount.
+                  expiration: Math.floor(new Date().getTime() / 1000 + 10000000).toString(),
+                  nonce,
+                },
+                spender: UNIVERSAL_ROUTER_ADDRESS,
+                sigDeadline: Math.floor(new Date().getTime() / 1000 + 10000000).toString(),
+              }
+
+              const { domain, types, values } = AllowanceTransfer.getPermitData(permit, PERMIT2_ADDRESS, 1)
+
+              const signature = await alice._signTypedData(domain, types, values)
+
+              // Trade of this size almost always results in splits.
+              const quoteReq: QuoteQueryParams = {
+                tokenInAddress: 'USDC',
+                tokenInChainId: 1,
+                tokenOutAddress: 'ETH',
+                tokenOutChainId: 1,
+                amount,
+                type,
+                recipient: alice.address,
+                slippageTolerance: LARGE_SLIPPAGE,
+                deadline: '360',
+                algorithm,
+                permitSignature: signature,
+                permitAmount: permit.details.amount.toString(),
+                permitExpiration: permit.details.expiration.toString(),
+                permitSigDeadline: permit.sigDeadline.toString(),
+                permitNonce: permit.details.nonce.toString(),
+                enableUniversalRouter: true,
+                protocols: ALL_PROTOCOLS,
+              }
+
+              const queryParams = qs.stringify(quoteReq)
+
+              const response = await axios.get<QuoteResponse>(`${API}?${queryParams}`, { headers: HEADERS_2_0 })
+              const { data, status } = response
+
+              expect(status).to.equal(200)
+              expect(data.methodParameters).to.not.be.undefined
+              expect(data.route).to.not.be.undefined
+
+              const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
+                data.methodParameters!,
+                USDC_MAINNET,
+                Ether.onChain(1),
+                true
+              )
+
+              if (type == 'exactIn') {
+                expect(tokenInBefore.subtract(tokenInAfter).toExact()).to.equal('1000000')
+                checkQuoteToken(
+                  tokenOutBefore,
+                  tokenOutAfter,
+                  CurrencyAmount.fromRawAmount(Ether.onChain(1), data.quote)
+                )
+              } else {
+                // Hard to test ETH balance due to gas costs for approval and swap. Just check tokenIn changes
+                checkQuoteToken(tokenInBefore, tokenInAfter, CurrencyAmount.fromRawAmount(USDC_MAINNET, data.quote))
+              }
+
+              // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
+              // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
+              // if it's exactOut quote, we should always hit the cached routes.
+              // this is regardless of protocol version.
+              // the reason is because exact in quote always runs before exact out
+              // along with the native or wrapped native pool token address assertions previously
+              // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
+              // and native for v4 pool routes
+              expect(response.data.hitsCachedRoutes).to.equal(true)
             })
 
             it(`eth -> erc20`, async () => {
@@ -2252,10 +830,9 @@ describe('quote', function () {
                     : await getAmount(1, type, 'ETH', 'UNI', '10000'),
                 type,
                 recipient: alice.address,
-                slippageTolerance: type == 'exactOut' ? LARGE_SLIPPAGE : SLIPPAGE, // for exact out somehow the liquidation wasn't sufficient, hence higher slippage
+                slippageTolerance: SLIPPAGE,
                 deadline: '360',
                 algorithm,
-                simulateFromAddress: '0x0716a17FBAeE714f1E6aB0f9d59edbC5f09815C0',
                 enableUniversalRouter: true,
                 protocols: ALL_PROTOCOLS,
               }
@@ -2264,8 +841,8 @@ describe('quote', function () {
 
               const response = await axios.get<QuoteResponse>(`${API}?${queryParams}`, { headers: HEADERS_2_0 })
               const { data, status } = response
+
               expect(status).to.equal(200)
-              expect(data.simulationError).to.equal(false)
               expect(data.methodParameters).to.not.be.undefined
 
               const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
@@ -2291,7 +868,7 @@ describe('quote', function () {
               // along with the native or wrapped native pool token address assertions previously
               // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
               // and native for v4 pool routes
-              expect(response.data.hitsCachedRoutes).to.be.true
+              expect(response.data.hitsCachedRoutes).to.equal(true)
             })
 
             it(`eth -> erc20 swaprouter02`, async () => {
@@ -2306,20 +883,21 @@ describe('quote', function () {
                     : await getAmount(1, type, 'ETH', 'UNI', '10000'),
                 type,
                 recipient: alice.address,
-                slippageTolerance: type == 'exactOut' ? LARGE_SLIPPAGE : SLIPPAGE, // for exact out somehow the liquidation wasn't sufficient, hence higher slippage,
+                slippageTolerance: type == 'exactOut' ? LARGE_SLIPPAGE : SLIPPAGE,
                 deadline: '360',
                 algorithm,
-                simulateFromAddress: '0x00000000219ab540356cBB839Cbe05303d7705Fa',
                 enableUniversalRouter: false,
                 protocols: ALL_PROTOCOLS,
               }
 
               const queryParams = qs.stringify(quoteReq)
 
-              const response = await axios.get<QuoteResponse>(`${API}?${queryParams}`, { headers: HEADERS_1_2 })
+              const response = await axios.get<QuoteResponse>(`${API}?${queryParams}`, { headers: HEADERS_2_0 })
               const { data, status } = response
+
               expect(status).to.equal(200)
               expect(data.methodParameters).to.not.be.undefined
+              expect(data.methodParameters?.to).to.equal(SWAP_ROUTER_02_ADDRESSES(ChainId.MAINNET))
 
               const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
                 data.methodParameters!,
@@ -2331,7 +909,6 @@ describe('quote', function () {
                 // We've swapped 10 ETH + gas costs
                 expect(tokenInBefore.subtract(tokenInAfter).greaterThan(parseAmount('10', Ether.onChain(1)))).to.be.true
                 checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(UNI_MAINNET, data.quote))
-                expect(data.simulationError).to.equal(false)
               } else {
                 checkAbsoluteDifference(tokenOutAfter.subtract(tokenOutBefore).toExact(), '10000', 0.0001)
                 // Can't easily check slippage for ETH due to gas costs effecting ETH balance.
@@ -2345,7 +922,7 @@ describe('quote', function () {
               // along with the native or wrapped native pool token address assertions previously
               // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
               // and native for v4 pool routes
-              expect(response.data.hitsCachedRoutes).to.be.true
+              expect(response.data.hitsCachedRoutes).to.equal(true)
             })
 
             it(`weth -> erc20`, async () => {
@@ -2360,7 +937,6 @@ describe('quote', function () {
                 slippageTolerance: SLIPPAGE,
                 deadline: '360',
                 algorithm,
-                simulateFromAddress: '0xf04a5cc80b1e94c69b48f5ee68a08cd2f09a7c3e',
                 enableUniversalRouter: true,
                 protocols: ALL_PROTOCOLS,
               }
@@ -2369,8 +945,8 @@ describe('quote', function () {
 
               const response = await axios.get<QuoteResponse>(`${API}?${queryParams}`, { headers: HEADERS_2_0 })
               const { data, status } = response
+
               expect(status).to.equal(200)
-              expect(data.simulationError).to.equal(false)
               expect(data.methodParameters).to.not.be.undefined
 
               const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
@@ -2395,7 +971,7 @@ describe('quote', function () {
               // along with the native or wrapped native pool token address assertions previously
               // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
               // and native for v4 pool routes
-              expect(response.data.hitsCachedRoutes).to.be.true
+              expect(response.data.hitsCachedRoutes).to.equal(true)
             })
 
             it(`erc20 -> weth`, async () => {
@@ -2410,7 +986,6 @@ describe('quote', function () {
                 slippageTolerance: SLIPPAGE,
                 deadline: '360',
                 algorithm,
-                simulateFromAddress: '0xf584f8728b874a6a5c7a8d4d387c9aae9172d621',
                 enableUniversalRouter: true,
                 protocols: ALL_PROTOCOLS,
               }
@@ -2419,8 +994,8 @@ describe('quote', function () {
 
               const response = await axios.get<QuoteResponse>(`${API}?${queryParams}`, { headers: HEADERS_2_0 })
               const { data, status } = response
+
               expect(status).to.equal(200)
-              expect(data.simulationError).to.equal(false)
               expect(data.methodParameters).to.not.be.undefined
 
               const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
@@ -2445,505 +1020,1863 @@ describe('quote', function () {
               // along with the native or wrapped native pool token address assertions previously
               // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
               // and native for v4 pool routes
-              expect(response.data.hitsCachedRoutes).to.be.true
+              expect(response.data.hitsCachedRoutes).to.equal(true)
             })
 
-            const uraRefactorInterimState = ['before', 'after']
-            GREENLIST_TOKEN_PAIRS.forEach(([tokenIn, tokenOut]) => {
-              uraRefactorInterimState.forEach((state) => {
-                it(`${tokenIn.symbol} -> ${tokenOut.symbol} with portion, state = ${state}`, async () => {
-                  const originalAmount = getTestAmount(type === 'exactIn' ? tokenIn : tokenOut)
-                  const tokenInSymbol = tokenIn.symbol!
-                  const tokenOutSymbol = tokenOut.symbol!
-                  const tokenInAddress = tokenIn.isNative ? tokenInSymbol : tokenIn.address
-                  const tokenOutAddress = tokenOut.isNative ? tokenOutSymbol : tokenOut.address
-                  const amount = await getAmountFromToken(type, tokenIn.wrapped, tokenOut.wrapped, originalAmount)
+            it(`eth -> usdc v4 only protocol`, async () => {
+              const quoteReq: QuoteQueryParams = {
+                tokenInAddress: 'ETH',
+                tokenInChainId: 1,
+                tokenOutAddress: 'USDC',
+                tokenOutChainId: 1,
+                amount: await getAmount(1, type, 'ETH', 'USDC', type == 'exactIn' ? '0.00001' : '0.1'),
+                type,
+                recipient: alice.address,
+                slippageTolerance: LARGE_SLIPPAGE,
+                deadline: '360',
+                algorithm,
+                protocols: 'v4',
+                enableUniversalRouter: true,
+              }
 
-                  // we need to simulate URA before and after merging https://github.com/Uniswap/unified-routing-api/pull/282 interim states
-                  // to ensure routing-api is backward compatible with URA
-                  let portionBips = undefined
-                  if (state === 'before' && type === 'exactIn') {
-                    portionBips = FLAT_PORTION.bips
-                  } else if (state === 'after') {
-                    portionBips = FLAT_PORTION.bips
-                  }
-                  let portionAmount = undefined
-                  if (state === 'before' && type === 'exactOut') {
-                    portionAmount = CurrencyAmount.fromRawAmount(tokenOut, amount)
-                      .multiply(new Fraction(FLAT_PORTION.bips, 10_000))
-                      .quotient.toString()
-                  } else if (state === 'after') {
-                    // after URA merges https://github.com/Uniswap/unified-routing-api/pull/282,
-                    // it no longer sends portionAmount
-                    portionAmount = undefined
-                  }
+              const queryParams = qs.stringify(quoteReq)
 
+              const response = await axios.get<QuoteResponse>(`${API}?${queryParams}`, { headers: HEADERS_2_0 })
+              const { data, status } = response
+
+              expect(status).to.equal(200)
+              expect(data.methodParameters).to.not.be.undefined
+              expect(data.route).to.not.be.undefined
+
+              // Verify only v4 pools are used
+              for (const r of data.route) {
+                for (const pool of r) {
+                  expect(pool.type).to.equal('v4-pool')
+                }
+              }
+
+              const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
+                data.methodParameters!,
+                Ether.onChain(1),
+                USDC_MAINNET
+              )
+
+              if (type == 'exactIn') {
+                expect(tokenInBefore.subtract(tokenInAfter).greaterThan(parseAmount('0.00001', Ether.onChain(1)))).to.be
+                  .true
+                checkQuoteToken(
+                  tokenOutBefore,
+                  tokenOutAfter,
+                  CurrencyAmount.fromRawAmount(USDC_MAINNET, data.quote),
+                  LARGE_SLIPPAGE
+                )
+              } else {
+                expect(tokenOutAfter.subtract(tokenOutBefore).toExact()).to.equal('0.1')
+              }
+
+              expect(response.data.hitsCachedRoutes).to.be.false
+            })
+
+            it(`eth -> usdc v4 include (v2,v3,v4)`, async () => {
+              const quoteReq: QuoteQueryParams = {
+                tokenInAddress: 'ETH',
+                tokenInChainId: 1,
+                tokenOutAddress: 'USDC',
+                tokenOutChainId: 1,
+                // Reducing amount as v4 ETH/USDC pool with very low liquidity might be selected, and liquidity changes often
+                amount: await getAmount(1, type, 'ETH', 'USDC', type == 'exactIn' ? '0.00001' : '0.1'),
+                type,
+                recipient: alice.address,
+                slippageTolerance: LARGE_SLIPPAGE,
+                deadline: '360',
+                algorithm,
+                protocols: ALL_PROTOCOLS,
+                enableUniversalRouter: true,
+              }
+
+              const queryParams = qs.stringify(quoteReq)
+
+              const response = await axios.get<QuoteResponse>(`${API}?${queryParams}`, { headers: HEADERS_2_0 })
+              const { data, status } = response
+
+              expect(status).to.equal(200)
+              expect(data.methodParameters).to.not.be.undefined
+              expect(data.route).to.not.be.undefined
+
+              const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
+                data.methodParameters!,
+                Ether.onChain(1),
+                USDC_MAINNET
+              )
+
+              if (type == 'exactIn') {
+                expect(tokenInBefore.subtract(tokenInAfter).greaterThan(parseAmount('0.00001', Ether.onChain(1)))).to.be
+                  .true
+                checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(USDC_MAINNET, data.quote))
+              } else {
+                expect(tokenOutAfter.subtract(tokenOutBefore).toExact()).to.equal('0.1')
+              }
+
+              expect(response.data.hitsCachedRoutes).to.equal(true)
+            })
+
+            it(`weth -> usdc v4 only protocol`, async () => {
+              const quoteReq: QuoteQueryParams = {
+                tokenInAddress: 'WETH',
+                tokenInChainId: 1,
+                tokenOutAddress: 'USDC',
+                tokenOutChainId: 1,
+                amount: await getAmount(1, type, 'WETH', 'USDC', type == 'exactIn' ? '0.00001' : '0.01'),
+                type,
+                recipient: alice.address,
+                slippageTolerance: LARGE_SLIPPAGE,
+                deadline: '360',
+                algorithm,
+                protocols: 'v4',
+                enableUniversalRouter: true,
+              }
+
+              const queryParams = qs.stringify(quoteReq)
+
+              const response = await axios.get<QuoteResponse>(`${API}?${queryParams}`, { headers: HEADERS_2_0 })
+              const { data, status } = response
+
+              expect(status).to.equal(200)
+              expect(data.methodParameters).to.not.be.undefined
+              expect(data.route).to.not.be.undefined
+
+              // Verify only v4 pools are used
+              for (const r of data.route) {
+                for (const pool of r) {
+                  expect(pool.type).to.equal('v4-pool')
+                }
+              }
+
+              const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
+                data.methodParameters!,
+                WETH9[1]!,
+                USDC_MAINNET
+              )
+
+              if (type == 'exactIn') {
+                expect(tokenInBefore.subtract(tokenInAfter).toExact()).to.equal('0.00001')
+                checkQuoteToken(
+                  tokenOutBefore,
+                  tokenOutAfter,
+                  CurrencyAmount.fromRawAmount(USDC_MAINNET, data.quote),
+                  LARGE_SLIPPAGE
+                )
+              } else {
+                expect(tokenOutAfter.subtract(tokenOutBefore).toExact()).to.equal('0.01')
+                checkQuoteToken(
+                  tokenInBefore,
+                  tokenInAfter,
+                  CurrencyAmount.fromRawAmount(WETH9[1]!, data.quote),
+                  LARGE_SLIPPAGE
+                )
+              }
+
+              expect(response.data.hitsCachedRoutes).to.be.false
+            })
+
+            it(`weth -> usdc v4 include (v2,v3,v4)`, async () => {
+              const quoteReq: QuoteQueryParams = {
+                tokenInAddress: 'WETH',
+                tokenInChainId: 1,
+                tokenOutAddress: 'USDC',
+                tokenOutChainId: 1,
+                amount: await getAmount(1, type, 'WETH', 'USDC', type == 'exactIn' ? '0.1' : '100'),
+                type,
+                recipient: alice.address,
+                slippageTolerance: LARGE_SLIPPAGE,
+                deadline: '360',
+                algorithm,
+                protocols: ALL_PROTOCOLS,
+                enableUniversalRouter: true,
+              }
+
+              const queryParams = qs.stringify(quoteReq)
+
+              const response = await axios.get<QuoteResponse>(`${API}?${queryParams}`, { headers: HEADERS_2_0 })
+              const { data, status } = response
+
+              expect(status).to.equal(200)
+              expect(data.methodParameters).to.not.be.undefined
+              expect(data.route).to.not.be.undefined
+
+              const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
+                data.methodParameters!,
+                WETH9[1]!,
+                USDC_MAINNET
+              )
+
+              if (type == 'exactIn') {
+                expect(tokenInBefore.subtract(tokenInAfter).toExact()).to.equal('0.1')
+                checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(USDC_MAINNET, data.quote))
+              } else {
+                expect(tokenOutAfter.subtract(tokenOutBefore).toExact()).to.equal('100')
+                checkQuoteToken(tokenInBefore, tokenInAfter, CurrencyAmount.fromRawAmount(WETH9[1]!, data.quote))
+              }
+
+              expect(response.data.hitsCachedRoutes).to.equal(true)
+            })
+
+            if (algorithm == 'alpha') {
+              it(`erc20 -> erc20 v3 only`, async () => {
+                const quoteReq: QuoteQueryParams = {
+                  tokenInAddress: 'USDC',
+                  tokenInChainId: 1,
+                  tokenOutAddress: 'USDT',
+                  tokenOutChainId: 1,
+                  amount: await getAmount(1, type, 'USDC', 'USDT', '100'),
+                  type,
+                  recipient: alice.address,
+                  slippageTolerance: SLIPPAGE,
+                  deadline: '360',
+                  algorithm: 'alpha',
+                  protocols: 'v3',
+                  enableUniversalRouter: true,
+                }
+
+                const queryParams = qs.stringify(quoteReq)
+
+                const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(`${API}?${queryParams}`, {
+                  headers: HEADERS_2_0,
+                })
+                const {
+                  data: { quote, quoteDecimals, quoteGasAdjustedDecimals, methodParameters, route },
+                  status,
+                } = response
+
+                expect(status).to.equal(200)
+                expect(parseFloat(quoteDecimals)).to.be.greaterThan(90)
+                expect(parseFloat(quoteDecimals)).to.be.lessThan(110)
+
+                if (type == 'exactIn') {
+                  expect(parseFloat(quoteGasAdjustedDecimals)).to.be.lessThanOrEqual(parseFloat(quoteDecimals))
+                } else {
+                  expect(parseFloat(quoteGasAdjustedDecimals)).to.be.greaterThanOrEqual(parseFloat(quoteDecimals))
+                }
+
+                expect(methodParameters).to.not.be.undefined
+
+                for (const r of route) {
+                  for (const pool of r) {
+                    expect(pool.type).to.equal('v3-pool')
+                  }
+                }
+
+                const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
+                  response.data.methodParameters!,
+                  USDC_MAINNET,
+                  USDT_MAINNET!
+                )
+
+                if (type == 'exactIn') {
+                  expect(tokenInBefore.subtract(tokenInAfter).toExact()).to.equal('100')
+                  checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(USDT_MAINNET, quote))
+                } else {
+                  expect(tokenOutAfter.subtract(tokenOutBefore).toExact()).to.equal('100')
+                  checkQuoteToken(tokenInBefore, tokenInAfter, CurrencyAmount.fromRawAmount(USDC_MAINNET, quote))
+                }
+
+                // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
+                // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
+                // if it's exactOut quote, we should always hit the cached routes.
+                // this is regardless of protocol version.
+                // the reason is because exact in quote always runs before exact out
+                // along with the native or wrapped native pool token address assertions previously
+                // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
+                // and native for v4 pool routes
+                expect(response.data.hitsCachedRoutes).to.be.false
+              })
+
+              it(`erc20 -> erc20 v2 only`, async () => {
+                const quoteReq: QuoteQueryParams = {
+                  tokenInAddress: 'USDC',
+                  tokenInChainId: 1,
+                  tokenOutAddress: 'USDT',
+                  tokenOutChainId: 1,
+                  amount: await getAmount(1, type, 'USDC', 'USDT', '100'),
+                  type,
+                  recipient: alice.address,
+                  slippageTolerance: SLIPPAGE,
+                  deadline: '360',
+                  algorithm: 'alpha',
+                  protocols: 'v2',
+                  enableUniversalRouter: true,
+                }
+
+                const queryParams = qs.stringify(quoteReq)
+
+                const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(`${API}?${queryParams}`, {
+                  headers: HEADERS_2_0,
+                })
+                const {
+                  data: { quote, quoteDecimals, quoteGasAdjustedDecimals, methodParameters, route },
+                  status,
+                } = response
+
+                expect(status).to.equal(200)
+                expect(parseFloat(quoteDecimals)).to.be.greaterThan(90)
+                expect(parseFloat(quoteDecimals)).to.be.lessThan(110)
+
+                if (type == 'exactIn') {
+                  expect(parseFloat(quoteGasAdjustedDecimals)).to.be.lessThanOrEqual(parseFloat(quoteDecimals))
+                } else {
+                  expect(parseFloat(quoteGasAdjustedDecimals)).to.be.greaterThanOrEqual(parseFloat(quoteDecimals))
+                }
+
+                expect(methodParameters).to.not.be.undefined
+
+                for (const r of route) {
+                  for (const pool of r) {
+                    expect(pool.type).to.equal('v2-pool')
+                  }
+                }
+
+                const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
+                  response.data.methodParameters!,
+                  USDC_MAINNET,
+                  USDT_MAINNET!
+                )
+
+                if (type == 'exactIn') {
+                  expect(tokenInBefore.subtract(tokenInAfter).toExact()).to.equal('100')
+                  checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(USDT_MAINNET, quote))
+                } else {
+                  expect(tokenOutAfter.subtract(tokenOutBefore).toExact()).to.equal('100')
+                  checkQuoteToken(tokenInBefore, tokenInAfter, CurrencyAmount.fromRawAmount(USDC_MAINNET, quote))
+                }
+
+                // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
+                // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
+                // if it's exactOut quote, we should always hit the cached routes.
+                // this is regardless of protocol version.
+                // the reason is because exact in quote always runs before exact out
+                // along with the native or wrapped native pool token address assertions previously
+                // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
+                // and native for v4 pool routes
+                expect(response.data.hitsCachedRoutes).to.be.false
+              })
+
+              it(`erc20 -> erc20 forceCrossProtocol`, async () => {
+                const quoteReq: QuoteQueryParams = {
+                  tokenInAddress: 'USDC',
+                  tokenInChainId: 1,
+                  tokenOutAddress: 'USDT',
+                  tokenOutChainId: 1,
+                  amount: await getAmount(1, type, 'USDC', 'USDT', '100'),
+                  type,
+                  recipient: alice.address,
+                  slippageTolerance: SLIPPAGE,
+                  deadline: '360',
+                  algorithm: 'alpha',
+                  forceCrossProtocol: true,
+                  enableUniversalRouter: true,
+                  protocols: ALL_PROTOCOLS,
+                }
+
+                const queryParams = qs.stringify(quoteReq)
+
+                const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(`${API}?${queryParams}`, {
+                  headers: HEADERS_2_0,
+                })
+                const {
+                  data: { quote, quoteDecimals, quoteGasAdjustedDecimals, methodParameters, route },
+                  status,
+                } = response
+
+                expect(status).to.equal(200)
+                expect(parseFloat(quoteDecimals)).to.be.greaterThan(90)
+                expect(parseFloat(quoteDecimals)).to.be.lessThan(110)
+
+                if (type == 'exactIn') {
+                  expect(parseFloat(quoteGasAdjustedDecimals)).to.be.lessThanOrEqual(parseFloat(quoteDecimals))
+                } else {
+                  expect(parseFloat(quoteGasAdjustedDecimals)).to.be.greaterThanOrEqual(parseFloat(quoteDecimals))
+                }
+
+                expect(methodParameters).to.not.be.undefined
+
+                let hasV3Pool = false
+                let hasV2Pool = false
+                for (const r of route) {
+                  for (const pool of r) {
+                    if (pool.type == 'v3-pool') {
+                      hasV3Pool = true
+                    }
+                    if (pool.type == 'v2-pool') {
+                      hasV2Pool = true
+                    }
+                  }
+                }
+
+                expect(hasV3Pool && hasV2Pool).to.be.true
+
+                const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
+                  response.data.methodParameters!,
+                  USDC_MAINNET,
+                  USDT_MAINNET!
+                )
+
+                if (type == 'exactIn') {
+                  expect(tokenInBefore.subtract(tokenInAfter).toExact()).to.equal('100')
+                  checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(USDT_MAINNET, quote))
+                } else {
+                  expect(tokenOutAfter.subtract(tokenOutBefore).toExact()).to.equal('100')
+                  checkQuoteToken(tokenInBefore, tokenInAfter, CurrencyAmount.fromRawAmount(USDC_MAINNET, quote))
+                }
+              })
+
+              /// Tests for routes likely to result in MixedRoutes being returned
+              if (type === 'exactIn') {
+                it.skip(`erc20 -> erc20 forceMixedRoutes not specified for v2,v3 does not return mixed route even when it is better`, async () => {
                   const quoteReq: QuoteQueryParams = {
-                    tokenInAddress: tokenInAddress,
-                    tokenInChainId: tokenIn.chainId,
-                    tokenOutAddress: tokenOutAddress,
-                    tokenOutChainId: tokenOut.chainId,
-                    amount: amount,
-                    type: type,
-                    protocols: ALL_PROTOCOLS,
+                    tokenInAddress: 'BOND',
+                    tokenInChainId: 1,
+                    tokenOutAddress: 'APE',
+                    tokenOutChainId: 1,
+                    amount: await getAmount(1, type, 'BOND', 'APE', '10000'),
+                    type,
                     recipient: alice.address,
                     slippageTolerance: SLIPPAGE,
                     deadline: '360',
-                    algorithm,
+                    algorithm: 'alpha',
+                    protocols: 'v2,v3',
                     enableUniversalRouter: true,
-                    simulateFromAddress: alice.address,
-                    portionBips: portionBips,
-                    portionAmount: portionAmount,
-                    portionRecipient: FLAT_PORTION.recipient,
                   }
 
                   const queryParams = qs.stringify(quoteReq)
 
                   const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(
                     `${API}?${queryParams}`,
-                    { headers: HEADERS_2_0 }
+                    {
+                      headers: HEADERS_2_0,
+                    }
                   )
-                  const { data, status } = response
-                  expect(status).to.equal(200)
-                  expect(data.simulationError).to.equal(false)
-                  expect(data.methodParameters).to.not.be.undefined
-
-                  expect(data.portionRecipient).to.not.be.undefined
-
-                  if (!(state === 'before' && type === 'exactOut')) {
-                    // before URA interim state it doesnt send portionBips to routing-api,
-                    // so routing-api has no way to know the portionBips
-                    expect(data.portionBips).to.not.be.undefined
-                    expect(data.portionBips).to.equal(FLAT_PORTION.bips)
-                  }
-                  expect(data.portionAmount).to.not.be.undefined
-                  expect(data.portionAmountDecimals).to.not.be.undefined
-                  expect(data.quoteGasAndPortionAdjusted).to.not.be.undefined
-                  expect(data.quoteGasAndPortionAdjustedDecimals).to.not.be.undefined
-
-                  expect(data.portionRecipient).to.equal(FLAT_PORTION.recipient)
-
-                  if (type == 'exactIn') {
-                    const allQuotesAcrossRoutes = data.route
-                      .map((routes) =>
-                        routes
-                          .map((route) => route.amountOut)
-                          .map((amountOut) => CurrencyAmount.fromRawAmount(tokenOut, amountOut ?? '0'))
-                          .reduce((cur, total) => total.add(cur), CurrencyAmount.fromRawAmount(tokenOut, '0'))
-                      )
-                      .reduce((cur, total) => total.add(cur), CurrencyAmount.fromRawAmount(tokenOut, '0'))
-
-                    const quote = CurrencyAmount.fromRawAmount(tokenOut, data.quote)
-                    const expectedPortionAmount = quote.multiply(new Fraction(FLAT_PORTION.bips, 10000))
-                    expect(data.portionAmount).to.equal(expectedPortionAmount.quotient.toString())
-
-                    // The most strict way to ensure the output amount from route path is correct with respect to portion
-                    // is to make sure the output amount from route path is exactly portion bps different from the quote
-                    const tokensDiff = quote.subtract(allQuotesAcrossRoutes)
-                    const percentDiff = tokensDiff.asFraction.divide(quote.asFraction)
-                    expect(percentDiff.quotient.toString()).equal(
-                      new Fraction(FLAT_PORTION.bips, 10_000).quotient.toString()
-                    )
-                  } else {
-                    const allQuotesAcrossRoutes = data.route
-                      .map((routes) =>
-                        routes
-                          .map((route) => route.amountOut)
-                          .map((amountOut) => CurrencyAmount.fromRawAmount(tokenIn, amountOut ?? '0'))
-                          .reduce((cur, total) => total.add(cur), CurrencyAmount.fromRawAmount(tokenIn, '0'))
-                      )
-                      .reduce((cur, total) => total.add(cur), CurrencyAmount.fromRawAmount(tokenIn, '0'))
-                    const quote = CurrencyAmount.fromRawAmount(tokenIn, data.quote)
-                    const expectedPortionAmount = CurrencyAmount.fromRawAmount(tokenOut, amount).multiply(
-                      new Fraction(FLAT_PORTION.bips, 10000)
-                    )
-                    expect(data.portionAmount).to.equal(expectedPortionAmount.quotient.toString())
-
-                    // The most strict way to ensure the output amount from route path is correct with respect to portion
-                    // is to make sure the output amount from route path is exactly portion bps different from the quote
-                    const tokensDiff = allQuotesAcrossRoutes.subtract(quote)
-                    const percentDiff = tokensDiff.asFraction.divide(quote.asFraction)
-                    expect(percentDiff.quotient.toString()).equal(
-                      new Fraction(FLAT_PORTION.bips, 10_000).quotient.toString()
-                    )
-                  }
-
                   const {
-                    tokenInBefore,
-                    tokenInAfter,
-                    tokenOutBefore,
-                    tokenOutAfter,
-                    tokenOutPortionRecipientBefore,
-                    tokenOutPortionRecipientAfter,
-                  } = await executeSwap(
-                    data.methodParameters!,
-                    tokenIn,
-                    tokenOut!,
-                    false,
-                    tokenIn.chainId,
-                    FLAT_PORTION
-                  )
+                    data: { quoteDecimals, quoteGasAdjustedDecimals, methodParameters, routeString },
+                    status,
+                  } = response
+
+                  expect(status).to.equal(200)
 
                   if (type == 'exactIn') {
-                    // if the token in is native token, the difference will be slightly larger due to gas. We have no way to know precise gas costs in terms of GWEI * gas units.
-                    if (!tokenIn.isNative) {
-                      expect(tokenInBefore.subtract(tokenInAfter).toExact()).to.equal(originalAmount)
-                    }
-
-                    // if the token out is native token, the difference will be slightly larger due to gas. We have no way to know precise gas costs in terms of GWEI * gas units.
-                    if (!tokenOut.isNative) {
-                      checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(tokenOut, data.quote))
-                    }
-
-                    expect(data.portionAmount).not.to.be.undefined
-
-                    const expectedPortionAmount = CurrencyAmount.fromRawAmount(tokenOut, data.portionAmount!)
-                    checkPortionRecipientToken(
-                      tokenOutPortionRecipientBefore!,
-                      tokenOutPortionRecipientAfter!,
-                      expectedPortionAmount
-                    )
+                    expect(parseFloat(quoteGasAdjustedDecimals)).to.be.lessThanOrEqual(parseFloat(quoteDecimals))
                   } else {
-                    // if the token out is native token, the difference will be slightly larger due to gas. We have no way to know precise gas costs in terms of GWEI * gas units.
-                    if (!tokenOut.isNative) {
-                      expect(tokenOutAfter.subtract(tokenOutBefore).toExact()).to.equal(originalAmount)
-                    }
-
-                    // if the token out is native token, the difference will be slightly larger due to gas. We have no way to know precise gas costs in terms of GWEI * gas units.
-                    if (!tokenIn.isNative) {
-                      checkQuoteToken(tokenInBefore, tokenInAfter, CurrencyAmount.fromRawAmount(tokenIn, data.quote))
-                    }
-
-                    expect(data.portionAmount).not.to.be.undefined
-
-                    const expectedPortionAmount = CurrencyAmount.fromRawAmount(tokenOut, data.portionAmount!)
-                    checkPortionRecipientToken(
-                      tokenOutPortionRecipientBefore!,
-                      tokenOutPortionRecipientAfter!,
-                      expectedPortionAmount
-                    )
+                    expect(parseFloat(quoteGasAdjustedDecimals)).to.be.greaterThanOrEqual(parseFloat(quoteDecimals))
                   }
 
-                  // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
-                  // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
-                  // if it's exactOut quote, we should always hit the cached routes.
-                  // this is regardless of protocol version.
-                  // the reason is because exact in quote always runs before exact out
-                  // along with the native or wrapped native pool token address assertions previously
-                  // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
-                  // and native for v4 pool routes
-                  expect(response.data.hitsCachedRoutes).to.be.true
+                  expect(methodParameters).to.not.be.undefined
+
+                  expect(!routeString.includes('[V2 + V3]'))
                 })
+
+                it(`erc20 -> erc20 forceMixedRoutes true for v2,v3`, async () => {
+                  const quoteReq: QuoteQueryParams = {
+                    tokenInAddress: 'BOND',
+                    tokenInChainId: 1,
+                    tokenOutAddress: 'APE',
+                    tokenOutChainId: 1,
+                    amount: await getAmount(1, type, 'BOND', 'APE', '10000'),
+                    type,
+                    recipient: alice.address,
+                    slippageTolerance: SLIPPAGE,
+                    deadline: '360',
+                    algorithm: 'alpha',
+                    forceMixedRoutes: true,
+                    protocols: 'v2,v3',
+                    enableUniversalRouter: true,
+                  }
+
+                  await callAndExpectFail(quoteReq, {
+                    status: 404,
+                    data: {
+                      detail: 'No route found',
+                      errorCode: 'NO_ROUTE',
+                    },
+                  })
+                })
+
+                it('USDC -> mockA forceMixedRoutes true for mixed protocol on Base with request source', async () => {
+                  if (type != 'exactIn') {
+                    // mixed route only works for exactIn
+                    return
+                  }
+
+                  const quoteReq: QuoteQueryParams = {
+                    tokenInAddress: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+                    tokenInChainId: 8453,
+                    tokenOutAddress: '0x878784f7ebf6e57d17c81d82ddf53f117a5e2988',
+                    tokenOutChainId: 8453,
+                    amount: '1000000',
+                    type,
+                    recipient: alice.address,
+                    slippageTolerance: SLIPPAGE,
+                    deadline: '360',
+                    algorithm: 'alpha',
+                    forceMixedRoutes: true,
+                    protocols: 'mixed',
+                    enableUniversalRouter: true,
+                  }
+
+                  const queryParams = qs.stringify(quoteReq)
+
+                  const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(
+                    `${API}?${queryParams}`,
+                    {
+                      headers: {
+                        ...HEADERS_2_0,
+                        'x-request-source': 'e2e-test',
+                      },
+                    }
+                  )
+                  const {
+                    data: { quoteDecimals, quoteGasAdjustedDecimals, methodParameters, routeString },
+                    status,
+                  } = response
+
+                  expect(status).to.equal(200)
+                  expect(parseFloat(quoteGasAdjustedDecimals)).to.be.lessThanOrEqual(parseFloat(quoteDecimals))
+                  expect(methodParameters).to.not.be.undefined
+
+                  /// since we only get the routeString back, we can check if there's V3 + V2
+                  expect(routeString.includes('[V2 + V3 + V4]'))
+                })
+
+                it('USDC -> mockA forceMixedRoutes true for mixed protocol on Base no request source', async () => {
+                  if (type != 'exactIn') {
+                    // mixed route only works for exactIn
+                    return
+                  }
+
+                  const quoteReq: QuoteQueryParams = {
+                    tokenInAddress: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+                    tokenInChainId: 8453,
+                    tokenOutAddress: '0x878784f7ebf6e57d17c81d82ddf53f117a5e2988',
+                    tokenOutChainId: 8453,
+                    amount: '1000000',
+                    type,
+                    recipient: alice.address,
+                    slippageTolerance: SLIPPAGE,
+                    deadline: '360',
+                    algorithm: 'alpha',
+                    forceMixedRoutes: true,
+                    protocols: 'mixed',
+                    enableUniversalRouter: true,
+                  }
+
+                  const queryParams = qs.stringify(quoteReq)
+
+                  try {
+                    await axios.get<QuoteResponse>(`${API}?${queryParams}`, {
+                      headers: HEADERS_2_0,
+                    })
+                  } catch (err) {
+                    if (err instanceof Error) {
+                      expect(err.message).to.contains('404')
+                    }
+                  }
+                })
+
+                it.skip(`erc20 -> erc20 forceMixedRoutes true for all protocols specified`, async () => {
+                  const quoteReq: QuoteQueryParams = {
+                    tokenInAddress: 'BOND',
+                    tokenInChainId: 1,
+                    tokenOutAddress: 'APE',
+                    tokenOutChainId: 1,
+                    amount: await getAmount(1, type, 'BOND', 'APE', '10000'),
+                    type,
+                    recipient: alice.address,
+                    slippageTolerance: SLIPPAGE,
+                    deadline: '360',
+                    algorithm: 'alpha',
+                    forceMixedRoutes: true,
+                    protocols: 'v2,v3,mixed',
+                    enableUniversalRouter: true,
+                  }
+
+                  const queryParams = qs.stringify(quoteReq)
+
+                  const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(
+                    `${API}?${queryParams}`,
+                    {
+                      headers: HEADERS_2_0,
+                    }
+                  )
+                  const {
+                    data: { quoteDecimals, quoteGasAdjustedDecimals, methodParameters, routeString },
+                    status,
+                  } = response
+
+                  expect(status).to.equal(200)
+
+                  if (type == 'exactIn') {
+                    expect(parseFloat(quoteGasAdjustedDecimals)).to.be.lessThanOrEqual(parseFloat(quoteDecimals))
+                  } else {
+                    expect(parseFloat(quoteGasAdjustedDecimals)).to.be.greaterThanOrEqual(parseFloat(quoteDecimals))
+                  }
+
+                  expect(methodParameters).to.not.be.undefined
+
+                  /// since we only get the routeString back, we can check if there's V3 + V2
+                  expect(routeString.includes('[V2 + V3]'))
+                })
+              }
+
+              // FOT swap only works for exact in
+              if (type === 'exactIn') {
+                const tokenInAndTokenOut = [
+                  [BULLET, WETH9[ChainId.MAINNET]!],
+                  [WETH9[ChainId.MAINNET]!, BULLET],
+                  // TODO: re-enable - DFNDR FOT test is flaky right now, disabling to unblock pipeline
+                  // [WETH9[ChainId.MAINNET]!, DFNDR],
+                ]
+
+                tokenInAndTokenOut.forEach(([tokenIn, tokenOut]) => {
+                  // If this test fails sporadically, dev needs to investigate further
+                  // There could be genuine regressions in the form of race condition, due to complex layers of caching
+                  // See https://github.com/Uniswap/smart-order-router/pull/415#issue-1914604864 as an example race condition
+                  it(`fee-on-transfer ${tokenIn.symbol} -> ${tokenOut.symbol}`, async () => {
+                    const enableFeeOnTransferFeeFetching = [true, false, undefined]
+                    // we want to swap the tokenIn/tokenOut order so that we can test both sellFeeBps and buyFeeBps for exactIn vs exactOut
+                    const originalAmount = tokenIn.equals(WETH9[ChainId.MAINNET]!) ? '10' : '2924'
+                    const amount = await getAmountFromToken(type, tokenIn, tokenOut, originalAmount)
+
+                    // Parallelize the FOT quote requests, because we notice there might be tricky race condition that could cause quote to not include FOT tax
+                    const responses = await Promise.all(
+                      enableFeeOnTransferFeeFetching.map(async (enableFeeOnTransferFeeFetching) => {
+                        if (enableFeeOnTransferFeeFetching) {
+                          // if it's FOT flag enabled request, we delay it so that it's more likely to repro the race condition in
+                          // https://github.com/Uniswap/smart-order-router/pull/415#issue-1914604864
+                          await new Promise((f) => setTimeout(f, 1000))
+                        }
+                        const simulateFromAddress = tokenIn.equals(WETH9[ChainId.MAINNET]!)
+                          ? '0x6B44ba0a126a2A1a8aa6cD1AdeeD002e141Bcd44'
+                          : '0x171d311eAcd2206d21Cb462d661C33F0eddadC03'
+                        const quoteReq: QuoteQueryParams = {
+                          tokenInAddress: tokenIn.address,
+                          tokenInChainId: tokenIn.chainId,
+                          tokenOutAddress: tokenOut.address,
+                          tokenOutChainId: tokenOut.chainId,
+                          amount: amount,
+                          type: type,
+                          protocols: 'v2,v3,mixed',
+                          // TODO: ROUTE-86 remove enableFeeOnTransferFeeFetching once we are ready to enable this by default
+                          enableFeeOnTransferFeeFetching: enableFeeOnTransferFeeFetching,
+                          recipient: alice.address,
+                          // we have to use large slippage for FOT swap, because routing-api always forks at the latest block,
+                          // and the FOT swap can have large slippage, despite SOR already subtracted FOT tax
+                          slippageTolerance: LARGE_SLIPPAGE,
+                          deadline: '360',
+                          algorithm,
+                          enableUniversalRouter: true,
+                          // if fee-on-transfer flag is not enabled, most likely the simulation will fail due to quote not subtracting the tax
+                          simulateFromAddress: enableFeeOnTransferFeeFetching ? simulateFromAddress : undefined,
+                          portionBips: FLAT_PORTION.bips,
+                          portionRecipient: FLAT_PORTION.recipient,
+                        }
+
+                        const queryParams = qs.stringify(quoteReq)
+
+                        const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(
+                          `${API}?${queryParams}`,
+                          { headers: HEADERS_2_0 }
+                        )
+
+                        // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
+                        // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
+                        // if it's exactOut quote, we should always hit the cached routes.
+                        // this is regardless of protocol version.
+                        // the reason is because exact in quote always runs before exact out
+                        // along with the native or wrapped native pool token address assertions previously
+                        // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
+                        // and native for v4 pool routes
+                        expect(response.data.hitsCachedRoutes).to.equal(true)
+
+                        return { enableFeeOnTransferFeeFetching, ...response }
+                      })
+                    )
+
+                    const quoteWithFlagOn = responses.find((r) => r.enableFeeOnTransferFeeFetching === true)
+                    expect(quoteWithFlagOn).not.to.be.undefined
+
+                    // TODO: flaky assertions, re-enable after fixing (probably real prod issue due to flaky GQL data)
+                    // // in case of FOT token that should not take a portion/fee, we assert that all portion fields are undefined
+                    // if (!tokenOut?.equals(WETH9[ChainId.MAINNET])) {
+                    //   expect(quoteWithFlagOn!.data.portionAmount).to.be.undefined
+                    //   expect(quoteWithFlagOn!.data.portionBips).to.be.undefined
+                    //   expect(quoteWithFlagOn!.data.portionRecipient).to.be.undefined
+                    // } else {
+                    //   expect(quoteWithFlagOn!.data.portionAmount).to.be.not.undefined
+                    //   expect(quoteWithFlagOn!.data.portionBips).to.be.not.undefined
+                    //   expect(quoteWithFlagOn!.data.portionRecipient).to.be.not.undefined
+                    // }
+
+                    responses
+                      .filter((r) => r.enableFeeOnTransferFeeFetching !== true)
+                      .forEach((r) => {
+                        if (type === 'exactIn') {
+                          const quote = CurrencyAmount.fromRawAmount(tokenOut, r.data.quote)
+                          const quoteWithFlagon = CurrencyAmount.fromRawAmount(tokenOut, quoteWithFlagOn!.data.quote)
+
+                          // quote without fot flag must be greater than the quote with fot flag
+                          // this is to catch https://github.com/Uniswap/smart-order-router/pull/421
+                          expect(quote.greaterThan(quoteWithFlagon)).to.be.true
+
+                          // below is additional assertion to ensure the quote without fot tax vs quote with tax should be very roughly equal to the fot sell/buy tax rate
+                          const tokensDiff = quote.subtract(quoteWithFlagon)
+                          const percentDiff = tokensDiff.asFraction.divide(quote.asFraction)
+                          if (tokenIn?.equals(BULLET)) {
+                            expect(percentDiff.toFixed(3, undefined, Rounding.ROUND_HALF_UP)).equal(
+                              new Fraction(BigNumber.from(BULLET_WHT_TAX.sellFeeBps ?? 0).toString(), 10_000).toFixed(3)
+                            )
+                          } else if (tokenOut?.equals(BULLET)) {
+                            expect(percentDiff.toFixed(3, undefined, Rounding.ROUND_HALF_UP)).equal(
+                              new Fraction(BigNumber.from(BULLET_WHT_TAX.buyFeeBps ?? 0).toString(), 10_000).toFixed(3)
+                            )
+                          }
+                        }
+                      })
+
+                    for (const response of responses) {
+                      const {
+                        enableFeeOnTransferFeeFetching,
+                        data: {
+                          quote,
+                          quoteDecimals,
+                          quoteGasAdjustedDecimals,
+                          methodParameters,
+                          route,
+                          simulationStatus,
+                          simulationError,
+                        },
+                        status,
+                      } = response
+
+                      expect(status).to.equal(200)
+
+                      if (type == 'exactIn') {
+                        expect(parseFloat(quoteGasAdjustedDecimals)).to.be.lessThanOrEqual(parseFloat(quoteDecimals))
+                      } else {
+                        expect(parseFloat(quoteGasAdjustedDecimals)).to.be.greaterThanOrEqual(parseFloat(quoteDecimals))
+                      }
+
+                      let hasV3Pool = false
+                      let hasV2Pool = false
+                      for (const r of route) {
+                        for (const pool of r) {
+                          if (pool.type == 'v3-pool') {
+                            hasV3Pool = true
+                          }
+                          if (pool.type == 'v2-pool') {
+                            hasV2Pool = true
+                            if (enableFeeOnTransferFeeFetching) {
+                              if (pool.tokenIn.address === BULLET.address) {
+                                expect(pool.tokenIn.sellFeeBps).to.be.not.undefined
+                                expect(pool.tokenIn.sellFeeBps).to.be.equals(BULLET_WHT_TAX.sellFeeBps?.toString())
+                                expect(pool.tokenIn.buyFeeBps).to.be.not.undefined
+                                expect(pool.tokenIn.buyFeeBps).to.be.equals(BULLET_WHT_TAX.buyFeeBps?.toString())
+                              }
+                              if (pool.tokenOut.address === BULLET.address) {
+                                expect(pool.tokenOut.sellFeeBps).to.be.not.undefined
+                                expect(pool.tokenOut.sellFeeBps).to.be.equals(BULLET_WHT_TAX.sellFeeBps?.toString())
+                                expect(pool.tokenOut.buyFeeBps).to.be.not.undefined
+                                expect(pool.tokenOut.buyFeeBps).to.be.equals(BULLET_WHT_TAX.buyFeeBps?.toString())
+                              }
+                              if (pool.reserve0.token.address === BULLET.address) {
+                                expect(pool.reserve0.token.sellFeeBps).to.be.not.undefined
+                                expect(pool.reserve0.token.sellFeeBps).to.be.equals(
+                                  BULLET_WHT_TAX.sellFeeBps?.toString()
+                                )
+                                expect(pool.reserve0.token.buyFeeBps).to.be.not.undefined
+                                expect(pool.reserve0.token.buyFeeBps).to.be.equals(BULLET_WHT_TAX.buyFeeBps?.toString())
+                              }
+                              if (pool.reserve1.token.address === BULLET.address) {
+                                expect(pool.reserve1.token.sellFeeBps).to.be.not.undefined
+                                expect(pool.reserve1.token.sellFeeBps).to.be.equals(
+                                  BULLET_WHT_TAX.sellFeeBps?.toString()
+                                )
+                                expect(pool.reserve1.token.buyFeeBps).to.be.not.undefined
+                                expect(pool.reserve1.token.buyFeeBps).to.be.equals(BULLET_WHT_TAX.buyFeeBps?.toString())
+                              }
+                            } else {
+                              expect(pool.tokenOut.sellFeeBps).to.be.undefined
+                              expect(pool.tokenOut.buyFeeBps).to.be.undefined
+                              expect(pool.reserve0.token.sellFeeBps).to.be.undefined
+                              expect(pool.reserve0.token.buyFeeBps).to.be.undefined
+                              expect(pool.reserve1.token.sellFeeBps).to.be.undefined
+                              expect(pool.reserve1.token.buyFeeBps).to.be.undefined
+                            }
+                          }
+                        }
+                      }
+
+                      expect(!hasV3Pool && hasV2Pool).to.be.true
+
+                      if (enableFeeOnTransferFeeFetching) {
+                        expect(simulationStatus).to.equal('SUCCESS')
+                        expect(simulationError).to.equal(false)
+                        expect(methodParameters).to.not.be.undefined
+
+                        // We don't have a bullet proof way to assert the fot-involved quote is post tax
+                        // so the best way is to execute the swap on hardhat mainnet fork,
+                        // and make sure the executed quote doesn't differ from callstatic simulated quote by over slippage tolerance
+                        const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
+                          response.data.methodParameters!,
+                          tokenIn,
+                          tokenOut
+                        )
+
+                        expect(tokenInBefore.subtract(tokenInAfter).toExact()).to.equal(originalAmount)
+                        checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(tokenOut, quote))
+                      }
+                    }
+                  })
+                })
+              }
+            }
+          }
+        })
+      })
+
+      if (algorithm == 'alpha') {
+        describe(`+ Simulate Swap + Execute Swap`, () => {
+          it(`erc20 -> erc20`, async () => {
+            const quoteReq: QuoteQueryParams = {
+              tokenInAddress: 'USDC',
+              tokenInChainId: 1,
+              tokenOutAddress: 'USDT',
+              tokenOutChainId: 1,
+              amount: await getAmount(1, type, 'USDC', 'USDT', '100'),
+              type,
+              recipient: alice.address,
+              slippageTolerance: SLIPPAGE,
+              deadline: '360',
+              algorithm,
+              simulateFromAddress: '0xf584f8728b874a6a5c7a8d4d387c9aae9172d621',
+              enableUniversalRouter: true,
+              protocols: ALL_PROTOCOLS,
+            }
+
+            const queryParams = qs.stringify(quoteReq)
+
+            const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(`${API}?${queryParams}`, {
+              headers: HEADERS_2_0,
+            })
+            const {
+              data: { quote, quoteDecimals, quoteGasAdjustedDecimals, methodParameters, simulationError },
+              status,
+            } = response
+
+            expect(status).to.equal(200)
+            expect(simulationError).to.equal(false)
+            expect(parseFloat(quoteDecimals)).to.be.greaterThan(90)
+            expect(parseFloat(quoteDecimals)).to.be.lessThan(110)
+
+            if (type == 'exactIn') {
+              expect(parseFloat(quoteGasAdjustedDecimals)).to.be.lessThanOrEqual(parseFloat(quoteDecimals))
+            } else {
+              expect(parseFloat(quoteGasAdjustedDecimals)).to.be.greaterThanOrEqual(parseFloat(quoteDecimals))
+            }
+
+            expect(methodParameters).to.not.be.undefined
+
+            const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
+              methodParameters!,
+              USDC_MAINNET,
+              USDT_MAINNET
+            )
+
+            if (type == 'exactIn') {
+              expect(tokenInBefore.subtract(tokenInAfter).toExact()).to.equal('100')
+              checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(USDT_MAINNET, quote))
+            } else {
+              expect(tokenOutAfter.subtract(tokenOutBefore).toExact()).to.equal('100')
+              checkQuoteToken(tokenInBefore, tokenInAfter, CurrencyAmount.fromRawAmount(USDC_MAINNET, quote))
+            }
+
+            // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
+            // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
+            // if it's exactOut quote, we should always hit the cached routes.
+            // this is regardless of protocol version.
+            // the reason is because exact in quote always runs before exact out
+            // along with the native or wrapped native pool token address assertions previously
+            // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
+            // and native for v4 pool routes
+            expect(response.data.hitsCachedRoutes).to.be.true
+          })
+
+          it(`erc20 -> erc20 swaprouter02`, async () => {
+            const quoteReq: QuoteQueryParams = {
+              tokenInAddress: 'USDC',
+              tokenInChainId: 1,
+              tokenOutAddress: 'USDT',
+              tokenOutChainId: 1,
+              amount: await getAmount(1, type, 'USDC', 'USDT', '100'),
+              type,
+              recipient: alice.address,
+              slippageTolerance: SLIPPAGE,
+              deadline: '360',
+              algorithm,
+              simulateFromAddress: '0xf584f8728b874a6a5c7a8d4d387c9aae9172d621',
+              protocols: 'v2,v3,mixed',
+            }
+
+            const queryParams = qs.stringify(quoteReq)
+
+            const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(`${API}?${queryParams}`, {
+              headers: HEADERS_1_2,
+            })
+            const {
+              data: { quote, quoteDecimals, quoteGasAdjustedDecimals, methodParameters, simulationError },
+              status,
+            } = response
+
+            expect(status).to.equal(200)
+            expect(simulationError).to.equal(false)
+            expect(parseFloat(quoteDecimals)).to.be.greaterThan(90)
+            expect(parseFloat(quoteDecimals)).to.be.lessThan(110)
+
+            if (type == 'exactIn') {
+              expect(parseFloat(quoteGasAdjustedDecimals)).to.be.lessThanOrEqual(parseFloat(quoteDecimals))
+            } else {
+              expect(parseFloat(quoteGasAdjustedDecimals)).to.be.greaterThanOrEqual(parseFloat(quoteDecimals))
+            }
+
+            expect(methodParameters).to.not.be.undefined
+            expect(methodParameters!.to).to.equal(SWAP_ROUTER_02_ADDRESSES(ChainId.MAINNET))
+
+            const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
+              methodParameters!,
+              USDC_MAINNET,
+              USDT_MAINNET
+            )
+
+            if (type == 'exactIn') {
+              expect(tokenInBefore.subtract(tokenInAfter).toExact()).to.equal('100')
+              checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(USDT_MAINNET, quote))
+            } else {
+              expect(tokenOutAfter.subtract(tokenOutBefore).toExact()).to.equal('100')
+              checkQuoteToken(tokenInBefore, tokenInAfter, CurrencyAmount.fromRawAmount(USDC_MAINNET, quote))
+            }
+
+            // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
+            // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
+            // if it's exactOut quote, we should always hit the cached routes.
+            // this is regardless of protocol version.
+            // the reason is because exact in quote always runs before exact out
+            // along with the native or wrapped native pool token address assertions previously
+            // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
+            // and native for v4 pool routes
+            expect(response.data.hitsCachedRoutes).to.be.true
+          })
+
+          if (isTesterPKEnvironmentSet()) {
+            it(`erc20 -> erc20 with permit with tester pk`, async () => {
+              // This test requires a private key with at least 10 USDC
+              // at FORK_BLOCK time.
+              const amount = await getAmount(1, type, 'USDC', 'USDT', '10')
+
+              const nonce = '0'
+
+              const permit: PermitSingle = {
+                details: {
+                  token: USDC_MAINNET.address,
+                  amount: amount,
+                  expiration: Math.floor(new Date().getTime() / 1000 + 10000000).toString(),
+                  nonce,
+                },
+                spender: UNIVERSAL_ROUTER_ADDRESS,
+                sigDeadline: Math.floor(new Date().getTime() / 1000 + 10000000).toString(),
+              }
+
+              const wallet = new Wallet(process.env.TESTER_PK!)
+
+              const { domain, types, values } = AllowanceTransfer.getPermitData(permit, PERMIT2_ADDRESS, 1)
+
+              const signature = await wallet._signTypedData(domain, types, values)
+
+              const quoteReq: QuoteQueryParams = {
+                tokenInAddress: 'USDC',
+                tokenInChainId: 1,
+                tokenOutAddress: 'USDT',
+                tokenOutChainId: 1,
+                amount,
+                type,
+                recipient: wallet.address,
+                slippageTolerance: SLIPPAGE,
+                deadline: '360',
+                algorithm,
+                simulateFromAddress: wallet.address,
+                permitSignature: signature,
+                permitAmount: permit.details.amount.toString(),
+                permitExpiration: permit.details.expiration.toString(),
+                permitSigDeadline: permit.sigDeadline.toString(),
+                permitNonce: permit.details.nonce.toString(),
+                enableUniversalRouter: true,
+                protocols: ALL_PROTOCOLS,
+              }
+
+              const queryParams = qs.stringify(quoteReq)
+
+              const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(`${API}?${queryParams}`, {
+                headers: HEADERS_2_0,
+              })
+              const {
+                data: { quoteDecimals, quoteGasAdjustedDecimals, methodParameters, simulationError },
+                status,
+              } = response
+              expect(status).to.equal(200)
+
+              expect(simulationError).to.equal(false)
+
+              expect(parseFloat(quoteDecimals)).to.be.greaterThan(9)
+              expect(parseFloat(quoteDecimals)).to.be.lessThan(11)
+
+              if (type == 'exactIn') {
+                expect(parseFloat(quoteGasAdjustedDecimals)).to.be.lessThanOrEqual(parseFloat(quoteDecimals))
+              } else {
+                expect(parseFloat(quoteGasAdjustedDecimals)).to.be.greaterThanOrEqual(parseFloat(quoteDecimals))
+              }
+
+              expect(methodParameters).to.not.be.undefined
+
+              // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
+              // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
+              // if it's exactOut quote, we should always hit the cached routes.
+              // this is regardless of protocol version.
+              // the reason is because exact in quote always runs before exact out
+              // along with the native or wrapped native pool token address assertions previously
+              // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
+              // and native for v4 pool routes
+              expect(response.data.hitsCachedRoutes).to.be.true
+            })
+          }
+
+          it(`erc20 -> eth`, async () => {
+            const quoteReq: QuoteQueryParams = {
+              tokenInAddress: 'USDC',
+              tokenInChainId: 1,
+              tokenOutAddress: 'ETH',
+              tokenOutChainId: 1,
+              amount: await getAmount(1, type, 'USDC', 'ETH', type == 'exactIn' ? '1000000' : '10'),
+              type,
+              recipient: alice.address,
+              slippageTolerance: SLIPPAGE,
+              deadline: '360',
+              algorithm,
+              simulateFromAddress: '0xf584f8728b874a6a5c7a8d4d387c9aae9172d621',
+              enableUniversalRouter: true,
+              protocols: ALL_PROTOCOLS,
+            }
+
+            const queryParams = qs.stringify(quoteReq)
+
+            const response = await axios.get<QuoteResponse>(`${API}?${queryParams}`, { headers: HEADERS_2_0 })
+            const {
+              data: { quote, methodParameters, simulationError },
+              status,
+            } = response
+
+            expect(status).to.equal(200)
+            expect(simulationError).to.equal(false)
+            expect(methodParameters).to.not.be.undefined
+
+            const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
+              methodParameters!,
+              USDC_MAINNET,
+              Ether.onChain(1)
+            )
+
+            if (type == 'exactIn') {
+              expect(tokenInBefore.subtract(tokenInAfter).toExact()).to.equal('1000000')
+              checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(Ether.onChain(1), quote))
+            } else {
+              // Hard to test ETH balance due to gas costs for approval and swap. Just check tokenIn changes
+              checkQuoteToken(tokenInBefore, tokenInAfter, CurrencyAmount.fromRawAmount(USDC_MAINNET, quote))
+            }
+
+            // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
+            // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
+            // if it's exactOut quote, we should always hit the cached routes.
+            // this is regardless of protocol version.
+            // the reason is because exact in quote always runs before exact out
+            // along with the native or wrapped native pool token address assertions previously
+            // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
+            // and native for v4 pool routes
+            expect(response.data.hitsCachedRoutes).to.be.true
+          })
+
+          it(`erc20 -> eth large trade`, async () => {
+            // Trade of this size almost always results in splits.
+            const quoteReq: QuoteQueryParams = {
+              tokenInAddress: 'USDC',
+              tokenInChainId: 1,
+              tokenOutAddress: 'ETH',
+              tokenOutChainId: 1,
+              amount:
+                type == 'exactIn'
+                  ? await getAmount(1, type, 'USDC', 'ETH', '1000000')
+                  : await getAmount(1, type, 'USDC', 'ETH', '100'),
+              type,
+              recipient: alice.address,
+              slippageTolerance: LARGE_SLIPPAGE,
+              deadline: '360',
+              algorithm,
+              simulateFromAddress: '0xf584f8728b874a6a5c7a8d4d387c9aae9172d621',
+              enableUniversalRouter: true,
+              protocols: ALL_PROTOCOLS,
+            }
+
+            const queryParams = qs.stringify(quoteReq)
+
+            const response = await axios.get<QuoteResponse>(`${API}?${queryParams}`, { headers: HEADERS_2_0 })
+            const { data, status } = response
+
+            expect(status).to.equal(200)
+            expect(data.simulationError).to.equal(false)
+            expect(data.methodParameters).to.not.be.undefined
+
+            expect(data.route).to.not.be.undefined
+
+            const amountInEdgesTotal = _(data.route)
+              .flatMap((route) => route[0]!)
+              .filter((pool) => !!pool.amountIn)
+              .map((pool) => BigNumber.from(pool.amountIn))
+              .reduce((cur, total) => total.add(cur), BigNumber.from(0))
+            const amountIn = BigNumber.from(data.quote)
+            expect(amountIn.eq(amountInEdgesTotal))
+
+            const amountOutEdgesTotal = _(data.route)
+              .flatMap((route) => route[0]!)
+              .filter((pool) => !!pool.amountOut)
+              .map((pool) => BigNumber.from(pool.amountOut))
+              .reduce((cur, total) => total.add(cur), BigNumber.from(0))
+            const amountOut = BigNumber.from(data.quote)
+            expect(amountOut.eq(amountOutEdgesTotal))
+
+            const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
+              data.methodParameters!,
+              USDC_MAINNET,
+              Ether.onChain(1)
+            )
+
+            if (type == 'exactIn') {
+              expect(tokenInBefore.subtract(tokenInAfter).toExact()).to.equal('1000000')
+              checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(Ether.onChain(1), data.quote))
+            } else {
+              // Hard to test ETH balance due to gas costs for approval and swap. Just check tokenIn changes
+              checkQuoteToken(tokenInBefore, tokenInAfter, CurrencyAmount.fromRawAmount(USDC_MAINNET, data.quote))
+            }
+
+            // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
+            // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
+            // if it's exactOut quote, we should always hit the cached routes.
+            // this is regardless of protocol version.
+            // the reason is because exact in quote always runs before exact out
+            // along with the native or wrapped native pool token address assertions previously
+            // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
+            // and native for v4 pool routes
+            expect(response.data.hitsCachedRoutes).to.be.true
+          })
+
+          it(`eth -> erc20`, async () => {
+            const quoteReq: QuoteQueryParams = {
+              tokenInAddress: 'ETH',
+              tokenInChainId: 1,
+              tokenOutAddress: 'UNI',
+              tokenOutChainId: 1,
+              amount:
+                type == 'exactIn'
+                  ? await getAmount(1, type, 'ETH', 'UNI', '10')
+                  : await getAmount(1, type, 'ETH', 'UNI', '10000'),
+              type,
+              recipient: alice.address,
+              slippageTolerance: type == 'exactOut' ? LARGE_SLIPPAGE : SLIPPAGE, // for exact out somehow the liquidation wasn't sufficient, hence higher slippage
+              deadline: '360',
+              algorithm,
+              simulateFromAddress: '0x0716a17FBAeE714f1E6aB0f9d59edbC5f09815C0',
+              enableUniversalRouter: true,
+              protocols: ALL_PROTOCOLS,
+            }
+
+            const queryParams = qs.stringify(quoteReq)
+
+            const response = await axios.get<QuoteResponse>(`${API}?${queryParams}`, { headers: HEADERS_2_0 })
+            const { data, status } = response
+            expect(status).to.equal(200)
+            expect(data.simulationError).to.equal(false)
+            expect(data.methodParameters).to.not.be.undefined
+
+            const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
+              data.methodParameters!,
+              Ether.onChain(1),
+              UNI_MAINNET
+            )
+
+            if (type == 'exactIn') {
+              // We've swapped 10 ETH + gas costs
+              expect(tokenInBefore.subtract(tokenInAfter).greaterThan(parseAmount('10', Ether.onChain(1)))).to.be.true
+              checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(UNI_MAINNET, data.quote))
+            } else {
+              checkAbsoluteDifference(tokenOutAfter.subtract(tokenOutBefore).toExact(), '10000', 0.0001)
+              // Can't easily check slippage for ETH due to gas costs effecting ETH balance.
+            }
+
+            // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
+            // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
+            // if it's exactOut quote, we should always hit the cached routes.
+            // this is regardless of protocol version.
+            // the reason is because exact in quote always runs before exact out
+            // along with the native or wrapped native pool token address assertions previously
+            // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
+            // and native for v4 pool routes
+            expect(response.data.hitsCachedRoutes).to.be.true
+          })
+
+          it(`eth -> erc20 swaprouter02`, async () => {
+            const quoteReq: QuoteQueryParams = {
+              tokenInAddress: 'ETH',
+              tokenInChainId: 1,
+              tokenOutAddress: 'UNI',
+              tokenOutChainId: 1,
+              amount:
+                type == 'exactIn'
+                  ? await getAmount(1, type, 'ETH', 'UNI', '10')
+                  : await getAmount(1, type, 'ETH', 'UNI', '10000'),
+              type,
+              recipient: alice.address,
+              slippageTolerance: type == 'exactOut' ? LARGE_SLIPPAGE : SLIPPAGE, // for exact out somehow the liquidation wasn't sufficient, hence higher slippage,
+              deadline: '360',
+              algorithm,
+              simulateFromAddress: '0x00000000219ab540356cBB839Cbe05303d7705Fa',
+              enableUniversalRouter: false,
+              protocols: ALL_PROTOCOLS,
+            }
+
+            const queryParams = qs.stringify(quoteReq)
+
+            const response = await axios.get<QuoteResponse>(`${API}?${queryParams}`, { headers: HEADERS_1_2 })
+            const { data, status } = response
+            expect(status).to.equal(200)
+            expect(data.methodParameters).to.not.be.undefined
+
+            const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
+              data.methodParameters!,
+              Ether.onChain(1),
+              UNI_MAINNET
+            )
+
+            if (type == 'exactIn') {
+              // We've swapped 10 ETH + gas costs
+              expect(tokenInBefore.subtract(tokenInAfter).greaterThan(parseAmount('10', Ether.onChain(1)))).to.be.true
+              checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(UNI_MAINNET, data.quote))
+              expect(data.simulationError).to.equal(false)
+            } else {
+              checkAbsoluteDifference(tokenOutAfter.subtract(tokenOutBefore).toExact(), '10000', 0.0001)
+              // Can't easily check slippage for ETH due to gas costs effecting ETH balance.
+            }
+
+            // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
+            // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
+            // if it's exactOut quote, we should always hit the cached routes.
+            // this is regardless of protocol version.
+            // the reason is because exact in quote always runs before exact out
+            // along with the native or wrapped native pool token address assertions previously
+            // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
+            // and native for v4 pool routes
+            expect(response.data.hitsCachedRoutes).to.be.true
+          })
+
+          it(`weth -> erc20`, async () => {
+            const quoteReq: QuoteQueryParams = {
+              tokenInAddress: 'WETH',
+              tokenInChainId: 1,
+              tokenOutAddress: 'DAI',
+              tokenOutChainId: 1,
+              amount: await getAmount(1, type, 'WETH', 'DAI', '100'),
+              type,
+              recipient: alice.address,
+              slippageTolerance: SLIPPAGE,
+              deadline: '360',
+              algorithm,
+              simulateFromAddress: '0xf04a5cc80b1e94c69b48f5ee68a08cd2f09a7c3e',
+              enableUniversalRouter: true,
+              protocols: ALL_PROTOCOLS,
+            }
+
+            const queryParams = qs.stringify(quoteReq)
+
+            const response = await axios.get<QuoteResponse>(`${API}?${queryParams}`, { headers: HEADERS_2_0 })
+            const { data, status } = response
+            expect(status).to.equal(200)
+            expect(data.simulationError).to.equal(false)
+            expect(data.methodParameters).to.not.be.undefined
+
+            const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
+              data.methodParameters!,
+              WETH9[1]!,
+              DAI_MAINNET
+            )
+
+            if (type == 'exactIn') {
+              expect(tokenInBefore.subtract(tokenInAfter).toExact()).to.equal('100')
+              checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(DAI_MAINNET, data.quote))
+            } else {
+              expect(tokenOutAfter.subtract(tokenOutBefore).toExact()).to.equal('100')
+              checkQuoteToken(tokenInBefore, tokenInAfter, CurrencyAmount.fromRawAmount(WETH9[1]!, data.quote))
+            }
+
+            // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
+            // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
+            // if it's exactOut quote, we should always hit the cached routes.
+            // this is regardless of protocol version.
+            // the reason is because exact in quote always runs before exact out
+            // along with the native or wrapped native pool token address assertions previously
+            // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
+            // and native for v4 pool routes
+            expect(response.data.hitsCachedRoutes).to.be.true
+          })
+
+          it(`erc20 -> weth`, async () => {
+            const quoteReq: QuoteQueryParams = {
+              tokenInAddress: 'USDC',
+              tokenInChainId: 1,
+              tokenOutAddress: 'WETH',
+              tokenOutChainId: 1,
+              amount: await getAmount(1, type, 'USDC', 'WETH', '100'),
+              type,
+              recipient: alice.address,
+              slippageTolerance: SLIPPAGE,
+              deadline: '360',
+              algorithm,
+              simulateFromAddress: '0xf584f8728b874a6a5c7a8d4d387c9aae9172d621',
+              enableUniversalRouter: true,
+              protocols: ALL_PROTOCOLS,
+            }
+
+            const queryParams = qs.stringify(quoteReq)
+
+            const response = await axios.get<QuoteResponse>(`${API}?${queryParams}`, { headers: HEADERS_2_0 })
+            const { data, status } = response
+            expect(status).to.equal(200)
+            expect(data.simulationError).to.equal(false)
+            expect(data.methodParameters).to.not.be.undefined
+
+            const { tokenInBefore, tokenInAfter, tokenOutBefore, tokenOutAfter } = await executeSwap(
+              data.methodParameters!,
+              USDC_MAINNET,
+              WETH9[1]!
+            )
+
+            if (type == 'exactIn') {
+              expect(tokenInBefore.subtract(tokenInAfter).toExact()).to.equal('100')
+              checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(WETH9[1], data.quote))
+            } else {
+              expect(tokenOutAfter.subtract(tokenOutBefore).toExact()).to.equal('100')
+              checkQuoteToken(tokenInBefore, tokenInAfter, CurrencyAmount.fromRawAmount(USDC_MAINNET, data.quote))
+            }
+
+            // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
+            // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
+            // if it's exactOut quote, we should always hit the cached routes.
+            // this is regardless of protocol version.
+            // the reason is because exact in quote always runs before exact out
+            // along with the native or wrapped native pool token address assertions previously
+            // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
+            // and native for v4 pool routes
+            expect(response.data.hitsCachedRoutes).to.be.true
+          })
+
+          const uraRefactorInterimState = ['before', 'after']
+          GREENLIST_TOKEN_PAIRS.forEach(([tokenIn, tokenOut]) => {
+            uraRefactorInterimState.forEach((state) => {
+              it(`${tokenIn.symbol} -> ${tokenOut.symbol} with portion, state = ${state}`, async () => {
+                const originalAmount = getTestAmount(type === 'exactIn' ? tokenIn : tokenOut)
+                const tokenInSymbol = tokenIn.symbol!
+                const tokenOutSymbol = tokenOut.symbol!
+                const tokenInAddress = tokenIn.isNative ? tokenInSymbol : tokenIn.address
+                const tokenOutAddress = tokenOut.isNative ? tokenOutSymbol : tokenOut.address
+                const amount = await getAmountFromToken(type, tokenIn.wrapped, tokenOut.wrapped, originalAmount)
+
+                // we need to simulate URA before and after merging https://github.com/Uniswap/unified-routing-api/pull/282 interim states
+                // to ensure routing-api is backward compatible with URA
+                let portionBips = undefined
+                if (state === 'before' && type === 'exactIn') {
+                  portionBips = FLAT_PORTION.bips
+                } else if (state === 'after') {
+                  portionBips = FLAT_PORTION.bips
+                }
+                let portionAmount = undefined
+                if (state === 'before' && type === 'exactOut') {
+                  portionAmount = CurrencyAmount.fromRawAmount(tokenOut, amount)
+                    .multiply(new Fraction(FLAT_PORTION.bips, 10_000))
+                    .quotient.toString()
+                } else if (state === 'after') {
+                  // after URA merges https://github.com/Uniswap/unified-routing-api/pull/282,
+                  // it no longer sends portionAmount
+                  portionAmount = undefined
+                }
+
+                const quoteReq: QuoteQueryParams = {
+                  tokenInAddress: tokenInAddress,
+                  tokenInChainId: tokenIn.chainId,
+                  tokenOutAddress: tokenOutAddress,
+                  tokenOutChainId: tokenOut.chainId,
+                  amount: amount,
+                  type: type,
+                  protocols: ALL_PROTOCOLS,
+                  recipient: alice.address,
+                  slippageTolerance: SLIPPAGE,
+                  deadline: '360',
+                  algorithm,
+                  enableUniversalRouter: true,
+                  simulateFromAddress: alice.address,
+                  portionBips: portionBips,
+                  portionAmount: portionAmount,
+                  portionRecipient: FLAT_PORTION.recipient,
+                }
+
+                const queryParams = qs.stringify(quoteReq)
+
+                const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(`${API}?${queryParams}`, {
+                  headers: HEADERS_2_0,
+                })
+                const { data, status } = response
+                expect(status).to.equal(200)
+                expect(data.simulationError).to.equal(false)
+                expect(data.methodParameters).to.not.be.undefined
+
+                expect(data.portionRecipient).to.not.be.undefined
+
+                if (!(state === 'before' && type === 'exactOut')) {
+                  // before URA interim state it doesnt send portionBips to routing-api,
+                  // so routing-api has no way to know the portionBips
+                  expect(data.portionBips).to.not.be.undefined
+                  expect(data.portionBips).to.equal(FLAT_PORTION.bips)
+                }
+                expect(data.portionAmount).to.not.be.undefined
+                expect(data.portionAmountDecimals).to.not.be.undefined
+                expect(data.quoteGasAndPortionAdjusted).to.not.be.undefined
+                expect(data.quoteGasAndPortionAdjustedDecimals).to.not.be.undefined
+
+                expect(data.portionRecipient).to.equal(FLAT_PORTION.recipient)
+
+                if (type == 'exactIn') {
+                  const allQuotesAcrossRoutes = data.route
+                    .map((routes) =>
+                      routes
+                        .map((route) => route.amountOut)
+                        .map((amountOut) => CurrencyAmount.fromRawAmount(tokenOut, amountOut ?? '0'))
+                        .reduce((cur, total) => total.add(cur), CurrencyAmount.fromRawAmount(tokenOut, '0'))
+                    )
+                    .reduce((cur, total) => total.add(cur), CurrencyAmount.fromRawAmount(tokenOut, '0'))
+
+                  const quote = CurrencyAmount.fromRawAmount(tokenOut, data.quote)
+                  const expectedPortionAmount = quote.multiply(new Fraction(FLAT_PORTION.bips, 10000))
+                  expect(data.portionAmount).to.equal(expectedPortionAmount.quotient.toString())
+
+                  // The most strict way to ensure the output amount from route path is correct with respect to portion
+                  // is to make sure the output amount from route path is exactly portion bps different from the quote
+                  const tokensDiff = quote.subtract(allQuotesAcrossRoutes)
+                  const percentDiff = tokensDiff.asFraction.divide(quote.asFraction)
+                  expect(percentDiff.quotient.toString()).equal(
+                    new Fraction(FLAT_PORTION.bips, 10_000).quotient.toString()
+                  )
+                } else {
+                  const allQuotesAcrossRoutes = data.route
+                    .map((routes) =>
+                      routes
+                        .map((route) => route.amountOut)
+                        .map((amountOut) => CurrencyAmount.fromRawAmount(tokenIn, amountOut ?? '0'))
+                        .reduce((cur, total) => total.add(cur), CurrencyAmount.fromRawAmount(tokenIn, '0'))
+                    )
+                    .reduce((cur, total) => total.add(cur), CurrencyAmount.fromRawAmount(tokenIn, '0'))
+                  const quote = CurrencyAmount.fromRawAmount(tokenIn, data.quote)
+                  const expectedPortionAmount = CurrencyAmount.fromRawAmount(tokenOut, amount).multiply(
+                    new Fraction(FLAT_PORTION.bips, 10000)
+                  )
+                  expect(data.portionAmount).to.equal(expectedPortionAmount.quotient.toString())
+
+                  // The most strict way to ensure the output amount from route path is correct with respect to portion
+                  // is to make sure the output amount from route path is exactly portion bps different from the quote
+                  const tokensDiff = allQuotesAcrossRoutes.subtract(quote)
+                  const percentDiff = tokensDiff.asFraction.divide(quote.asFraction)
+                  expect(percentDiff.quotient.toString()).equal(
+                    new Fraction(FLAT_PORTION.bips, 10_000).quotient.toString()
+                  )
+                }
+
+                const {
+                  tokenInBefore,
+                  tokenInAfter,
+                  tokenOutBefore,
+                  tokenOutAfter,
+                  tokenOutPortionRecipientBefore,
+                  tokenOutPortionRecipientAfter,
+                } = await executeSwap(data.methodParameters!, tokenIn, tokenOut!, false, tokenIn.chainId, FLAT_PORTION)
+
+                if (type == 'exactIn') {
+                  // if the token in is native token, the difference will be slightly larger due to gas. We have no way to know precise gas costs in terms of GWEI * gas units.
+                  if (!tokenIn.isNative) {
+                    expect(tokenInBefore.subtract(tokenInAfter).toExact()).to.equal(originalAmount)
+                  }
+
+                  // if the token out is native token, the difference will be slightly larger due to gas. We have no way to know precise gas costs in terms of GWEI * gas units.
+                  if (!tokenOut.isNative) {
+                    checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(tokenOut, data.quote))
+                  }
+
+                  expect(data.portionAmount).not.to.be.undefined
+
+                  const expectedPortionAmount = CurrencyAmount.fromRawAmount(tokenOut, data.portionAmount!)
+                  checkPortionRecipientToken(
+                    tokenOutPortionRecipientBefore!,
+                    tokenOutPortionRecipientAfter!,
+                    expectedPortionAmount
+                  )
+                } else {
+                  // if the token out is native token, the difference will be slightly larger due to gas. We have no way to know precise gas costs in terms of GWEI * gas units.
+                  if (!tokenOut.isNative) {
+                    expect(tokenOutAfter.subtract(tokenOutBefore).toExact()).to.equal(originalAmount)
+                  }
+
+                  // if the token out is native token, the difference will be slightly larger due to gas. We have no way to know precise gas costs in terms of GWEI * gas units.
+                  if (!tokenIn.isNative) {
+                    checkQuoteToken(tokenInBefore, tokenInAfter, CurrencyAmount.fromRawAmount(tokenIn, data.quote))
+                  }
+
+                  expect(data.portionAmount).not.to.be.undefined
+
+                  const expectedPortionAmount = CurrencyAmount.fromRawAmount(tokenOut, data.portionAmount!)
+                  checkPortionRecipientToken(
+                    tokenOutPortionRecipientBefore!,
+                    tokenOutPortionRecipientAfter!,
+                    expectedPortionAmount
+                  )
+                }
+
+                // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
+                // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
+                // if it's exactOut quote, we should always hit the cached routes.
+                // this is regardless of protocol version.
+                // the reason is because exact in quote always runs before exact out
+                // along with the native or wrapped native pool token address assertions previously
+                // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
+                // and native for v4 pool routes
+                expect(response.data.hitsCachedRoutes).to.be.true
               })
             })
           })
+        })
+      }
+      it(`erc20 -> erc20 no recipient/deadline/slippage`, async () => {
+        const quoteReq: QuoteQueryParams = {
+          tokenInAddress: 'USDC',
+          tokenInChainId: 1,
+          tokenOutAddress: 'USDT',
+          tokenOutChainId: 1,
+          amount: await getAmount(1, type, 'USDC', 'USDT', '100'),
+          type,
+          algorithm,
+          enableUniversalRouter: true,
+          protocols: ALL_PROTOCOLS,
         }
-        it(`erc20 -> erc20 no recipient/deadline/slippage`, async () => {
-          const quoteReq: QuoteQueryParams = {
-            tokenInAddress: 'USDC',
-            tokenInChainId: 1,
-            tokenOutAddress: 'USDT',
-            tokenOutChainId: 1,
-            amount: await getAmount(1, type, 'USDC', 'USDT', '100'),
-            type,
-            algorithm,
-            enableUniversalRouter: true,
-            protocols: ALL_PROTOCOLS,
-          }
 
-          const queryParams = qs.stringify(quoteReq)
+        const queryParams = qs.stringify(quoteReq)
 
-          const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(`${API}?${queryParams}`, {
-            headers: HEADERS_2_0,
-          })
-          const {
-            data: { quoteDecimals, quoteGasAdjustedDecimals, methodParameters },
-            status,
-          } = response
+        const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(`${API}?${queryParams}`, {
+          headers: HEADERS_2_0,
+        })
+        const {
+          data: { quoteDecimals, quoteGasAdjustedDecimals, methodParameters },
+          status,
+        } = response
 
-          expect(status).to.equal(200)
-          expect(parseFloat(quoteDecimals)).to.be.greaterThan(90)
-          expect(parseFloat(quoteDecimals)).to.be.lessThan(110)
+        expect(status).to.equal(200)
+        expect(parseFloat(quoteDecimals)).to.be.greaterThan(90)
+        expect(parseFloat(quoteDecimals)).to.be.lessThan(110)
 
-          if (type == 'exactIn') {
-            expect(parseFloat(quoteGasAdjustedDecimals)).to.be.lessThanOrEqual(parseFloat(quoteDecimals))
-          } else {
-            expect(parseFloat(quoteGasAdjustedDecimals)).to.be.greaterThanOrEqual(parseFloat(quoteDecimals))
-          }
+        if (type == 'exactIn') {
+          expect(parseFloat(quoteGasAdjustedDecimals)).to.be.lessThanOrEqual(parseFloat(quoteDecimals))
+        } else {
+          expect(parseFloat(quoteGasAdjustedDecimals)).to.be.greaterThanOrEqual(parseFloat(quoteDecimals))
+        }
 
-          expect(methodParameters).to.be.undefined
+        expect(methodParameters).to.be.undefined
 
-          // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
-          // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
-          // if it's exactOut quote, we should always hit the cached routes.
-          // this is regardless of protocol version.
-          // the reason is because exact in quote always runs before exact out
-          // along with the native or wrapped native pool token address assertions previously
-          // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
-          // and native for v4 pool routes
-          expect(response.data.hitsCachedRoutes).to.be.true
+        // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
+        // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
+        // if it's exactOut quote, we should always hit the cached routes.
+        // this is regardless of protocol version.
+        // the reason is because exact in quote always runs before exact out
+        // along with the native or wrapped native pool token address assertions previously
+        // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
+        // and native for v4 pool routes
+        expect(response.data.hitsCachedRoutes).to.be.true
+      })
+
+      it(`one of recipient/deadline/slippage is missing`, async () => {
+        const quoteReq: QuoteQueryParams = {
+          tokenInAddress: 'USDC',
+          tokenInChainId: 1,
+          tokenOutAddress: 'USDT',
+          tokenOutChainId: 1,
+          amount: await getAmount(1, type, 'USDC', 'USDT', '100'),
+          type,
+          slippageTolerance: SLIPPAGE,
+          deadline: '360',
+          algorithm,
+          enableUniversalRouter: true,
+          protocols: ALL_PROTOCOLS,
+        }
+        const queryParams = qs.stringify(quoteReq)
+
+        const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(`${API}?${queryParams}`, {
+          headers: HEADERS_2_0,
+        })
+        const {
+          data: { quoteDecimals, quoteGasAdjustedDecimals, methodParameters },
+          status,
+        } = response
+
+        expect(status).to.equal(200)
+        expect(parseFloat(quoteDecimals)).to.be.greaterThan(90)
+        expect(parseFloat(quoteDecimals)).to.be.lessThan(110)
+
+        if (type == 'exactIn') {
+          expect(parseFloat(quoteGasAdjustedDecimals)).to.be.lessThanOrEqual(parseFloat(quoteDecimals))
+        } else {
+          expect(parseFloat(quoteGasAdjustedDecimals)).to.be.greaterThanOrEqual(parseFloat(quoteDecimals))
+        }
+
+        // Since ur-sdk hardcodes recipient in case of no recipient https://github.com/Uniswap/universal-router-sdk/blob/main/src/entities/protocols/uniswap.ts#L68
+        // the calldata will still get generated even if URA doesn't pass in recipient
+        expect(methodParameters).not.to.be.undefined
+
+        // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
+        // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
+        // if it's exactOut quote, we should always hit the cached routes.
+        // this is regardless of protocol version.
+        // the reason is because exact in quote always runs before exact out
+        // along with the native or wrapped native pool token address assertions previously
+        // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
+        // and native for v4 pool routes
+        expect(response.data.hitsCachedRoutes).to.be.true
+      })
+
+      it(`erc20 -> erc20 gas price specified`, async () => {
+        const quoteReq: QuoteQueryParams = {
+          tokenInAddress: 'USDC',
+          tokenInChainId: 1,
+          tokenOutAddress: 'USDT',
+          tokenOutChainId: 1,
+          amount: await getAmount(1, type, 'USDC', 'USDT', '100'),
+          type,
+          algorithm,
+          gasPriceWei: '60000000000',
+          enableUniversalRouter: true,
+          protocols: ALL_PROTOCOLS,
+        }
+
+        const queryParams = qs.stringify(quoteReq)
+
+        const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(`${API}?${queryParams}`, {
+          headers: HEADERS_2_0,
+        })
+        const {
+          data: { quoteDecimals, quoteGasAdjustedDecimals, methodParameters, gasPriceWei },
+          status,
+        } = response
+
+        expect(status).to.equal(200)
+
+        if (algorithm == 'alpha') {
+          expect(gasPriceWei).to.equal('60000000000')
+        }
+
+        expect(parseFloat(quoteDecimals)).to.be.greaterThan(90)
+        expect(parseFloat(quoteDecimals)).to.be.lessThan(110)
+
+        if (type == 'exactIn') {
+          expect(parseFloat(quoteGasAdjustedDecimals)).to.be.lessThanOrEqual(parseFloat(quoteDecimals))
+        } else {
+          expect(parseFloat(quoteGasAdjustedDecimals)).to.be.greaterThanOrEqual(parseFloat(quoteDecimals))
+        }
+
+        expect(methodParameters).to.be.undefined
+
+        // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
+        // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
+        // if it's exactOut quote, we should always hit the cached routes.
+        // this is regardless of protocol version.
+        // the reason is because exact in quote always runs before exact out
+        // along with the native or wrapped native pool token address assertions previously
+        // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
+        // and native for v4 pool routes
+        expect(response.data.hitsCachedRoutes).to.be.true
+      })
+
+      it(`erc20 -> erc20 gas token specified`, async () => {
+        const quoteReq: QuoteQueryParams = {
+          tokenInAddress: 'USDC',
+          tokenInChainId: 1,
+          tokenOutAddress: 'USDT',
+          tokenOutChainId: 1,
+          amount: await getAmount(1, type, 'USDC', 'USDT', '100'),
+          type,
+          algorithm,
+          gasPriceWei: '60000000000',
+          enableUniversalRouter: true,
+          gasToken: USDC_MAINNET.address,
+          protocols: ALL_PROTOCOLS,
+        }
+
+        const queryParams = qs.stringify(quoteReq)
+
+        const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(`${API}?${queryParams}`, {
+          headers: HEADERS_2_0,
+        })
+        const {
+          data: {
+            quoteDecimals,
+            quoteGasAdjustedDecimals,
+            gasUseEstimateGasToken,
+            gasUseEstimateGasTokenDecimals,
+            methodParameters,
+            gasPriceWei,
+          },
+          status,
+        } = response
+
+        expect(status).to.equal(200)
+        expect(gasUseEstimateGasToken).to.not.be.undefined
+        expect(gasUseEstimateGasTokenDecimals).to.not.be.undefined
+
+        if (algorithm == 'alpha') {
+          expect(gasPriceWei).to.equal('60000000000')
+        }
+
+        expect(parseFloat(quoteDecimals)).to.be.greaterThan(90)
+        expect(parseFloat(quoteDecimals)).to.be.lessThan(110)
+        expect(parseFloat(gasUseEstimateGasTokenDecimals!)).to.be.greaterThan(0)
+
+        if (type == 'exactIn') {
+          expect(parseFloat(quoteGasAdjustedDecimals)).to.be.lessThanOrEqual(parseFloat(quoteDecimals))
+        } else {
+          expect(parseFloat(quoteGasAdjustedDecimals)).to.be.greaterThanOrEqual(parseFloat(quoteDecimals))
+        }
+
+        expect(methodParameters).to.be.undefined
+
+        // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
+        // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
+        // if it's exactOut quote, we should always hit the cached routes.
+        // this is regardless of protocol version.
+        // the reason is because exact in quote always runs before exact out
+        // along with the native or wrapped native pool token address assertions previously
+        // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
+        // and native for v4 pool routes
+        expect(response.data.hitsCachedRoutes).to.be.true
+      })
+
+      it(`erc20 -> erc20 by address`, async () => {
+        const quoteReq: QuoteQueryParams = {
+          tokenInAddress: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
+          tokenInChainId: 1, // DAI
+          tokenOutAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+          tokenOutChainId: 1, // USDC
+          amount: await getAmount(1, type, 'DAI', 'USDC', '100'),
+          type,
+          recipient: alice.address,
+          slippageTolerance: SLIPPAGE,
+          deadline: '360',
+          algorithm,
+          enableUniversalRouter: true,
+          protocols: ALL_PROTOCOLS,
+        }
+
+        const queryParams = qs.stringify(quoteReq)
+
+        const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(`${API}?${queryParams}`, {
+          headers: HEADERS_2_0,
         })
 
-        it(`one of recipient/deadline/slippage is missing`, async () => {
-          const quoteReq: QuoteQueryParams = {
-            tokenInAddress: 'USDC',
-            tokenInChainId: 1,
-            tokenOutAddress: 'USDT',
-            tokenOutChainId: 1,
-            amount: await getAmount(1, type, 'USDC', 'USDT', '100'),
-            type,
-            slippageTolerance: SLIPPAGE,
-            deadline: '360',
-            algorithm,
-            enableUniversalRouter: true,
-            protocols: ALL_PROTOCOLS,
-          }
-          const queryParams = qs.stringify(quoteReq)
+        const {
+          data: { quoteDecimals, quoteGasAdjustedDecimals },
+          status,
+        } = response
 
-          const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(`${API}?${queryParams}`, {
-            headers: HEADERS_2_0,
-          })
-          const {
-            data: { quoteDecimals, quoteGasAdjustedDecimals, methodParameters },
-            status,
-          } = response
+        expect(status).to.equal(200)
+        expect(parseFloat(quoteDecimals)).to.be.greaterThan(90)
 
-          expect(status).to.equal(200)
-          expect(parseFloat(quoteDecimals)).to.be.greaterThan(90)
-          expect(parseFloat(quoteDecimals)).to.be.lessThan(110)
+        if (type == 'exactIn') {
+          expect(parseFloat(quoteGasAdjustedDecimals)).to.be.lessThanOrEqual(parseFloat(quoteDecimals))
+        } else {
+          expect(parseFloat(quoteGasAdjustedDecimals)).to.be.greaterThanOrEqual(parseFloat(quoteDecimals))
+        }
 
-          if (type == 'exactIn') {
-            expect(parseFloat(quoteGasAdjustedDecimals)).to.be.lessThanOrEqual(parseFloat(quoteDecimals))
-          } else {
-            expect(parseFloat(quoteGasAdjustedDecimals)).to.be.greaterThanOrEqual(parseFloat(quoteDecimals))
-          }
+        expect(parseFloat(quoteDecimals)).to.be.lessThan(110)
 
-          // Since ur-sdk hardcodes recipient in case of no recipient https://github.com/Uniswap/universal-router-sdk/blob/main/src/entities/protocols/uniswap.ts#L68
-          // the calldata will still get generated even if URA doesn't pass in recipient
-          expect(methodParameters).not.to.be.undefined
+        // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
+        // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
+        // if it's exactOut quote, we should always hit the cached routes.
+        // this is regardless of protocol version.
+        // the reason is because exact in quote always runs before exact out
+        // along with the native or wrapped native pool token address assertions previously
+        // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
+        // and native for v4 pool routes
+        expect(response.data.hitsCachedRoutes).to.be.true
+      })
 
-          // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
-          // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
-          // if it's exactOut quote, we should always hit the cached routes.
-          // this is regardless of protocol version.
-          // the reason is because exact in quote always runs before exact out
-          // along with the native or wrapped native pool token address assertions previously
-          // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
-          // and native for v4 pool routes
-          expect(response.data.hitsCachedRoutes).to.be.true
+      it(`erc20 -> erc20 one by address one by symbol`, async () => {
+        const quoteReq: QuoteQueryParams = {
+          tokenInAddress: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
+          tokenInChainId: 1,
+          tokenOutAddress: 'USDC',
+          tokenOutChainId: 1,
+          amount: await getAmount(1, type, 'DAI', 'USDC', '100'),
+          type,
+          recipient: alice.address,
+          slippageTolerance: SLIPPAGE,
+          deadline: '360',
+          algorithm,
+          enableUniversalRouter: true,
+          protocols: ALL_PROTOCOLS,
+        }
+
+        const queryParams = qs.stringify(quoteReq)
+
+        const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(`${API}?${queryParams}`, {
+          headers: HEADERS_2_0,
         })
+        const {
+          data: { quoteDecimals, quoteGasAdjustedDecimals },
+          status,
+        } = response
 
-        it(`erc20 -> erc20 gas price specified`, async () => {
-          const quoteReq: QuoteQueryParams = {
-            tokenInAddress: 'USDC',
-            tokenInChainId: 1,
-            tokenOutAddress: 'USDT',
-            tokenOutChainId: 1,
-            amount: await getAmount(1, type, 'USDC', 'USDT', '100'),
-            type,
-            algorithm,
-            gasPriceWei: '60000000000',
-            enableUniversalRouter: true,
-            protocols: ALL_PROTOCOLS,
-          }
+        expect(status).to.equal(200)
+        expect(parseFloat(quoteDecimals)).to.be.greaterThan(90)
 
-          const queryParams = qs.stringify(quoteReq)
+        if (type == 'exactIn') {
+          expect(parseFloat(quoteGasAdjustedDecimals)).to.be.lessThanOrEqual(parseFloat(quoteDecimals))
+        } else {
+          expect(parseFloat(quoteGasAdjustedDecimals)).to.be.greaterThanOrEqual(parseFloat(quoteDecimals))
+        }
 
-          const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(`${API}?${queryParams}`, {
-            headers: HEADERS_2_0,
-          })
-          const {
-            data: { quoteDecimals, quoteGasAdjustedDecimals, methodParameters, gasPriceWei },
-            status,
-          } = response
+        expect(parseFloat(quoteDecimals)).to.be.lessThan(110)
 
-          expect(status).to.equal(200)
-
-          if (algorithm == 'alpha') {
-            expect(gasPriceWei).to.equal('60000000000')
-          }
-
-          expect(parseFloat(quoteDecimals)).to.be.greaterThan(90)
-          expect(parseFloat(quoteDecimals)).to.be.lessThan(110)
-
-          if (type == 'exactIn') {
-            expect(parseFloat(quoteGasAdjustedDecimals)).to.be.lessThanOrEqual(parseFloat(quoteDecimals))
-          } else {
-            expect(parseFloat(quoteGasAdjustedDecimals)).to.be.greaterThanOrEqual(parseFloat(quoteDecimals))
-          }
-
-          expect(methodParameters).to.be.undefined
-
-          // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
-          // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
-          // if it's exactOut quote, we should always hit the cached routes.
-          // this is regardless of protocol version.
-          // the reason is because exact in quote always runs before exact out
-          // along with the native or wrapped native pool token address assertions previously
-          // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
-          // and native for v4 pool routes
-          expect(response.data.hitsCachedRoutes).to.be.true
-        })
-
-        it(`erc20 -> erc20 gas token specified`, async () => {
-          const quoteReq: QuoteQueryParams = {
-            tokenInAddress: 'USDC',
-            tokenInChainId: 1,
-            tokenOutAddress: 'USDT',
-            tokenOutChainId: 1,
-            amount: await getAmount(1, type, 'USDC', 'USDT', '100'),
-            type,
-            algorithm,
-            gasPriceWei: '60000000000',
-            enableUniversalRouter: true,
-            gasToken: USDC_MAINNET.address,
-            protocols: ALL_PROTOCOLS,
-          }
-
-          const queryParams = qs.stringify(quoteReq)
-
-          const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(`${API}?${queryParams}`, {
-            headers: HEADERS_2_0,
-          })
-          const {
-            data: {
-              quoteDecimals,
-              quoteGasAdjustedDecimals,
-              gasUseEstimateGasToken,
-              gasUseEstimateGasTokenDecimals,
-              methodParameters,
-              gasPriceWei,
-            },
-            status,
-          } = response
-
-          expect(status).to.equal(200)
-          expect(gasUseEstimateGasToken).to.not.be.undefined
-          expect(gasUseEstimateGasTokenDecimals).to.not.be.undefined
-
-          if (algorithm == 'alpha') {
-            expect(gasPriceWei).to.equal('60000000000')
-          }
-
-          expect(parseFloat(quoteDecimals)).to.be.greaterThan(90)
-          expect(parseFloat(quoteDecimals)).to.be.lessThan(110)
-          expect(parseFloat(gasUseEstimateGasTokenDecimals!)).to.be.greaterThan(0)
-
-          if (type == 'exactIn') {
-            expect(parseFloat(quoteGasAdjustedDecimals)).to.be.lessThanOrEqual(parseFloat(quoteDecimals))
-          } else {
-            expect(parseFloat(quoteGasAdjustedDecimals)).to.be.greaterThanOrEqual(parseFloat(quoteDecimals))
-          }
-
-          expect(methodParameters).to.be.undefined
-
-          // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
-          // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
-          // if it's exactOut quote, we should always hit the cached routes.
-          // this is regardless of protocol version.
-          // the reason is because exact in quote always runs before exact out
-          // along with the native or wrapped native pool token address assertions previously
-          // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
-          // and native for v4 pool routes
-          expect(response.data.hitsCachedRoutes).to.be.true
-        })
-
-        it(`erc20 -> erc20 by address`, async () => {
-          const quoteReq: QuoteQueryParams = {
-            tokenInAddress: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
-            tokenInChainId: 1, // DAI
-            tokenOutAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
-            tokenOutChainId: 1, // USDC
-            amount: await getAmount(1, type, 'DAI', 'USDC', '100'),
-            type,
-            recipient: alice.address,
-            slippageTolerance: SLIPPAGE,
-            deadline: '360',
-            algorithm,
-            enableUniversalRouter: true,
-            protocols: ALL_PROTOCOLS,
-          }
-
-          const queryParams = qs.stringify(quoteReq)
-
-          const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(`${API}?${queryParams}`, {
-            headers: HEADERS_2_0,
-          })
-
-          const {
-            data: { quoteDecimals, quoteGasAdjustedDecimals },
-            status,
-          } = response
-
-          expect(status).to.equal(200)
-          expect(parseFloat(quoteDecimals)).to.be.greaterThan(90)
-
-          if (type == 'exactIn') {
-            expect(parseFloat(quoteGasAdjustedDecimals)).to.be.lessThanOrEqual(parseFloat(quoteDecimals))
-          } else {
-            expect(parseFloat(quoteGasAdjustedDecimals)).to.be.greaterThanOrEqual(parseFloat(quoteDecimals))
-          }
-
-          expect(parseFloat(quoteDecimals)).to.be.lessThan(110)
-
-          // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
-          // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
-          // if it's exactOut quote, we should always hit the cached routes.
-          // this is regardless of protocol version.
-          // the reason is because exact in quote always runs before exact out
-          // along with the native or wrapped native pool token address assertions previously
-          // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
-          // and native for v4 pool routes
-          expect(response.data.hitsCachedRoutes).to.be.true
-        })
-
-        it(`erc20 -> erc20 one by address one by symbol`, async () => {
-          const quoteReq: QuoteQueryParams = {
-            tokenInAddress: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
-            tokenInChainId: 1,
-            tokenOutAddress: 'USDC',
-            tokenOutChainId: 1,
-            amount: await getAmount(1, type, 'DAI', 'USDC', '100'),
-            type,
-            recipient: alice.address,
-            slippageTolerance: SLIPPAGE,
-            deadline: '360',
-            algorithm,
-            enableUniversalRouter: true,
-            protocols: ALL_PROTOCOLS,
-          }
-
-          const queryParams = qs.stringify(quoteReq)
-
-          const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(`${API}?${queryParams}`, {
-            headers: HEADERS_2_0,
-          })
-          const {
-            data: { quoteDecimals, quoteGasAdjustedDecimals },
-            status,
-          } = response
-
-          expect(status).to.equal(200)
-          expect(parseFloat(quoteDecimals)).to.be.greaterThan(90)
-
-          if (type == 'exactIn') {
-            expect(parseFloat(quoteGasAdjustedDecimals)).to.be.lessThanOrEqual(parseFloat(quoteDecimals))
-          } else {
-            expect(parseFloat(quoteGasAdjustedDecimals)).to.be.greaterThanOrEqual(parseFloat(quoteDecimals))
-          }
-
-          expect(parseFloat(quoteDecimals)).to.be.lessThan(110)
-
-          // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
-          // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
-          // if it's exactOut quote, we should always hit the cached routes.
-          // this is regardless of protocol version.
-          // the reason is because exact in quote always runs before exact out
-          // along with the native or wrapped native pool token address assertions previously
-          // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
-          // and native for v4 pool routes
-          expect(response.data.hitsCachedRoutes).to.be.true
-        })
+        // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
+        // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
+        // if it's exactOut quote, we should always hit the cached routes.
+        // this is regardless of protocol version.
+        // the reason is because exact in quote always runs before exact out
+        // along with the native or wrapped native pool token address assertions previously
+        // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
+        // and native for v4 pool routes
+        expect(response.data.hitsCachedRoutes).to.be.true
       })
 
       describe(`${ID_TO_NETWORK_NAME(1)} ${algorithm} ${type} 4xx`, () => {

--- a/test/mocha/e2e/quote.test.ts
+++ b/test/mocha/e2e/quote.test.ts
@@ -59,11 +59,12 @@ chai.use(chaiSubset)
 
 const UNIVERSAL_ROUTER_ADDRESS = UNIVERSAL_ROUTER_ADDRESS_BY_CHAIN(UniversalRouterVersion.V2_0, 1)
 
-if (!process.env.UNISWAP_ROUTING_API || !process.env.ARCHIVE_NODE_RPC) {
-  throw new Error('Must set UNISWAP_ROUTING_API and ARCHIVE_NODE_RPC env variables for integ tests. See README')
+if (!process.env.UNISWAP_ROUTING_API || !process.env.ARCHIVE_NODE_RPC || !process.env.UNICORN_SECRETS) {
+  throw new Error('Must set UNISWAP_ROUTING_API and ARCHIVE_NODE_RPC and UNICORN_SECRETS env variables for integ tests. See README')
 }
 
 const API = `${process.env.UNISWAP_ROUTING_API!}quote`
+const unicornSecrets = `${!process.env.UNICORN_SECRETS}`
 
 const SLIPPAGE = '5'
 const LARGE_SLIPPAGE = '20'
@@ -361,6 +362,8 @@ describe('quote', function () {
   for (const algorithm of ['alpha']) {
     for (const type of TRADE_TYPES) {
       describe(`${ID_TO_NETWORK_NAME(1)} ${algorithm} ${type} 2xx`, () => {
+        const hitsCachedRoutes = true
+
         describe(`+ Execute Swap`, () => {
           for (const uraVersion of [UniversalRouterVersion.V1_2, UniversalRouterVersion.V2_0]) {
             it(`erc20 -> erc20 (uraVersion:${uraVersion})`, async () => {


### PR DESCRIPTION
we want to cover e2e test with the cached routes cache miss codepath. we do so by leveraging the `debugRoutingConfig` so that the test will trigger the cache miss path deterministically.