### PR TITLE
fix: add hooksOption into quote schema

### DIFF
--- a/lib/handlers/quote/schema/quote-schema.ts
+++ b/lib/handlers/quote/schema/quote-schema.ts
@@ -75,6 +75,7 @@ export const QuoteQueryParamsJoi = Joi.object({
   gasToken: Joi.string().alphanum().max(42).optional(),
   cachedRoutesRouteIds: Joi.string().optional(),
   enableDebug: Joi.boolean().optional().default(false),
+  hooksOptions: Joi.string().valid('NO_HOOKS', 'HOOKS_ONLY', 'HOOKS_INCLUSIVE').optional(),
 })
 
 // Future work: this TradeTypeParam can be converted into an enum and used in the


### PR DESCRIPTION
tested this makes hook toggle finally works.

HOOKS_ONLY against local endpoint - https://app.warp.dev/block/a1UGK525Rn8XHYcDN6amNt
HOOKS_ONLY against prod endpoint - https://app.warp.dev/block/yNYUdObrf1sPZRhsVZe04H

correct behavior is we no longer anticipate a hookless route through USD₮0 -> USDC on unichain, because we specified HOOKS_ONLY. However this case is not possible w/ current UI toggle design, so low priority.

NO_HOOKS against local endpoint - https://app.warp.dev/block/vjKOmHGdooiiqbkrYr1ByZ
NO_HOOKS against prod endpoint -https://app.warp.dev/block/4isnjJR0xpVhpB8RtJ4fKg

correct behavior is we no longer expect a hookful route through ETH -> flETH -> BHDG on base, because we specified NO_HOOKS. This is a high priority user story to support.

HOOKS_INCLUSIVE against local endpoint -  https://app.warp.dev/block/oH0VKHYVUaE4jwiPvZ9EOy
no hooksOptions specified - https://app.warp.dev/block/U2GCoQByBqTl1anQsgcTHd

Those two user story are default behavior, hence returning exactly the same route. high priority.