### PR TITLE
chore: bump sor to 4.20.9 - fix: UR v1.2 should have mixed route w/ v4 pool filtered out

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^2.0.2",
         "@uniswap/sdk-core": "^7.7.1",
-        "@uniswap/smart-order-router": "4.20.8",
+        "@uniswap/smart-order-router": "4.20.9",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^4.19.5",
         "@uniswap/v2-sdk": "^4.15.2",
@@ -4508,9 +4508,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "4.20.8",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.20.8.tgz",
-      "integrity": "sha512-rLE1OJuWTg4JZhDZYieIB6+Qgzt+GXPKOBDEtEnYVXpgPKZ1JQ10C1SPRTVKjs6q2+mot1YAbZJyRl4K4DMU7w==",
+      "version": "4.20.9",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.20.9.tgz",
+      "integrity": "sha512-Rb1L+4S6Nz3Aarp58sCHdk93NR0SB0F6Y1ynvmjuQo4Kodu8b6XSHx8djeW/CGbAjMr3NtLNUhv0CTKakRoVLw==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -27936,9 +27936,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "4.20.8",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.20.8.tgz",
-      "integrity": "sha512-rLE1OJuWTg4JZhDZYieIB6+Qgzt+GXPKOBDEtEnYVXpgPKZ1JQ10C1SPRTVKjs6q2+mot1YAbZJyRl4K4DMU7w==",
+      "version": "4.20.9",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.20.9.tgz",
+      "integrity": "sha512-Rb1L+4S6Nz3Aarp58sCHdk93NR0SB0F6Y1ynvmjuQo4Kodu8b6XSHx8djeW/CGbAjMr3NtLNUhv0CTKakRoVLw==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@uniswap/permit2-sdk": "^1.3.0",
     "@uniswap/router-sdk": "^2.0.2",
     "@uniswap/sdk-core": "^7.7.1",
-    "@uniswap/smart-order-router": "4.20.8",
+    "@uniswap/smart-order-router": "4.20.9",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^4.19.5",
     "@uniswap/v2-sdk": "^4.15.2",


### PR DESCRIPTION
Release https://github.com/Uniswap/smart-order-router/pull/848