### PR TITLE
fix: test assertion for v4 native

### DIFF
--- a/test/mocha/e2e/quote.test.ts
+++ b/test/mocha/e2e/quote.test.ts
@@ -310,7 +310,7 @@ describe('quote', function () {
   }
 
   before(async function () {
-    this.timeout(400000)
+    this.timeout(40000)
     ;[alice] = await ethers.getSigners()
 
     // Make a dummy call to the API to get a block number to fork from.

--- a/test/mocha/e2e/quote.test.ts
+++ b/test/mocha/e2e/quote.test.ts
@@ -310,7 +310,7 @@ describe('quote', function () {
   }
 
   before(async function () {
-    this.timeout(40000)
+    this.timeout(400000)
     ;[alice] = await ethers.getSigners()
 
     // Make a dummy call to the API to get a block number to fork from.
@@ -3620,7 +3620,6 @@ describe('quote', function () {
             data.route.forEach((pools) => {
               pools.forEach((pool) => {
                 if (
-                  chain === ChainId.SEPOLIA &&
                   pool.tokenIn.address === '0x0000000000000000000000000000000000000000'
                 ) {
                   nativeOrWrappedNativePoolFound = true
@@ -3628,7 +3627,6 @@ describe('quote', function () {
                 }
 
                 if (
-                  chain !== ChainId.SEPOLIA &&
                   pool.tokenIn.address.toLowerCase() === WNATIVE_ON(chain).address.toLowerCase()
                 ) {
                   nativeOrWrappedNativePoolFound = true
@@ -3656,6 +3654,7 @@ describe('quote', function () {
               expect(data.hitsCachedRoutes).to.be.true
             }
           } catch (err: any) {
+            console.log(err) // log to see which assertion in the try block failed
             fail(JSON.stringify(err.response.data))
           }
         })

--- a/test/mocha/e2e/quote.test.ts
+++ b/test/mocha/e2e/quote.test.ts
@@ -3619,16 +3619,12 @@ describe('quote', function () {
             // we just have to iterate through to make sure find it and assert the important data
             data.route.forEach((pools) => {
               pools.forEach((pool) => {
-                if (
-                  pool.tokenIn.address === '0x0000000000000000000000000000000000000000'
-                ) {
+                if (pool.tokenIn.address === '0x0000000000000000000000000000000000000000') {
                   nativeOrWrappedNativePoolFound = true
                   nativePoolFound = true
                 }
 
-                if (
-                  pool.tokenIn.address.toLowerCase() === WNATIVE_ON(chain).address.toLowerCase()
-                ) {
+                if (pool.tokenIn.address.toLowerCase() === WNATIVE_ON(chain).address.toLowerCase()) {
                   nativeOrWrappedNativePoolFound = true
                 }
               })

--- a/test/mocha/e2e/quote.test.ts
+++ b/test/mocha/e2e/quote.test.ts
@@ -3574,7 +3574,8 @@ describe('quote', function () {
             chain === ChainId.ZKSYNC ||
             chain === ChainId.UNICHAIN_SEPOLIA ||
             chain === ChainId.UNICHAIN ||
-            chain === ChainId.SONEIUM
+            chain === ChainId.SONEIUM ||
+            chain === ChainId.AVALANCHE
           ) {
             // Blast doesn't have DAI or USDC yet
             // Zora doesn't have DAI

--- a/test/mocha/e2e/quote.test.ts
+++ b/test/mocha/e2e/quote.test.ts
@@ -3574,8 +3574,7 @@ describe('quote', function () {
             chain === ChainId.ZKSYNC ||
             chain === ChainId.UNICHAIN_SEPOLIA ||
             chain === ChainId.UNICHAIN ||
-            chain === ChainId.SONEIUM ||
-            chain === ChainId.AVALANCHE
+            chain === ChainId.SONEIUM
           ) {
             // Blast doesn't have DAI or USDC yet
             // Zora doesn't have DAI
@@ -3585,7 +3584,7 @@ describe('quote', function () {
 
           // TODO ROUTE-64: Remove this once smart-order-router supports ETH native currency on BASE
           // see https://uniswapteam.slack.com/archives/C021SU4PMR7/p1691593679108459?thread_ts=1691532336.742419&cid=C021SU4PMR7
-          const tokenOut = [ChainId.BASE, ChainId.SEPOLIA].includes(chain)
+          const tokenOut = [ChainId.BASE, ChainId.SEPOLIA, ChainId.AVALANCHE].includes(chain)
             ? chain !== ChainId.SEPOLIA
               ? USDC_ON(chain)
               : USDC_NATIVE_SEPOLIA


### PR DESCRIPTION
ETH -> erc20 tests consistently failed, due to the incorrect test setup. In case of v4 only protocol, every chain has good enough liquidity to go through native pools now.

tested locally
- https://app.warp.dev/block/wbhIf8RyFzb0q06IjbL4Df

then fixed avax test:
- https://app.warp.dev/block/fQyuzsHVPdcRgkUYQfXW9Q
- https://app.warp.dev/block/QJ4uu16ewiYfcnwAcwtUSc