### PR TITLE
fix(alerts): increase evaluationPeriods for low-volume chains alerts v2

### DIFF
--- a/bin/stacks/routing-api-stack.ts
+++ b/bin/stacks/routing-api-stack.ts
@@ -31,10 +31,15 @@ export const LOW_VOLUME_CHAINS: Set<ChainId> = new Set([
   ChainId.BLAST,
   ChainId.ZKSYNC,
   ChainId.SONEIUM,
+  ChainId.AVALANCHE,
+  ChainId.WORLDCHAIN
 ])
 
 // For low volume request sources, we'll increase the evaluation periods to reduce triggering sensitivity.
-export const LOW_VOLUME_REQUEST_SOURCES: Set<string> = new Set(['uniswap-extension'])
+export const LOW_VOLUME_REQUEST_SOURCES: Set<string> = new Set([
+  'uniswap-extension',
+  'uniswap-android'
+])
 
 export class RoutingAPIStack extends cdk.Stack {
   public readonly url: CfnOutput

--- a/bin/stacks/routing-api-stack.ts
+++ b/bin/stacks/routing-api-stack.ts
@@ -32,14 +32,11 @@ export const LOW_VOLUME_CHAINS: Set<ChainId> = new Set([
   ChainId.ZKSYNC,
   ChainId.SONEIUM,
   ChainId.AVALANCHE,
-  ChainId.WORLDCHAIN
+  ChainId.WORLDCHAIN,
 ])
 
 // For low volume request sources, we'll increase the evaluation periods to reduce triggering sensitivity.
-export const LOW_VOLUME_REQUEST_SOURCES: Set<string> = new Set([
-  'uniswap-extension',
-  'uniswap-android'
-])
+export const LOW_VOLUME_REQUEST_SOURCES: Set<string> = new Set(['uniswap-extension', 'uniswap-android'])
 
 export class RoutingAPIStack extends cdk.Stack {
   public readonly url: CfnOutput


### PR DESCRIPTION
Low-volume chains/request sources alerts are very sensitive to small hiccups.
This PR increases the evaluation period from 2 to 4 for low-volume chains/request sources

each period is 5mins so we'll get notified if alert lasts for 20 mins instead of 10mins)