### PR TITLE
chore: bump sor to 4.18.2 - fix: support mixed quote on rest of L2s

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -539,7 +539,6 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
             ChainId.GOERLI,
             ChainId.BASE,
             ChainId.UNICHAIN,
-            ChainId.BASE,
             ChainId.ARBITRUM_ONE,
             ChainId.POLYGON,
             ChainId.OPTIMISM,

--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -533,7 +533,21 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
             ChainId.MAINNET,
           ]
 
-          const mixedSupported = [ChainId.MAINNET, ChainId.SEPOLIA, ChainId.GOERLI, ChainId.UNICHAIN, ChainId.BASE]
+          const mixedSupported = [
+            ChainId.MAINNET,
+            ChainId.SEPOLIA,
+            ChainId.GOERLI,
+            ChainId.BASE,
+            ChainId.UNICHAIN,
+            ChainId.BASE,
+            ChainId.ARBITRUM_ONE,
+            ChainId.POLYGON,
+            ChainId.OPTIMISM,
+            ChainId.AVALANCHE,
+            ChainId.BNB,
+            ChainId.WORLDCHAIN,
+            ChainId.ZORA,
+          ]
 
           const cachedRoutesCacheInvalidationFixRolloutPercentage = NEW_CACHED_ROUTES_ROLLOUT_PERCENT[chainId]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.22.2",
         "@uniswap/sdk-core": "^7.5.0",
-        "@uniswap/smart-order-router": "4.18.1",
+        "@uniswap/smart-order-router": "4.18.2",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^4.18.1",
         "@uniswap/v2-sdk": "^4.13.0",
@@ -4508,9 +4508,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.18.1.tgz",
-      "integrity": "sha512-882yBaoQ6YBHeObASR5XK6F/RzihTzAl6mVEVhoFowO6G0AHl17YYyKJz8iaX/rS3IHphROsGR85A8Z1PkH2OA==",
+      "version": "4.18.2",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.18.2.tgz",
+      "integrity": "sha512-wMKkJgfKzog/bFCJfA++rhBrp36W6t7VGq4KJQcdwodaVDXgzgLFLXrwqrnLlJ5cafyTCCWcQt7yrTrkD22YMw==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -27936,9 +27936,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.18.1.tgz",
-      "integrity": "sha512-882yBaoQ6YBHeObASR5XK6F/RzihTzAl6mVEVhoFowO6G0AHl17YYyKJz8iaX/rS3IHphROsGR85A8Z1PkH2OA==",
+      "version": "4.18.2",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.18.2.tgz",
+      "integrity": "sha512-wMKkJgfKzog/bFCJfA++rhBrp36W6t7VGq4KJQcdwodaVDXgzgLFLXrwqrnLlJ5cafyTCCWcQt7yrTrkD22YMw==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@uniswap/permit2-sdk": "^1.3.0",
     "@uniswap/router-sdk": "^1.22.2",
     "@uniswap/sdk-core": "^7.5.0",
-    "@uniswap/smart-order-router": "4.18.1",
+    "@uniswap/smart-order-router": "4.18.2",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^4.18.1",
     "@uniswap/v2-sdk": "^4.13.0",


### PR DESCRIPTION
Release https://github.com/Uniswap/smart-order-router/pull/831

alll L2 tests passed https://app.warp.dev/block/Q43sdmGDmSdE8SKuB3Eh1m, L1 tests failure cannot be due to this change, because it does not touch any L1 logic at all.