### PR TITLE
fix: bump sor 4.19.4 - fix: don't use cachedRoutes if intent.caching (50% experiment)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.22.2",
         "@uniswap/sdk-core": "^7.5.0",
-        "@uniswap/smart-order-router": "4.19.3",
+        "@uniswap/smart-order-router": "4.19.4",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^4.18.1",
         "@uniswap/v2-sdk": "^4.13.0",
@@ -4508,9 +4508,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "4.19.3",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.19.3.tgz",
-      "integrity": "sha512-RveVkRB1wdXJe7ZZl6EVhwIrFz4wRPg1FPfWNM9in23IjKjheF2a3KDTS4cwImvQLxrQw6DDkgHlJKayFCdp/w==",
+      "version": "4.19.4",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.19.4.tgz",
+      "integrity": "sha512-Rs9AsFQ+zK7dQHJfUwsrdsjVDtloARj1sOHiLaTHw1fy4cbu1dRfPF0bHVUSTg6BGk2DuVayMzYycWjQwua5DA==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -27936,9 +27936,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "4.19.3",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.19.3.tgz",
-      "integrity": "sha512-RveVkRB1wdXJe7ZZl6EVhwIrFz4wRPg1FPfWNM9in23IjKjheF2a3KDTS4cwImvQLxrQw6DDkgHlJKayFCdp/w==",
+      "version": "4.19.4",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.19.4.tgz",
+      "integrity": "sha512-Rs9AsFQ+zK7dQHJfUwsrdsjVDtloARj1sOHiLaTHw1fy4cbu1dRfPF0bHVUSTg6BGk2DuVayMzYycWjQwua5DA==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@uniswap/permit2-sdk": "^1.3.0",
     "@uniswap/router-sdk": "^1.22.2",
     "@uniswap/sdk-core": "^7.5.0",
-    "@uniswap/smart-order-router": "4.19.3",
+    "@uniswap/smart-order-router": "4.19.4",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^4.18.1",
     "@uniswap/v2-sdk": "^4.13.0",


### PR DESCRIPTION
Release https://github.com/Uniswap/smart-order-router/pull/836