### PR TITLE
chore: bump sor to 4.20.5 - fix: use v2 mixed quoter ABI for most chains

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^2.0.2",
         "@uniswap/sdk-core": "^7.7.1",
-        "@uniswap/smart-order-router": "4.20.4",
+        "@uniswap/smart-order-router": "4.20.5",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^4.19.5",
         "@uniswap/v2-sdk": "^4.15.2",
@@ -4508,9 +4508,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "4.20.4",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.20.4.tgz",
-      "integrity": "sha512-ew4462wfZ0mQAn755o0BdQglz0xkato1BF5Bm+9Ugvcc3EYCW7kaX/HCUyvgB0zmLXj9irBcD1fHi4FO/7n3Ww==",
+      "version": "4.20.5",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.20.5.tgz",
+      "integrity": "sha512-d5dKmM+2ZeqWzFIZ+2OSu6kX8p8mfD5I4OhRugrRC7ydIjcPGDYPxLggDvqNzDOkpKOPQfYOJJZ2qdgqeW4xMA==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -27936,9 +27936,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "4.20.4",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.20.4.tgz",
-      "integrity": "sha512-ew4462wfZ0mQAn755o0BdQglz0xkato1BF5Bm+9Ugvcc3EYCW7kaX/HCUyvgB0zmLXj9irBcD1fHi4FO/7n3Ww==",
+      "version": "4.20.5",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.20.5.tgz",
+      "integrity": "sha512-d5dKmM+2ZeqWzFIZ+2OSu6kX8p8mfD5I4OhRugrRC7ydIjcPGDYPxLggDvqNzDOkpKOPQfYOJJZ2qdgqeW4xMA==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@uniswap/permit2-sdk": "^1.3.0",
     "@uniswap/router-sdk": "^2.0.2",
     "@uniswap/sdk-core": "^7.7.1",
-    "@uniswap/smart-order-router": "4.20.4",
+    "@uniswap/smart-order-router": "4.20.5",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^4.19.5",
     "@uniswap/v2-sdk": "^4.15.2",


### PR DESCRIPTION
release https://github.com/Uniswap/smart-order-router/pull/844