### PR TITLE
fix: enable mixed route eth <-> weth fix for web

### DIFF
--- a/lib/util/enableMixedRouteEthWeth.ts
+++ b/lib/util/enableMixedRouteEthWeth.ts
@@ -2,6 +2,7 @@ export function enableMixedRouteEthWeth(requestSourceHeader?: string): boolean {
   switch (requestSourceHeader) {
     // only used for e2e-test purpose
     case 'e2e-test':
+    case 'uniswap-web':
       return true
     // TODO: enable once web, mobile, extension releases the FE bug fix for mixed route (https://uniswapteam.slack.com/archives/C07AD3507SQ/p1739296535359709?thread_ts=1739224900.129809&cid=C07AD3507SQ)
     // TODO: for mobile, we need to ensure backward compatibility with the old version, using app version (https://uniswapteam.slack.com/archives/C07AD3507SQ/p1739309767819639?thread_ts=1739224900.129809&cid=C07AD3507SQ)


### PR DESCRIPTION
@plondon mentioned they released web this AM (https://uniswapteam.slack.com/archives/C08DSTY7J1X/p1739569427618859). @Ayoakala mentioned they bumped sdks in trading-api https://github.com/Uniswap/external-api/pull/773. We are actually good to enable mixed route eth <-> weth for web, especially next week we are gonna bash this (https://uniswapteam.slack.com/archives/C07AD3507SQ/p1739570984797999). 