### PR TITLE
chore: bump sor to 4.20.4 - log cached routes change metrics

### DIFF
--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -237,7 +237,7 @@ export class QuoteHandler extends APIGLambdaHandler<
         portionAmount,
         portionRecipient,
         gasToken,
-        routeId,
+        cachedRoutesRouteIds,
       },
       requestInjected: {
         router,
@@ -352,7 +352,7 @@ export class QuoteHandler extends APIGLambdaHandler<
       ...(gasToken ? { gasToken } : {}),
       ...(excludedProtocolsFromMixed ? { excludedProtocolsFromMixed } : {}),
       shouldEnableMixedRouteEthWeth: shouldEnableMixedRouteEthWeth,
-      ...(routeId ? { routeId } : {}),
+      ...(cachedRoutesRouteIds ? { cachedRoutesRouteIds: cachedRoutesRouteIds } : {}),
     }
 
     metric.putMetric(`${intent}Intent`, 1, MetricLoggerUnit.Count)

--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -352,7 +352,7 @@ export class QuoteHandler extends APIGLambdaHandler<
       ...(gasToken ? { gasToken } : {}),
       ...(excludedProtocolsFromMixed ? { excludedProtocolsFromMixed } : {}),
       shouldEnableMixedRouteEthWeth: shouldEnableMixedRouteEthWeth,
-      ...(cachedRoutesRouteIds ? { cachedRoutesRouteIds: cachedRoutesRouteIds } : {}),
+      ...(cachedRoutesRouteIds ? { cachedRoutesRouteIds } : {}),
     }
 
     metric.putMetric(`${intent}Intent`, 1, MetricLoggerUnit.Count)

--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -237,6 +237,7 @@ export class QuoteHandler extends APIGLambdaHandler<
         portionAmount,
         portionRecipient,
         gasToken,
+        routeId,
       },
       requestInjected: {
         router,
@@ -351,6 +352,7 @@ export class QuoteHandler extends APIGLambdaHandler<
       ...(gasToken ? { gasToken } : {}),
       ...(excludedProtocolsFromMixed ? { excludedProtocolsFromMixed } : {}),
       shouldEnableMixedRouteEthWeth: shouldEnableMixedRouteEthWeth,
+      ...(routeId ? { routeId } : {}),
     }
 
     metric.putMetric(`${intent}Intent`, 1, MetricLoggerUnit.Count)

--- a/lib/handlers/quote/schema/quote-schema.ts
+++ b/lib/handlers/quote/schema/quote-schema.ts
@@ -113,5 +113,5 @@ export type QuoteQueryParams = {
   source?: string
   gasToken?: string
   quotedId?: string
-  cachedRoutesRouteIds?: number
+  cachedRoutesRouteIds?: string
 }

--- a/lib/handlers/quote/schema/quote-schema.ts
+++ b/lib/handlers/quote/schema/quote-schema.ts
@@ -72,6 +72,7 @@ export const QuoteQueryParamsJoi = Joi.object({
   portionRecipient: Joi.string().alphanum().max(42).optional(),
   source: Joi.string().max(20).optional(),
   gasToken: Joi.string().alphanum().max(42).optional(),
+  routeId: Joi.number().optional(),
 })
 
 // Future work: this TradeTypeParam can be converted into an enum and used in the
@@ -111,4 +112,6 @@ export type QuoteQueryParams = {
   portionRecipient?: string
   source?: string
   gasToken?: string
+  quotedId?: string
+  routeId?: number
 }

--- a/lib/handlers/quote/schema/quote-schema.ts
+++ b/lib/handlers/quote/schema/quote-schema.ts
@@ -72,7 +72,7 @@ export const QuoteQueryParamsJoi = Joi.object({
   portionRecipient: Joi.string().alphanum().max(42).optional(),
   source: Joi.string().max(20).optional(),
   gasToken: Joi.string().alphanum().max(42).optional(),
-  routeId: Joi.number().optional(),
+  cachedRoutesRouteIds: Joi.string().optional(),
 })
 
 // Future work: this TradeTypeParam can be converted into an enum and used in the
