### PR TITLE
fix: migrate routing-api pipeline github access token

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -1,6 +1,6 @@
 import { ChainId } from '@uniswap/sdk-core'
 import * as cdk from 'aws-cdk-lib'
-import { CfnOutput, SecretValue, Stack, StackProps, Stage, StageProps } from 'aws-cdk-lib'
+import { CfnOutput, Stack, StackProps, Stage, StageProps } from 'aws-cdk-lib'
 import * as chatbot from 'aws-cdk-lib/aws-chatbot'
 import { BuildEnvironmentVariableType } from 'aws-cdk-lib/aws-codebuild'
 import { PipelineNotificationEvents } from 'aws-cdk-lib/aws-codepipeline'
@@ -95,8 +95,9 @@ export class RoutingAPIPipeline extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props)
 
-    const code = CodePipelineSource.gitHub('Uniswap/routing-api', 'main', {
-      authentication: SecretValue.secretsManager('github-token-2'),
+    const code = CodePipelineSource.connection('Uniswap/routing-api', 'main', {
+      connectionArn:
+        'arn:aws:codestar-connections:us-east-2:644039819003:connection/4806faf1-c31e-4ea2-a5bf-c6fc1fa79487',
     })
 
     const synthStep = new CodeBuildStep('Synth', {


### PR DESCRIPTION
routing-api didn't update the github connection from personal access token to code-star connection, see https://uniswapteam.slack.com/archives/C015DE5T719/p1743700451038299?thread_ts=1743642201.084969&cid=C015DE5T719.

we are updating the code to connect via codestar. note it also requires AWS admin to update routing-api pipeline policy to allow codestar connection. See past [commit](https://github.com/Uniswap/uniswapx-parameterization-api/commit/8be2eefdd9d751ee96d26494edd9baf641d395e3) from other repo as an example.