### PR TITLE
feat: debug param

### DIFF
--- a/lib/handlers/quote/injector.ts
+++ b/lib/handlers/quote/injector.ts
@@ -29,16 +29,6 @@ export class QuoteHandlerInjector extends InjectorSOR<
     log: Logger,
     metricsLogger: MetricsLogger
   ): Promise<RequestInjected<IRouter<AlphaRouterConfig | LegacyRoutingConfig>>> {
-    const { dependencies, activityId } = containerInjected
-
-    const requestId = context.awsRequestId
-    const quoteId = requestId.substring(0, 5)
-    // Sample 10% of all requests at the INFO log level for debugging purposes.
-    // All other requests will only log warnings and errors.
-    // Note that we use WARN as a default rather than ERROR
-    // to capture Tapcompare logs in the smart-order-router.
-    const logLevel = Math.random() < 0.1 ? bunyan.INFO : bunyan.WARN
-
     const {
       tokenInAddress,
       tokenInChainId,
@@ -50,7 +40,18 @@ export class QuoteHandlerInjector extends InjectorSOR<
       quoteSpeed,
       intent,
       gasToken,
+      enableDebug,
     } = requestQueryParams
+
+    const { dependencies, activityId } = containerInjected
+
+    const requestId = context.awsRequestId
+    const quoteId = requestId.substring(0, 5)
+    // Sample 10% of all requests at the INFO log level for debugging purposes.
+    // All other requests will only log warnings and errors.
+    // Note that we use WARN as a default rather than ERROR
+    // to capture Tapcompare logs in the smart-order-router.
+    const logLevel = enableDebug ? bunyan.DEBUG : Math.random() < 0.1 ? bunyan.INFO : bunyan.WARN
 
     log = log.child({
       serializers: bunyan.stdSerializers,

--- a/lib/handlers/quote/schema/quote-schema.ts
+++ b/lib/handlers/quote/schema/quote-schema.ts
@@ -73,6 +73,7 @@ export const QuoteQueryParamsJoi = Joi.object({
   source: Joi.string().max(20).optional(),
   gasToken: Joi.string().alphanum().max(42).optional(),
   cachedRoutesRouteIds: Joi.string().optional(),
+  enableDebug: Joi.boolean().optional().default(false),
 })
 
 // Future work: this TradeTypeParam can be converted into an enum and used in the
@@ -114,4 +115,5 @@ export type QuoteQueryParams = {
   gasToken?: string
   quotedId?: string
   cachedRoutesRouteIds?: string
+  enableDebug?: boolean
 }


### PR DESCRIPTION
we dont have a way to enable per-quote request debugging logging mode. this makes recent routing investigations harder. we need to enable debuggability in prod on demand to speed up the investigations.

One concrete example of the investigation difficulty is in https://uniswapteam.slack.com/archives/C021SU4PMR7/p1742316090353569?thread_ts=1741884189.239149&cid=C021SU4PMR7

local routing-api shows lots of logs, indicating debug on-demand works:

![Screenshot 2025-03-18 at 9.54.56 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/a2fddd95-607f-48eb-91ad-cc0e0122572a.png)

