### PR TITLE
fix: bump SOR to 4.19.1 - fix: don't use cachedRoutes if intent.caching (1% experiment)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.22.2",
         "@uniswap/sdk-core": "^7.5.0",
-        "@uniswap/smart-order-router": "4.19.0",
+        "@uniswap/smart-order-router": "4.19.1",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^4.18.1",
         "@uniswap/v2-sdk": "^4.13.0",
@@ -4508,9 +4508,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.19.0.tgz",
-      "integrity": "sha512-0ZzcAW3uSTdyXaA0OWVSBsXBgI/dtJxjGzikVqYA1581nH5bWUmMeLIWsm8ffggNPN5VI4FA9i01INIP8fO2/g==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.19.1.tgz",
+      "integrity": "sha512-dyN80GSKswpGnzjOlTQ4ULkNdSHxeSbD8+VhUtPRiY2QZ6fDZFcZw3yKMu3YFQwX0+V+TC2YoEAbXWgPr+PThQ==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -27936,9 +27936,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.19.0.tgz",
-      "integrity": "sha512-0ZzcAW3uSTdyXaA0OWVSBsXBgI/dtJxjGzikVqYA1581nH5bWUmMeLIWsm8ffggNPN5VI4FA9i01INIP8fO2/g==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.19.1.tgz",
+      "integrity": "sha512-dyN80GSKswpGnzjOlTQ4ULkNdSHxeSbD8+VhUtPRiY2QZ6fDZFcZw3yKMu3YFQwX0+V+TC2YoEAbXWgPr+PThQ==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@uniswap/permit2-sdk": "^1.3.0",
     "@uniswap/router-sdk": "^1.22.2",
     "@uniswap/sdk-core": "^7.5.0",
-    "@uniswap/smart-order-router": "4.19.0",
+    "@uniswap/smart-order-router": "4.19.1",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^4.18.1",
     "@uniswap/v2-sdk": "^4.13.0",


### PR DESCRIPTION
Release https://github.com/Uniswap/smart-order-router/pull/833