### PR TITLE
fix: add bnb protocol v4 subgraph cronjob

### DIFF
--- a/lib/cron/cache-config.ts
+++ b/lib/cron/cache-config.ts
@@ -622,4 +622,18 @@ export const chainProtocols = [
       v4SubgraphUrlOverride(ChainId.SONEIUM)
     ),
   },
+  {
+    protocol: Protocol.V4,
+    chainId: ChainId.BNB,
+    timeout: 90000,
+    provider: new V4SubgraphProvider(
+      ChainId.BNB,
+      3,
+      90000,
+      true,
+      v4TrackedEthThreshold,
+      v4UntrackedUsdThreshold,
+      v4SubgraphUrlOverride(ChainId.BNB)
+    ),
+  }
 ]

--- a/lib/cron/cache-config.ts
+++ b/lib/cron/cache-config.ts
@@ -635,5 +635,5 @@ export const chainProtocols = [
       v4UntrackedUsdThreshold,
       v4SubgraphUrlOverride(ChainId.BNB)
     ),
-  }
+  },
 ]


### PR DESCRIPTION
I don't see BNB V4 cronjob lambda:

![Screenshot 2025-04-16 at 1.45.38 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/c3b9facb-e114-41b4-9aef-3d12370b5441.png)

Because I forgot to add it into the cache-cron