### PR TITLE
migrate blast v3/v4 subgraphs to new account

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The best way to develop and test the API is to deploy your own instance to AWS.
    TENDERLY_ACCESS_KEY = '' # For enabling Tenderly simulations
    TENDERLY_NODE_API_KEY = '' # For enabling Tenderly node-level RPC access
    ALCHEMY_QUERY_KEY = '' # For Alchemy subgraph query access
+   ALCHEMY_QUERY_KEY_2 = '' # For Alchemy subgraph query access
    GQL_URL = '' # The GraphQL endpoint url, for Uniswap graphql query access
    GQL_H_ORGN = '' # The GraphQL header origin, for Uniswap graphql query access
    ```

--- a/bin/app.ts
+++ b/bin/app.ts
@@ -38,7 +38,7 @@ export class RoutingAPIStage extends Stage {
       tenderlyNodeApiKey: string
       unicornSecret: string
       alchemyQueryKey?: string
-      decentralizedNetworkApiKey?: string
+      alchemyQueryKey2?: string
       uniGraphQLEndpoint: string
       uniGraphQLHeaderOrigin: string
     }
@@ -61,7 +61,7 @@ export class RoutingAPIStage extends Stage {
       tenderlyNodeApiKey,
       unicornSecret,
       alchemyQueryKey,
-      decentralizedNetworkApiKey,
+      alchemyQueryKey2,
       uniGraphQLEndpoint,
       uniGraphQLHeaderOrigin,
     } = props
@@ -83,7 +83,7 @@ export class RoutingAPIStage extends Stage {
       tenderlyNodeApiKey,
       unicornSecret,
       alchemyQueryKey,
-      decentralizedNetworkApiKey,
+      alchemyQueryKey2,
       uniGraphQLEndpoint,
       uniGraphQLHeaderOrigin,
     })
@@ -176,6 +176,11 @@ export class RoutingAPIPipeline extends Stack {
 
     const routingApiNewSecrets = sm.Secret.fromSecretAttributes(this, 'RoutingApiNewSecrets', {
       secretCompleteArn: 'arn:aws:secretsmanager:us-east-2:644039819003:secret:RoutingApiNewSecrets-7EijpM',
+    })
+
+    // ALchemy subgraphs are split between two accounts, hence the two keys alchemy-query-key and alchemy-query-key-2
+    const alchemySubgraphSecret = sm.Secret.fromSecretAttributes(this, 'RoutingAlchemySubgraphSecret', {
+      secretCompleteArn: 'arn:aws:secretsmanager:us-east-2:644039819003:secret:RoutingAlchemySubgraphSecret-QKtgMX',
     })
 
     // Load RPC provider URLs from AWS secret
@@ -271,8 +276,8 @@ export class RoutingAPIPipeline extends Stack {
       tenderlyAccessKey: tenderlyCreds.secretValueFromJson('tenderly-access-key').toString(),
       tenderlyNodeApiKey: tenderlyCreds.secretValueFromJson('tenderly-node-api-key').toString(),
       unicornSecret: unicornSecrets.secretValueFromJson('debug-config-unicorn-key').toString(),
-      alchemyQueryKey: routingApiNewSecrets.secretValueFromJson('alchemy-query-key').toString(),
-      decentralizedNetworkApiKey: routingApiNewSecrets.secretValueFromJson('decentralized-network-api-key').toString(),
+      alchemyQueryKey: alchemySubgraphSecret.secretValueFromJson('alchemy-query-key').toString(),
+      alchemyQueryKey2: alchemySubgraphSecret.secretValueFromJson('alchemy-query-key-2').toString(),
       uniGraphQLEndpoint: routingApiNewSecrets.secretValueFromJson('uni-graphql-endpoint').toString(),
       uniGraphQLHeaderOrigin: routingApiNewSecrets.secretValueFromJson('uni-graphql-header-origin').toString(),
     })
@@ -300,8 +305,8 @@ export class RoutingAPIPipeline extends Stack {
       tenderlyAccessKey: tenderlyCreds.secretValueFromJson('tenderly-access-key').toString(),
       tenderlyNodeApiKey: tenderlyCreds.secretValueFromJson('tenderly-node-api-key').toString(),
       unicornSecret: unicornSecrets.secretValueFromJson('debug-config-unicorn-key').toString(),
-      alchemyQueryKey: routingApiNewSecrets.secretValueFromJson('alchemy-query-key').toString(),
-      decentralizedNetworkApiKey: routingApiNewSecrets.secretValueFromJson('decentralized-network-api-key').toString(),
+      alchemyQueryKey: alchemySubgraphSecret.secretValueFromJson('alchemy-query-key').toString(),
+      alchemyQueryKey2: alchemySubgraphSecret.secretValueFromJson('alchemy-query-key-2').toString(),
       uniGraphQLEndpoint: routingApiNewSecrets.secretValueFromJson('uni-graphql-endpoint').toString(),
       uniGraphQLHeaderOrigin: routingApiNewSecrets.secretValueFromJson('uni-graphql-header-origin').toString(),
     })
@@ -448,6 +453,8 @@ new RoutingAPIStack(app, 'RoutingAPIStack', {
   unicornSecret: process.env.UNICORN_SECRET!,
   uniGraphQLEndpoint: process.env.GQL_URL!,
   uniGraphQLHeaderOrigin: process.env.GQL_H_ORGN!,
+  alchemyQueryKey: process.env.ALCHEMY_QUERY_KEY!,
+  alchemyQueryKey2: process.env.ALCHEMY_QUERY_KEY_2!,
 })
 
 new RoutingAPIPipeline(app, 'RoutingAPIPipelineStack', {

--- a/bin/stacks/routing-api-stack.ts
+++ b/bin/stacks/routing-api-stack.ts
@@ -48,7 +48,7 @@ export class RoutingAPIStack extends cdk.Stack {
       tenderlyNodeApiKey: string
       unicornSecret: string
       alchemyQueryKey?: string
-      decentralizedNetworkApiKey?: string
+      alchemyQueryKey2?: string
       uniGraphQLEndpoint: string
       uniGraphQLHeaderOrigin: string
     }
@@ -73,7 +73,7 @@ export class RoutingAPIStack extends cdk.Stack {
       tenderlyNodeApiKey,
       unicornSecret,
       alchemyQueryKey,
-      decentralizedNetworkApiKey,
+      alchemyQueryKey2,
       uniGraphQLEndpoint,
       uniGraphQLHeaderOrigin,
     } = props
@@ -95,7 +95,7 @@ export class RoutingAPIStack extends cdk.Stack {
       pinata_secret,
       hosted_zone,
       alchemyQueryKey,
-      decentralizedNetworkApiKey,
+      alchemyQueryKey2,
     })
 
     const {

--- a/bin/stacks/routing-caching-stack.ts
+++ b/bin/stacks/routing-caching-stack.ts
@@ -26,7 +26,7 @@ export interface RoutingCachingStackProps extends cdk.NestedStackProps {
   hosted_zone?: string
   chatbotSNSArn?: string
   alchemyQueryKey?: string
-  decentralizedNetworkApiKey?: string
+  alchemyQueryKey2?: string
 }
 
 export class RoutingCachingStack extends cdk.NestedStack {
@@ -40,18 +40,17 @@ export class RoutingCachingStack extends cdk.NestedStack {
   public readonly ipfsCleanPoolCachingLambda: aws_lambda_nodejs.NodejsFunction
   public readonly poolCacheLambdaNameArray: string[] = []
   public readonly alchemyQueryKey: string | undefined = undefined
-  public readonly decentralizedNetworkApiKey: string | undefined = undefined
+  public readonly alchemyQueryKey2: string | undefined = undefined
 
   constructor(scope: Construct, name: string, props: RoutingCachingStackProps) {
     super(scope, name, props)
 
-    const { chatbotSNSArn, alchemyQueryKey, decentralizedNetworkApiKey } = props
+    const { chatbotSNSArn, alchemyQueryKey, alchemyQueryKey2 } = props
 
     const chatBotTopic = chatbotSNSArn ? aws_sns.Topic.fromTopicArn(this, 'ChatbotTopic', chatbotSNSArn) : undefined
 
     this.alchemyQueryKey = alchemyQueryKey
-    this.decentralizedNetworkApiKey = decentralizedNetworkApiKey
-
+    this.alchemyQueryKey2 = alchemyQueryKey2
     // TODO: Remove and swap to the new bucket below. Kept around for the rollout, but all requests will go to bucket 2.
     this.poolCacheBucket = new aws_s3.Bucket(this, 'PoolCacheBucket')
     this.poolCacheBucket2 = new aws_s3.Bucket(this, 'PoolCacheBucket2')
@@ -133,7 +132,7 @@ export class RoutingCachingStack extends cdk.NestedStack {
             POOL_CACHE_BUCKET_3: this.poolCacheBucket3.bucketName,
             POOL_CACHE_GZIP_KEY: this.poolCacheGzipKey,
             ALCHEMY_QUERY_KEY: this.alchemyQueryKey ?? '',
-            DCN_API_KEY: this.decentralizedNetworkApiKey ?? '',
+            ALCHEMY_QUERY_KEY_2: this.alchemyQueryKey2 ?? '',
             chainId: chainId.toString(),
             protocol,
             timeout: timeout.toString(),

--- a/lib/cron/cache-config.ts
+++ b/lib/cron/cache-config.ts
@@ -23,7 +23,7 @@ export const v4SubgraphUrlOverride = (chainId: ChainId) => {
     case ChainId.UNICHAIN:
       return `https://subgraph.satsuma-prod.com/${process.env.ALCHEMY_QUERY_KEY}/uniswap/uniswap-v4-unichain-mainnet/api`
     case ChainId.BLAST:
