### PR TITLE
feat: get cached routes to filter out mismatched mixed routes against requested protocol versions

### DIFF
--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -353,7 +353,7 @@ export class QuoteHandler extends APIGLambdaHandler<
       ...(excludedProtocolsFromMixed ? { excludedProtocolsFromMixed } : {}),
       shouldEnableMixedRouteEthWeth: shouldEnableMixedRouteEthWeth,
       ...(cachedRoutesRouteIds ? { cachedRoutesRouteIds } : {}),
-      enableMixedRouteWithUR1_2Percent: 1, // enable mixed route with UR v1.2 fix at 1%, to see whether we see quote endpoint perf improvement.
+      enableMixedRouteWithUR1_2: 1 >= Math.random() * 100, // enable mixed route with UR v1.2 fix at 1%, to see whether we see quote endpoint perf improvement.
     }
 
     metric.putMetric(`${intent}Intent`, 1, MetricLoggerUnit.Count)

--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -353,6 +353,7 @@ export class QuoteHandler extends APIGLambdaHandler<
       ...(excludedProtocolsFromMixed ? { excludedProtocolsFromMixed } : {}),
       shouldEnableMixedRouteEthWeth: shouldEnableMixedRouteEthWeth,
       ...(cachedRoutesRouteIds ? { cachedRoutesRouteIds } : {}),
+      enableMixedRouteWithUR1_2Percent: 1, // enable mixed route with UR v1.2 fix at 1%, to see whether we see quote endpoint perf improvement.
     }
 
     metric.putMetric(`${intent}Intent`, 1, MetricLoggerUnit.Count)

--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -147,7 +147,7 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
             // requested protocols do not involve MIXED, so there is no need to filter by protocolsInvolved
             || !protocols.includes(Protocol.MIXED)
             // we know MIXED is getting requested, in this case, we need to ensure that protocolsInvolved contains at least one of the requested protocols
-            || protocols.includes(record.protocolsInvolved))
+            || protocols.includes(record.protocolsInvolved.split(',')))
           .sort((a, b) => b.blockNumber - a.blockNumber)
           .slice(0, this.ROUTES_TO_TAKE_FROM_ROUTES_DB)
 

--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -148,8 +148,10 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
               !record.protocolsInvolved ||
               // requested protocols do not involve MIXED, so there is no need to filter by protocolsInvolved
               !protocols.includes(Protocol.MIXED) ||
-              // we know MIXED is getting requested, in this case, we need to ensure that protocolsInvolved contains at least one of the requested protocols
-              (record.protocolsInvolved as String).split(',').every((protocol) => protocols.includes(protocol))
+              // we know MIXED is getting requested, in this case, we need to ensure that protocolsInvolved contains all the requested protocols
+              (record.protocolsInvolved as String)
+                .split(',')
+                .every((protocol) => (Object.values(protocols) as string[]).includes(protocol))
           )
           .sort((a, b) => b.blockNumber - a.blockNumber)
           .slice(0, this.ROUTES_TO_TAKE_FROM_ROUTES_DB)

