### PR TITLE
feat: routing-api support route hook toggle

### DIFF
--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -239,6 +239,7 @@ export class QuoteHandler extends APIGLambdaHandler<
         gasToken,
         cachedRoutesRouteIds,
         enableDebug,
+        hooksOptions,
       },
       requestInjected: {
         router,
@@ -358,6 +359,7 @@ export class QuoteHandler extends APIGLambdaHandler<
       ...(cachedRoutesRouteIds ? { cachedRoutesRouteIds } : {}),
       enableMixedRouteWithUR1_2: 100 >= Math.random() * 100, // enable mixed route with UR v1.2 fix at 50%, to see whether we see quote endpoint perf improvement.
       enableDebug: enableDebug,
+      hooksOptions: hooksOptions,
     }
 
     metric.putMetric(`${intent}Intent`, 1, MetricLoggerUnit.Count)

--- a/lib/handlers/quote/schema/quote-schema.ts
+++ b/lib/handlers/quote/schema/quote-schema.ts
@@ -1,5 +1,6 @@
 import BaseJoi from '@hapi/joi'
 import { SUPPORTED_CHAINS } from '../../injector-sor'
+import { HooksOptions } from '@uniswap/smart-order-router'
 
 const Joi = BaseJoi.extend((joi) => ({
   base: joi.array(),
@@ -116,4 +117,5 @@ export type QuoteQueryParams = {
   quotedId?: string
   cachedRoutesRouteIds?: string
   enableDebug?: boolean
+  hooksOptions?: HooksOptions
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^2.0.2",
         "@uniswap/sdk-core": "^7.7.1",
-        "@uniswap/smart-order-router": "4.20.13",
+        "@uniswap/smart-order-router": "4.21.0",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^4.19.5",
         "@uniswap/v2-sdk": "^4.15.2",
@@ -4508,9 +4508,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "4.20.13",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.20.13.tgz",
-      "integrity": "sha512-k4W1HYLsnF9cpvwJjRWwkAF8gWAybQgjl1dzl03FK2WROU3hmS97LLunRv4zFWPXhoGSJwQFHJ9bHRxW/yzsZA==",
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.21.0.tgz",
+      "integrity": "sha512-evAVFEsKpofqaTLkG/xa/Lq6b28yxHEi9s8Pb0eVxFO6tETlhEo3aJ8HUw3QuqXTjyhdwsHo9O5ziwOjtXQ+DQ==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -27936,9 +27936,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "4.20.13",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.20.13.tgz",
-      "integrity": "sha512-k4W1HYLsnF9cpvwJjRWwkAF8gWAybQgjl1dzl03FK2WROU3hmS97LLunRv4zFWPXhoGSJwQFHJ9bHRxW/yzsZA==",
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.21.0.tgz",
+      "integrity": "sha512-evAVFEsKpofqaTLkG/xa/Lq6b28yxHEi9s8Pb0eVxFO6tETlhEo3aJ8HUw3QuqXTjyhdwsHo9O5ziwOjtXQ+DQ==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@uniswap/permit2-sdk": "^1.3.0",
     "@uniswap/router-sdk": "^2.0.2",
     "@uniswap/sdk-core": "^7.7.1",
-    "@uniswap/smart-order-router": "4.20.13",
+    "@uniswap/smart-order-router": "4.21.0",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^4.19.5",
     "@uniswap/v2-sdk": "^4.15.2",


### PR DESCRIPTION
routing-api query string param to accept hooksOption with enum NO_HOOKS, HOOKS_ONLY, or HOOKS_INCLUSIVE. Spec in https://linear.app/uniswap/issue/ROUTE-424/routing-without-hooks