@@ -113,5 +113,5 @@ export type QuoteQueryParams = {
   source?: string
   gasToken?: string
   quotedId?: string
-  routeId?: number
+  cachedRoutesRouteIds?: number
 }

--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -339,7 +339,12 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
       // if no Item is found it means we need to send a caching request
       if (shouldSendCachingRequest) {
         metric.putMetric('CachingQuoteForRoutesDbRequestSent', 1, MetricLoggerUnit.Count)
-        this.sendAsyncCachingRequest(partitionKey, [Protocol.V2, Protocol.V3, Protocol.V4, Protocol.MIXED], amount, routeId)
+        this.sendAsyncCachingRequest(
+          partitionKey,
+          [Protocol.V2, Protocol.V3, Protocol.V4, Protocol.MIXED],
+          amount,
+          routeId
+        )
         this.setRoutesDbCachingIntentFlag(partitionKey, amount, currentBlockNumber)
       } else {
         metric.putMetric('CachingQuoteForRoutesDbRequestNotNeeded', 1, MetricLoggerUnit.Count)

--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -294,7 +294,12 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
     if (optimistic) {
       // We send an async caching quote
       // we do not await on this function, it's a fire and forget
-      this.maybeSendCachingQuoteForRoutesDb(partitionKey, amount, currentBlockNumber, cachedRoutes.routes.map((route) => route.routeId))
+      this.maybeSendCachingQuoteForRoutesDb(
+        partitionKey,
+        amount,
+        currentBlockNumber,
+        cachedRoutes.routes.map((route) => route.routeId)
+      )
     }
 
     return cachedRoutes

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^2.0.2",
         "@uniswap/sdk-core": "^7.7.1",
-        "@uniswap/smart-order-router": "4.20.3",
+        "@uniswap/smart-order-router": "4.20.4",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^4.19.5",
         "@uniswap/v2-sdk": "^4.15.2",
@@ -4508,9 +4508,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "4.20.3",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.20.3.tgz",
-      "integrity": "sha512-X2prIy9vfr9dfPskyFDYYA8D39yv9l55Zr9LubQ2s/CHMmgI3FfE2K5zsQAWfPCNJUKihq3g/YZi6nIIy+xdEg==",
+      "version": "4.20.4",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.20.4.tgz",
+      "integrity": "sha512-ew4462wfZ0mQAn755o0BdQglz0xkato1BF5Bm+9Ugvcc3EYCW7kaX/HCUyvgB0zmLXj9irBcD1fHi4FO/7n3Ww==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -27936,9 +27936,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "4.20.3",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.20.3.tgz",
-      "integrity": "sha512-X2prIy9vfr9dfPskyFDYYA8D39yv9l55Zr9LubQ2s/CHMmgI3FfE2K5zsQAWfPCNJUKihq3g/YZi6nIIy+xdEg==",
+      "version": "4.20.4",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.20.4.tgz",
+      "integrity": "sha512-ew4462wfZ0mQAn755o0BdQglz0xkato1BF5Bm+9Ugvcc3EYCW7kaX/HCUyvgB0zmLXj9irBcD1fHi4FO/7n3Ww==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@uniswap/permit2-sdk": "^1.3.0",
     "@uniswap/router-sdk": "^2.0.2",
     "@uniswap/sdk-core": "^7.7.1",
-    "@uniswap/smart-order-router": "4.20.3",
+    "@uniswap/smart-order-router": "4.20.4",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^4.19.5",
     "@uniswap/v2-sdk": "^4.15.2",


### PR DESCRIPTION
routing-api side change complimentary of https://github.com/Uniswap/smart-order-router/pull/843/files. Online Routing lambda needs to send the hashed routeId to the async routing lambda, in order for async routing lambda to track how often cached routes changes metric

Tested in routing-api, I can see:

query string param cachedRoutesRouteIds
![Screenshot 2025-03-10 at 5.11.17 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/32924e9f-d531-4cd2-bd92-107ffbef1c96.png)

cachedRoutesNotChanged metrics
![Screenshot 2025-03-10 at 5.12.34 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/486bc597-f67c-4400-9386-03d4fd53dce3.png)