--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -152,9 +152,13 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
             return (
               !record.protocolsInvolved ||
               !protocols.includes(Protocol.MIXED) ||
+              // if UR header is v2.0, then it does not make sense to have mixed route filter by protocols
+              // only when UR header is v1.2, we explicitly delete the V4 from protocols in
+              // https://github.com/Uniswap/smart-order-router/blob/main/src/routers/alpha-router/alpha-router.ts#L1461
+              alphaRouterConfig?.universalRouterVersion === UniversalRouterVersion.V2_0 ||
               // We want to roll out the mixed route with UR v1_2 with percent control,
               // along with the cached routes so that we can test the performance of the mixed route with UR v1_2ss
-              ((alphaRouterConfig?.enableMixedRouteWithUR1_2Percent ?? 0) >= Math.random() * 100 &&
+              (alphaRouterConfig?.enableMixedRouteWithUR1_2 &&
                 // requested protocols do not involve MIXED, so there is no need to filter by protocolsInvolved
                 // we know MIXED is getting requested, in this case, we need to ensure that protocolsInvolved contains all the requested protocols
                 (record.protocolsInvolved as String)

--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -165,6 +165,7 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
         if (protocols.includes(Protocol.MIXED)) {
           filteredItems.forEach((record) => {
             if (
+              record.protocolsInvolved &&
               !(record.protocolsInvolved as String)
                 .split(',')
                 .every((protocol) => protocols.includes(protocol as Protocol))

--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -9,7 +9,7 @@ import {
   metric,
   MetricLoggerUnit,
   routeToString,
-  SupportedRoutes,
+  SupportedRoutes
 } from '@uniswap/smart-order-router'
 import { AWSError, DynamoDB, Lambda } from 'aws-sdk'
 import { ChainId, Currency, CurrencyAmount, Fraction, Token, TradeType } from '@uniswap/sdk-core'
@@ -142,6 +142,12 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
         const filteredItems = result.Items
           // Older routes might not have the protocol field, so we keep them if they don't have it
           .filter((record) => !record.protocol || protocols.includes(record.protocol))
+          // Older routes might not have the protocolsInvolved field, so we keep them if they don't have it
+          .filter((record) => !record.protocolsInvolved
+            // requested protocols do not involve MIXED, so there is no need to filter by protocolsInvolved
+            || !protocols.includes(Protocol.MIXED)
+            // we know MIXED is getting requested, in this case, we need to ensure that protocolsInvolved contains at least one of the requested protocols
+            || protocols.includes(record.protocolsInvolved))
           .sort((a, b) => b.blockNumber - a.blockNumber)
           .slice(0, this.ROUTES_TO_TAKE_FROM_ROUTES_DB)
 

--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -96,6 +96,9 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
    * @param quoteCurrency
    * @param tradeType
    * @param protocols
+   * @param currentBlockNumber
+   * @param optimistic
+   * @param alphaRouterConfig
    * @protected
    */
   protected override async _getCachedRoute(

--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -149,7 +149,7 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
               // requested protocols do not involve MIXED, so there is no need to filter by protocolsInvolved
               !protocols.includes(Protocol.MIXED) ||
               // we know MIXED is getting requested, in this case, we need to ensure that protocolsInvolved contains at least one of the requested protocols
-              protocols.every((protocol) => (record.protocolsInvolved as String).split(',').includes(protocol))
+              (record.protocolsInvolved as String).split(',').every((protocol) => protocols.includes(protocol))
           )
           .sort((a, b) => b.blockNumber - a.blockNumber)
           .slice(0, this.ROUTES_TO_TAKE_FROM_ROUTES_DB)

--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -149,7 +149,7 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
               // requested protocols do not involve MIXED, so there is no need to filter by protocolsInvolved
               !protocols.includes(Protocol.MIXED) ||
               // we know MIXED is getting requested, in this case, we need to ensure that protocolsInvolved contains at least one of the requested protocols
-              protocols.includes(record.protocolsInvolved.split(','))
+              protocols.every((protocol) => (record.protocolsInvolved as String).split(',').includes(protocol))
           )
           .sort((a, b) => b.blockNumber - a.blockNumber)
           .slice(0, this.ROUTES_TO_TAKE_FROM_ROUTES_DB)

--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -9,7 +9,7 @@ import {
   metric,
   MetricLoggerUnit,
   routeToString,
-  SupportedRoutes
+  SupportedRoutes,
 } from '@uniswap/smart-order-router'
 import { AWSError, DynamoDB, Lambda } from 'aws-sdk'
 import { ChainId, Currency, CurrencyAmount, Fraction, Token, TradeType } from '@uniswap/sdk-core'
@@ -143,11 +143,14 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
           // Older routes might not have the protocol field, so we keep them if they don't have it
           .filter((record) => !record.protocol || protocols.includes(record.protocol))
           // Older routes might not have the protocolsInvolved field, so we keep them if they don't have it
-          .filter((record) => !record.protocolsInvolved
-            // requested protocols do not involve MIXED, so there is no need to filter by protocolsInvolved
-            || !protocols.includes(Protocol.MIXED)
-            // we know MIXED is getting requested, in this case, we need to ensure that protocolsInvolved contains at least one of the requested protocols
-            || protocols.includes(record.protocolsInvolved.split(',')))
+          .filter(
+            (record) =>
+              !record.protocolsInvolved ||
+              // requested protocols do not involve MIXED, so there is no need to filter by protocolsInvolved
+              !protocols.includes(Protocol.MIXED) ||
+              // we know MIXED is getting requested, in this case, we need to ensure that protocolsInvolved contains at least one of the requested protocols
+              protocols.includes(record.protocolsInvolved.split(','))
+          )
           .sort((a, b) => b.blockNumber - a.blockNumber)
           .slice(0, this.ROUTES_TO_TAKE_FROM_ROUTES_DB)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^2.0.2",
         "@uniswap/sdk-core": "^7.7.1",
-        "@uniswap/smart-order-router": "4.20.10",
+        "@uniswap/smart-order-router": "4.20.11",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^4.19.5",
         "@uniswap/v2-sdk": "^4.15.2",
@@ -4508,9 +4508,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "4.20.10",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.20.10.tgz",
-      "integrity": "sha512-0W9Y5vREx8C3TMjov3+1x91AqVopnkNGcOWrxxDaHWhn6Tumk7PFTm/Y3rdWp4Az07P2IzVrDLa+LZn81HOeEw==",
+      "version": "4.20.11",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.20.11.tgz",
+      "integrity": "sha512-W4MFkI6PZ+sbRx5RnmN/kQzir5hNvmj8z2zDRkRXEccY2UBTUzorDJDW8gjSFD3ym+yi2se5azXt1n43aaqs+A==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -27936,9 +27936,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "4.20.10",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.20.10.tgz",
-      "integrity": "sha512-0W9Y5vREx8C3TMjov3+1x91AqVopnkNGcOWrxxDaHWhn6Tumk7PFTm/Y3rdWp4Az07P2IzVrDLa+LZn81HOeEw==",
+      "version": "4.20.11",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.20.11.tgz",
+      "integrity": "sha512-W4MFkI6PZ+sbRx5RnmN/kQzir5hNvmj8z2zDRkRXEccY2UBTUzorDJDW8gjSFD3ym+yi2se5azXt1n43aaqs+A==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^2.0.2",
         "@uniswap/sdk-core": "^7.7.1",
-        "@uniswap/smart-order-router": "4.20.11",
+        "@uniswap/smart-order-router": "4.20.12",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^4.19.5",
         "@uniswap/v2-sdk": "^4.15.2",
@@ -4508,9 +4508,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "4.20.11",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.20.11.tgz",
-      "integrity": "sha512-W4MFkI6PZ+sbRx5RnmN/kQzir5hNvmj8z2zDRkRXEccY2UBTUzorDJDW8gjSFD3ym+yi2se5azXt1n43aaqs+A==",
+      "version": "4.20.12",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.20.12.tgz",
+      "integrity": "sha512-ygNByiB94LIcUkWsM+RDhZAC6++MHMz6MTBh3SGR/QUheLSaCaFZJvX0xTspUPycpz78trHy1SfjXs7HNyNvFA==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -27936,9 +27936,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "4.20.11",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.20.11.tgz",
-      "integrity": "sha512-W4MFkI6PZ+sbRx5RnmN/kQzir5hNvmj8z2zDRkRXEccY2UBTUzorDJDW8gjSFD3ym+yi2se5azXt1n43aaqs+A==",
+      "version": "4.20.12",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.20.12.tgz",
+      "integrity": "sha512-ygNByiB94LIcUkWsM+RDhZAC6++MHMz6MTBh3SGR/QUheLSaCaFZJvX0xTspUPycpz78trHy1SfjXs7HNyNvFA==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@uniswap/permit2-sdk": "^1.3.0",
     "@uniswap/router-sdk": "^2.0.2",
     "@uniswap/sdk-core": "^7.7.1",
-    "@uniswap/smart-order-router": "4.20.11",
+    "@uniswap/smart-order-router": "4.20.12",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^4.19.5",
     "@uniswap/v2-sdk": "^4.15.2",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@uniswap/permit2-sdk": "^1.3.0",
     "@uniswap/router-sdk": "^2.0.2",
     "@uniswap/sdk-core": "^7.7.1",
-    "@uniswap/smart-order-router": "4.20.10",
+    "@uniswap/smart-order-router": "4.20.11",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^4.19.5",
     "@uniswap/v2-sdk": "^4.15.2",

--- a/test/mocha/e2e/quote.test.ts
+++ b/test/mocha/e2e/quote.test.ts
@@ -1497,7 +1497,7 @@ describe('quote', function () {
 
             // Test that repros https://uniswapteam.slack.com/archives/C08JM8SKMV2/p1742424330903569?thread_ts=1742424322.824189&cid=C08JM8SKMV2
             // Where quote request contains v2,v3
-            it(`erc20 -> erc20 cached routes should not return mixed route`, async() => {
+            it(`erc20 -> erc20 cached routes should not return mixed route`, async () => {
               if (type !== 'exactIn') {
                 return
               }
@@ -1520,10 +1520,9 @@ describe('quote', function () {
 
               const queryParams = qs.stringify(quoteReq)
 
-              const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(
-                `${API}?${queryParams}`,
-                { headers: HEADERS_1_2 }
-              )
+              const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(`${API}?${queryParams}`, {
+                headers: HEADERS_1_2,
+              })
 
               const {
                 data: { route },
@@ -1534,8 +1533,8 @@ describe('quote', function () {
 
               // Verify no mixed routes returned when using cached routes
               for (const r of route) {
-                expect(r.every(pool => pool.type === 'v3-pool' || pool.type === 'v2-pool')).to.equal(true)
-                expect(r.every(pool => pool.type !== 'v4-pool')).to.equal(true)
+                expect(r.every((pool) => pool.type === 'v3-pool' || pool.type === 'v2-pool')).to.equal(true)
+                expect(r.every((pool) => pool.type !== 'v4-pool')).to.equal(true)
               }
             })
 

--- a/test/mocha/e2e/quote.test.ts
+++ b/test/mocha/e2e/quote.test.ts
@@ -1495,6 +1495,8 @@ describe('quote', function () {
               }
             })
 
+            // Test that repros https://uniswapteam.slack.com/archives/C08JM8SKMV2/p1742424330903569?thread_ts=1742424322.824189&cid=C08JM8SKMV2
+            // Where quote request contains v2,v3
             it(`erc20 -> erc20 cached routes should not return mixed route`, async() => {
               if (type !== 'exactIn') {
                 return
@@ -1520,7 +1522,7 @@ describe('quote', function () {
 
               const response: AxiosResponse<QuoteResponse> = await axios.get<QuoteResponse>(
                 `${API}?${queryParams}`,
-                { headers: HEADERS_2_0 }
+                { headers: HEADERS_1_2 }
               )
 
               const {
@@ -1533,6 +1535,7 @@ describe('quote', function () {
               // Verify no mixed routes returned when using cached routes
               for (const r of route) {
                 expect(r.every(pool => pool.type === 'v3-pool' || pool.type === 'v2-pool')).to.equal(true)
+                expect(r.every(pool => pool.type !== 'v4-pool')).to.equal(true)
               }
             })
 

--- a/test/mocha/integ/handlers/router-entities/route-caching/dynamo-route-caching-provider.test.ts
+++ b/test/mocha/integ/handlers/router-entities/route-caching/dynamo-route-caching-provider.test.ts
@@ -30,6 +30,7 @@ import sinon, { SinonSpy } from 'sinon'
 import { metric } from '@uniswap/smart-order-router/build/main/util/metric'
 import { DynamoDB } from 'aws-sdk'
 import { DEFAULT_ROUTING_CONFIG_BY_CHAIN } from '../../../../../../lib/handlers/shared'
+import { UniversalRouterVersion } from '@uniswap/universal-router-sdk'
 
 chai.use(chaiAsPromised)
 
@@ -428,7 +429,7 @@ describe('DynamoRouteCachingProvider', async () => {
       false,
       {
         ...DEFAULT_ROUTING_CONFIG_BY_CHAIN(ChainId.MAINNET),
-        enableMixedRouteWithUR1_2Percent: 100,
+        enableMixedRouteWithUR1_2: true,
       }
     )
     expect(route).to.not.be.undefined
@@ -444,7 +445,7 @@ describe('DynamoRouteCachingProvider', async () => {
       false,
       {
         ...DEFAULT_ROUTING_CONFIG_BY_CHAIN(ChainId.MAINNET),
-        enableMixedRouteWithUR1_2Percent: 100,
+        enableMixedRouteWithUR1_2: true,
       }
     )
     expect(mixedRoutes).to.not.be.undefined
@@ -460,7 +461,7 @@ describe('DynamoRouteCachingProvider', async () => {
       false,
       {
         ...DEFAULT_ROUTING_CONFIG_BY_CHAIN(ChainId.MAINNET),
-        enableMixedRouteWithUR1_2Percent: 100,
+        enableMixedRouteWithUR1_2: true,
       }
     )
     expect(mixedRouteWithExtraV2).to.not.be.undefined
@@ -476,10 +477,27 @@ describe('DynamoRouteCachingProvider', async () => {
       false,
       {
         ...DEFAULT_ROUTING_CONFIG_BY_CHAIN(ChainId.MAINNET),
-        enableMixedRouteWithUR1_2Percent: 100,
+        enableMixedRouteWithUR1_2: true,
       }
     )
     expect(nonExistV3OnlyMixedRoutes).to.be.undefined
+
+    const nonExistV3OnlyMixedRoutesUR2_0 = await dynamoRouteCache.getCachedRoute(
+      ChainId.MAINNET,
+      currencyAmount,
+      UNI_MAINNET,
+      TradeType.EXACT_INPUT,
+      // we fetch mixed route with only v3 missing v4, expect to retrieve nothing
+      [Protocol.MIXED, Protocol.V3],
+      TEST_CACHED_MIXED_ROUTES.blockNumber,
+      false,
+      {
+        ...DEFAULT_ROUTING_CONFIG_BY_CHAIN(ChainId.MAINNET),
+        universalRouterVersion: UniversalRouterVersion.V2_0,
+        enableMixedRouteWithUR1_2: true,
+      }
+    )
+    expect(nonExistV3OnlyMixedRoutesUR2_0).not.to.be.undefined
 
     const nonExistV4OnlyMixedRoutes = await dynamoRouteCache.getCachedRoute(
       ChainId.MAINNET,
@@ -492,9 +510,26 @@ describe('DynamoRouteCachingProvider', async () => {
       false,
       {
         ...DEFAULT_ROUTING_CONFIG_BY_CHAIN(ChainId.MAINNET),
-        enableMixedRouteWithUR1_2Percent: 100,
+        enableMixedRouteWithUR1_2: true,
       }
     )
     expect(nonExistV4OnlyMixedRoutes).to.be.undefined
+
+    const nonExistV4OnlyMixedRoutesUR2_0 = await dynamoRouteCache.getCachedRoute(
+      ChainId.MAINNET,
+      currencyAmount,
+      UNI_MAINNET,
+      TradeType.EXACT_INPUT,
+      // we fetch mixed route with only v4 missing v3, expect to retrieve nothing
+      [Protocol.MIXED, Protocol.V4],
+      TEST_CACHED_MIXED_ROUTES.blockNumber,
+      false,
+      {
+        ...DEFAULT_ROUTING_CONFIG_BY_CHAIN(ChainId.MAINNET),
+        universalRouterVersion: UniversalRouterVersion.V2_0,
+        enableMixedRouteWithUR1_2: true,
+      }
+    )
+    expect(nonExistV4OnlyMixedRoutesUR2_0).not.to.be.undefined
   })
 })


### PR DESCRIPTION
part 2 is to filter out the cached routes which happens to be mixed route, and when requested protocol versions include MIXED. We need to ensure, when this happens, mixed route needs to have exact requested protocol versions match, e.g. V2,V3, then MIXED routes has to include V2,V3 in protocolsInvolved.

Pending e2e test