### PR TITLE
fix: do not fetch soneium RPC url from secrets

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -192,7 +192,8 @@ export class RoutingAPIPipeline extends Stack {
         chainId !== ChainId.UNICHAIN_SEPOLIA &&
         chainId !== ChainId.MONAD_TESTNET &&
         chainId !== ChainId.BASE_SEPOLIA &&
-        chainId !== ChainId.UNICHAIN
+        chainId !== ChainId.UNICHAIN &&
+        chainId !== ChainId.SONEIUM
       ) {
         const key = `WEB3_RPC_${chainId}`
         jsonRpcProviders[key] = jsonRpcProvidersSecret.secretValueFromJson(key).toString()


### PR DESCRIPTION
I forgot to exclude soneium from fetching the secrets. as a result, beta deploy failed:

>2025-03-06 08:46:02 UTC-0800
beta-us-east-2-RoutingAPI-RoutingLambdaStackNestedStackRoutingLambdaStackNestedStackRe-1IEZ6NNQOT7C4 
UPDATE_ROLLBACK_IN_PROGRESS
-
The following resource(s) failed to update: [CachingRoutingLambdaFB792963].
2025-03-06 08:46:02 UTC-0800
CachingRoutingLambdaFB792963 
UPDATE_FAILED
Likely root cause
-
Could not find a value associated with JSONKey in SecretString