-      return `https://subgraph.satsuma-prod.com/${process.env.ALCHEMY_QUERY_KEY}/uniswap/uniswap-v4-blast/api`
+      return `https://subgraph.satsuma-prod.com/${process.env.ALCHEMY_QUERY_KEY_2}/uniswap-2/uniswap-v4-blast/api`
     case ChainId.MAINNET:
       return `https://subgraph.satsuma-prod.com/${process.env.ALCHEMY_QUERY_KEY}/uniswap/uniswap-v4-mainnet/api`
     default:
@@ -46,7 +46,7 @@ export const v3SubgraphUrlOverride = (chainId: ChainId) => {
     case ChainId.BNB:
       return `https://subgraph.satsuma-prod.com/${process.env.ALCHEMY_QUERY_KEY}/uniswap/uniswap-v3-bsc-ii/api`
     case ChainId.BLAST:
-      return `https://subgraph.satsuma-prod.com/${process.env.ALCHEMY_QUERY_KEY}/uniswap/uniswap-v3-blast/api`
+      return `https://subgraph.satsuma-prod.com/${process.env.ALCHEMY_QUERY_KEY_2}/uniswap-2/uniswap-v3-blast/api`
     case ChainId.BASE:
       return `https://subgraph.satsuma-prod.com/${process.env.ALCHEMY_QUERY_KEY}/uniswap/uniswap-v3-base/api`
     case ChainId.CELO:


### PR DESCRIPTION
Alchemy is migrating a set of its subgraphs to a new account to split the indexing load. We need to migrate the v3/v4 subgraphs in routing to query from the new subgraph. We are starting with blast as it is one of the lower-traffic chains. Follow-up PRs will be filed for the remaining chains. 

I added a new secret to the Pipelines account, and made sure to update the ACL so that the routing account will be able to see it. 

This PR also removes the decentralized API key as it didn't look to be used anymore. 

`Tested locally:`
V3 Logs:
```
-25T18:53:06.559Z","v":0}
{
  "name": "RoutingLambda",
  "hostname": "169.254.75.251",
  "pid": 11,
  "level": 30,
  "msg": "Got 3125 V3 pools from the subgraph. 95 after filtering",
  "time": "2025-02-25T18:53:06.970Z",
  "v": 0
}
{
  "name": "RoutingLambda",
  "hostname": "169.254.75.251",
  "pid": 11,
  "level": 30,
  "msg": "Got 95 V3 pools from the subgraph for 81457. Saving to poolCacheGzip.json-81457-V3",
  "time": "2025-02-25T18:53:06.970Z",
  "v": 0
}
{
  "name": "RoutingLambda",
  "hostname": "169.254.75.251",
  "pid": 11,
  "level": 30,
  "result": {
    "Expiration": "expiry-date=\"Sat, 24 Feb 2035 00:00:00 GMT\", rule-id=\"MGRmMzJjNDgtMjA3Yi00ODAzLWE1MjctNzk4ZDQ1YTgyYjFl\"",
    "ETag": "\"74d6056f08a99ef696600ce76394f3ca\"",
    "ServerSideEncryption": "AES256"
  },
  "msg": "Done V3 for 81457",
  "time": "2025-02-25T18:53:07.104Z",
  "v": 0
}
{
  "name": "RoutingLambda",
  "hostname": "169.254.75.251",
  "pid": 11,
  "level": 30,
  "msg": "Successfully cached 81457 V3 pools to S3 bucket routingapistack-routingca-poolcachebucket3c1337d0e-zustlam1u50d",
  "time": "2025-02-25T18:53:07.104Z",
  "v": 0
}
{
  "name": "RoutingLambda",
  "hostname": "169.254.75.251",
  "pid": 11,
  "level": 30,
  "msg": "compression ratio for 81457 V3 pool file is 26332:6800",
  "time": "2025-02-25T18:53:07.104Z",
  "v": 0
}
```

V4 Logs:
```
{
  "name": "RoutingLambda",
  "hostname": "169.254.46.109",
  "pid": 11,
  "level": 30,
  "msg": "Got 7 V4 pools from the subgraph. 7 after filtering",
  "time": "2025-02-25T18:54:32.830Z",
  "v": 0
}
{
  "name": "RoutingLambda",
  "hostname": "169.254.46.109",
  "pid": 11,
  "level": 30,
  "msg": "Got 7 V4 pools from the subgraph for 81457. Saving to poolCacheGzip.json-81457-V4",
  "time": "2025-02-25T18:54:32.831Z",
  "v": 0
}
{
  "name": "RoutingLambda",
  "hostname": "169.254.46.109",
  "pid": 11,
  "level": 30,
  "result": {
    "Expiration": "expiry-date=\"Sat, 24 Feb 2035 00:00:00 GMT\", rule-id=\"MGRmMzJjNDgtMjA3Yi00ODAzLWE1MjctNzk4ZDQ1YTgyYjFl\"",
    "ETag": "\"87788015cb2c21c5dab58a98050cf469\"",
    "ServerSideEncryption": "AES256"
  },
  "msg": "Done V4 for 81457",
  "time": "2025-02-25T18:54:32.905Z",
  "v": 0
}
{
  "name": "RoutingLambda",
  "hostname": "169.254.46.109",
  "pid": 11,
  "level": 30,
  "msg": "Successfully cached 81457 V4 pools to S3 bucket routingapistack-routingca-poolcachebucket3c1337d0e-zustlam1u50d",
  "time": "2025-02-25T18:54:32.905Z",
  "v": 0
}
{
  "name": "RoutingLambda",
  "hostname": "169.254.46.109",
  "pid": 11,
  "level": 30,
  "msg": "compression ratio for 81457 V4 pool file is 2621:658",
  "time": "2025-02-25T18:54:32.905Z",
  "v": 0
}
```