### PR TITLE
fix: move worlchain to unirpc

### DIFF
--- a/bin/stacks/rpc-gateway-dashboard.ts
+++ b/bin/stacks/rpc-gateway-dashboard.ts
@@ -66,33 +66,6 @@ function getProviderDbHealthStateChangeForChain(chainId: ChainId) {
   return metrics
 }
 
-function getProviderHealthStateChangeForChain(chainId: ChainId) {
-  const metrics = []
-  for (const providerName of getProviderNameForChain(chainId)) {
-    metrics.push([
-      'Uniswap',
-      `RPC_GATEWAY_${chainId}_${providerName}_becomes_UNHEALTHY`,
-      'Service',
-      'RoutingAPI',
-      {
-        id: `provider_into_unhealthy_${chainId}_${providerName}`,
-        label: `${providerName} into UNHEALTHY ${ID_TO_NETWORK_NAME(chainId)}`,
-      },
-    ])
-    metrics.push([
-      'Uniswap',
-      `RPC_GATEWAY_${chainId}_${providerName}_becomes_HEALTHY`,
-      'Service',
-      'RoutingAPI',
-      {
-        id: `provider_into_healthy_${chainId}_${providerName}`,
-        label: `${providerName} into HEALTHY ${ID_TO_NETWORK_NAME(chainId)}`,
-      },
-    ])
-  }
-  return metrics
-}
-
 function getLatencyMetricsForChain(chainId: ChainId) {
   const metrics = []
   for (const providerName of getProviderNameForChain(chainId)) {
@@ -594,27 +567,6 @@ export class RpcGatewayDashboardStack extends cdk.NestedStack {
             left: {
               showUnits: false,
               label: 'DB health state changes',
-            },
-          },
-        },
-      },
-      {
-        height: 8,
-        width: 24,
-        type: 'metric',
-        properties: {
-          metrics: getProviderHealthStateChangeForChain(chainId),
-          view: 'timeSeries',
-          stacked: false,
-          region,
-          stat: 'Maximum',
-          period: 300,
-          title: `Provider health state for ${ID_TO_NETWORK_NAME(chainId)}`,
-          setPeriodToTimeRange: true,
-          yAxis: {
-            left: {
-              showUnits: false,
-              label: 'Health state changes',
             },
           },
         },

--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -113,9 +113,9 @@
     "useMultiProviderProb": 1,
     "latencyEvaluationSampleProb": 0,
     "healthCheckSampleProb": 0,
-    "providerInitialWeights": [1],
-    "providerUrls": ["QUICKNODE_480"],
-    "providerNames": ["QUICKNODE"]
+    "providerInitialWeights": [0, 1],
+    "providerUrls": ["QUICKNODE_480", "UNIRPC_0"],
+    "providerNames": ["QUICKNODE", "UNIRPC"]
   },
   {
     "chainId": 1301,


### PR DESCRIPTION
WorldChain is still on QN -> move to unirpc

Manually tested


Also had to remove some (unused?) metrics from `RpcGatewayDashboard` due to some widget limitation.

```
2:37:27 PM | UPDATE_FAILED        | AWS::CloudWatch::Dashboard    | RpcGatewayDashboard
Resource handler returned message: "The dashboard body is invalid, there are 1 validation errors:
[
{
"dataPath": "/widgets",
"message": "Invalid number of metrics per dashboard (2566), the total is limited to 2500"
}
```