### PR TITLE
chore: disable mockA test

### DIFF
--- a/test/mocha/e2e/quote.test.ts
+++ b/test/mocha/e2e/quote.test.ts
@@ -1585,7 +1585,7 @@ describe('quote', function () {
                 })
               })
 
-              it('USDC -> mockA forceMixedRoutes true for mixed protocol on Base with request source', async () => {
+              it.skip('USDC -> mockA forceMixedRoutes true for mixed protocol on Base with request source', async () => {
                 if (type != 'exactIn') {
                   // mixed route only works for exactIn
                   return
@@ -1636,7 +1636,7 @@ describe('quote', function () {
                 expect(route[0][1].tokenOut.address).to.equal('0x878784F7eBF6e57d17C81D82DDF53F117a5E2988')
               })
 
-              it('USDC -> mockA forceMixedRoutes true for mixed protocol on Base no request source', async () => {
+              it.skip('USDC -> mockA forceMixedRoutes true for mixed protocol on Base no request source', async () => {
                 if (type != 'exactIn') {
                   // mixed route only works for exactIn
                   return


### PR DESCRIPTION
disable USDC -> mockA force mixed route test, because someone made eth/mockA pool (https://uniswapteam.slack.com/archives/C07AD3507SQ/p1740074379045309?thread_ts=1739990355.165739&cid=C07AD3507SQ), and made the price impact 100% for the mixed route.

we can make a new mockB token for forcing mixed route test, but it's a chicken and egg, because someone will try to extract value against the mock pool again.