### PR TITLE
chore: bump sor to 4.21.2 - feat: skip cachedRoutes for large swaps

### DIFF
--- a/lib/graphql/graphql-provider.ts
+++ b/lib/graphql/graphql-provider.ts
@@ -3,9 +3,11 @@ import { ChainId } from '@uniswap/sdk-core'
 import { GraphQLClient, IGraphQLClient } from './graphql-client'
 import {
   GRAPHQL_QUERY_MULTIPLE_TOKEN_INFO_BY_CONTRACTS,
+  GRAPHQL_QUERY_MULTIPLE_TOKEN_PRICE_BY_CONTRACTS,
   GRAPHQL_QUERY_TOKEN_INFO_BY_ADDRESS_CHAIN,
+  GRAPHQL_QUERY_TOKEN_PRICE_BY_ADDRESS_CHAIN,
 } from './graphql-queries'
-import { TokenInfoResponse, TokensInfoResponse } from './graphql-schemas'
+import { TokenInfoResponse, TokensInfoResponse, TokenPriceResponse, TokensPriceResponse } from './graphql-schemas'
 
 /* Interface for accessing Uniswap GraphQL API */
 export interface IUniGraphQLProvider {
@@ -13,6 +15,10 @@ export interface IUniGraphQLProvider {
   getTokenInfo(chainId: ChainId, address: string): Promise<TokenInfoResponse>
   /* Fetch token info for multiple tokens given a chain and addresses */
   getTokensInfo(chainId: ChainId, addresses: string[]): Promise<TokensInfoResponse>
+  /* Fetch token price for multiple tokens given a chain and addresses */
+  getTokensPrice(chainId: ChainId, addresses: string[]): Promise<TokensPriceResponse>
+  /* Fetch token price for a single token given a chain and address */
+  getTokenPrice(chainId: ChainId, address: string): Promise<TokenPriceResponse>
   // Add more methods here as needed.
   // - more details: https://github.com/Uniswap/data-api-graphql/blob/main/graphql/schema.graphql
 }
@@ -88,5 +94,21 @@ export class UniGraphQLProvider implements IUniGraphQLProvider {
     }))
     const variables = { contracts: contracts }
     return this.client.fetchData<TokensInfoResponse>(query, variables)
+  }
+
+  async getTokenPrice(chainId: ChainId, address: string): Promise<TokenPriceResponse> {
+    const query = GRAPHQL_QUERY_TOKEN_PRICE_BY_ADDRESS_CHAIN
+    const variables = { chain: this._chainIdToGraphQLChainName(chainId), address: address }
+    return this.client.fetchData<TokenPriceResponse>(query, variables)
+  }
+
+  async getTokensPrice(chainId: ChainId, addresses: string[]): Promise<TokensPriceResponse> {
+    const query = GRAPHQL_QUERY_MULTIPLE_TOKEN_PRICE_BY_CONTRACTS
+    const contracts = addresses.map((address) => ({
+      chain: this._chainIdToGraphQLChainName(chainId),
+      address: address,
+    }))
+    const variables = { contracts: contracts }
+    return this.client.fetchData<TokensPriceResponse>(query, variables)
   }
 }

--- a/lib/graphql/graphql-queries.ts
+++ b/lib/graphql/graphql-queries.ts
@@ -39,3 +39,41 @@ query Tokens($contracts: [ContractInput!]!) {
       }
     }
 `
+
+/* Query to get the token price by address and chain */
+export const GRAPHQL_QUERY_TOKEN_PRICE_BY_ADDRESS_CHAIN = `
+query Token($chain: Chain!, $address: String!) {
+        token(chain: $chain, address: $address) {
+            name
+            chain
+            address
+            decimals
+            symbol
+            standard
+            market {
+                price {
+                    value
+                }
+            }
+        }
+    }
+`
+
+/* Query to get the token price by multiple addresses and chain */
+export const GRAPHQL_QUERY_MULTIPLE_TOKEN_PRICE_BY_CONTRACTS = `
+query Tokens($contracts: [ContractInput!]!) {
+      tokens(contracts: $contracts) {
+          name
+          chain
+          address
+          decimals
+          symbol
+          standard
+          market {
+              price {
+                  value
+              }
+          }
+      }
+  }
+`

--- a/lib/graphql/graphql-schemas.ts
+++ b/lib/graphql/graphql-schemas.ts
@@ -26,3 +26,25 @@ export interface TokenInfo {
     sellReverted?: boolean
   }
 }
+
+export interface TokenPriceResponse {
+  token: TokenPrice
+}
+
+export interface TokensPriceResponse {
+  tokens: TokenPrice[]
+}
+
+export interface TokenPrice {
+  name: string
+  chain: string
+  address: string
+  decimals: number
+  symbol: string
+  standard: string
+  market: {
+    price: {
+      value: number
+    }
+  }
+}

--- a/lib/graphql/graphql-token-price-fetcher.ts
+++ b/lib/graphql/graphql-token-price-fetcher.ts
@@ -1,0 +1,52 @@
+import {
+  ITokenPriceFetcher,
+  TokenPricesMap,
+} from '@uniswap/smart-order-router/build/main/providers/token-price-provider'
+import { IUniGraphQLProvider } from './graphql-provider'
+import { ProviderConfig } from '@uniswap/smart-order-router/build/main/providers/provider'
+import { TokensPriceResponse } from './graphql-schemas'
+import { ChainId } from '@uniswap/sdk-core'
+import { metric } from '@uniswap/smart-order-router/build/main/util/metric'
+import { log, MetricLoggerUnit } from '@uniswap/smart-order-router'
+
+// Implementation of the ITokenFeeFetcher interface to give access to Uniswap GraphQL API token price data.
+export class GraphQLTokenPriceFetcher implements ITokenPriceFetcher {
+  private readonly graphQLProvider: IUniGraphQLProvider
+  private readonly chainId: ChainId
+
+  constructor(graphQLProvider: IUniGraphQLProvider, chainId: ChainId) {
+    this.graphQLProvider = graphQLProvider
+    this.chainId = chainId
+  }
+
+  async fetchPrices(addresses: string[], _providerConfig?: ProviderConfig): Promise<TokenPricesMap> {
+    let tokenPricesMap: TokenPricesMap = {}
+
+    try {
+      if (addresses.length > 0) {
+        const tokensPriceResponse: TokensPriceResponse = await this.graphQLProvider.getTokensPrice(
+          this.chainId,
+          addresses
+        )
+        tokensPriceResponse.tokens.forEach((token) => {
+          if (token && token.market && token.market.price && token.market.price.value) {
+            tokenPricesMap[token.address] = {
+              price: token.market.price.value,
+            }
+          } else {
+            tokenPricesMap[token.address] = {
+              price: undefined,
+            }
+          }
+        })
+        metric.putMetric('GraphQLTokenPriceFetcherFetchFeesSuccess', 1, MetricLoggerUnit.Count)
+      }
+    } catch (err) {
+      log.error({ err }, `Error calling GraphQLTokenPriceFetcher for tokens: ${addresses}`)
+
+      metric.putMetric('GraphQLTokenPriceFetcherFetchFeesFailure', 1, MetricLoggerUnit.Count)
+    }
+
+    return tokenPricesMap
+  }
+}

--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -38,6 +38,7 @@ import {
   StaticV3SubgraphProvider,
   StaticV4SubgraphProvider,
   TenderlySimulator,
+  TokenPriceProvider,
   TokenPropertiesProvider,
   TokenProvider,
   TokenValidatorProvider,
@@ -92,6 +93,7 @@ import {
 } from '../util/extraV4FeeTiersTickSpacingsHookAddresses'
 import { NEW_CACHED_ROUTES_ROLLOUT_PERCENT } from '../util/newCachedRoutesRolloutPercent'
 import { TENDERLY_NEW_ENDPOINT_ROLLOUT_PERCENT } from '../util/tenderlyNewEndpointRolloutPercent'
+import { GraphQLTokenPriceFetcher } from '../graphql/graphql-token-price-fetcher'
 
 export const SUPPORTED_CHAINS: ChainId[] = [
   ChainId.MAINNET,
@@ -154,6 +156,7 @@ export type ContainerDependencies = {
   mixedSupported?: ChainId[]
   v4PoolParams?: Array<[number, number, string]>
   cachedRoutesCacheInvalidationFixRolloutPercentage?: number
+  tokenPriceProvider: TokenPriceProvider
 }
 
 export interface ContainerInjected {
@@ -291,6 +294,12 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
               pctShadowSampling: 0.005,
             },
           })
+          const graphQLTokenPriceFetcher = new GraphQLTokenPriceFetcher(new UniGraphQLProvider(), chainId)
+          const tokenPriceProvider = new TokenPriceProvider(
+            chainId,
+            new NodeJSCache(new NodeCache({ stdTTL: 30000, useClones: false })),
+            graphQLTokenPriceFetcher
+          )
 
           const tokenValidatorProvider = new TokenValidatorProvider(
             chainId,
@@ -592,6 +601,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
               mixedSupported,
               v4PoolParams,
               cachedRoutesCacheInvalidationFixRolloutPercentage,
+              tokenPriceProvider,
             },
           }
         })

--- a/lib/handlers/quote/injector.ts
+++ b/lib/handlers/quote/injector.ts
@@ -106,6 +106,7 @@ export class QuoteHandlerInjector extends InjectorSOR<
       mixedSupported,
       v4PoolParams,
       cachedRoutesCacheInvalidationFixRolloutPercentage,
+      tokenPriceProvider,
     } = dependencies[chainIdEnum]!
 
     let onChainQuoteProvider = dependencies[chainIdEnum]!.onChainQuoteProvider
@@ -144,6 +145,7 @@ export class QuoteHandlerInjector extends InjectorSOR<
           mixedSupported,
           v4PoolParams,
           cachedRoutesCacheInvalidationFixRolloutPercentage,
+          tokenPriceProvider,
         })
         break
     }

--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -26,6 +26,7 @@ import {
   DEFAULT_ROUTING_CONFIG_BY_CHAIN,
   FEE_ON_TRANSFER_SPECIFIC_CONFIG,
   INTENT_SPECIFIC_CONFIG,
+  LARGE_SWAP_USD_THRESHOLD,
   QUOTE_SPEED_CONFIG,
 } from '../shared'
 import { QuoteQueryParams, QuoteQueryParamsJoi, TradeTypeParam } from './schema/quote-schema'
@@ -360,6 +361,7 @@ export class QuoteHandler extends APIGLambdaHandler<
       enableMixedRouteWithUR1_2: 100 >= Math.random() * 100, // enable mixed route with UR v1.2 fix at 50%, to see whether we see quote endpoint perf improvement.
       enableDebug: enableDebug,
       hooksOptions: hooksOptions,
+      largeSwapUsdThreshold: LARGE_SWAP_USD_THRESHOLD,
     }
 
     metric.putMetric(`${intent}Intent`, 1, MetricLoggerUnit.Count)

--- a/lib/handlers/quote/schema/quote-schema.ts
+++ b/lib/handlers/quote/schema/quote-schema.ts
@@ -75,6 +75,7 @@ export const QuoteQueryParamsJoi = Joi.object({
   gasToken: Joi.string().alphanum().max(42).optional(),
   cachedRoutesRouteIds: Joi.string().optional(),
   enableDebug: Joi.boolean().optional().default(false),
+  hooksOptions: Joi.string().valid('NO_HOOKS', 'HOOKS_ONLY', 'HOOKS_INCLUSIVE').optional(),
 })
 
 // Future work: this TradeTypeParam can be converted into an enum and used in the

--- a/lib/handlers/shared.ts
+++ b/lib/handlers/shared.ts
@@ -384,3 +384,6 @@ export function computePortionAmount(currencyOut: CurrencyAmount<Currency>, port
 
 export const DEFAULT_DEADLINE = 600 // 10 minutes
 export const UNISWAP_DOT_ETH_ADDRESS = '0x1a9C8182C09F50C8318d769245beA52c32BE35BC'
+
+// Used in order to skip cached routes if input amount is larger than this amount.
+export const LARGE_SWAP_USD_THRESHOLD = 100_000

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^2.0.2",
         "@uniswap/sdk-core": "^7.7.1",
-        "@uniswap/smart-order-router": "4.21.2",
+        "@uniswap/smart-order-router": "4.21.3",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^4.19.5",
         "@uniswap/v2-sdk": "^4.15.2",
@@ -4508,9 +4508,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.21.2.tgz",
-      "integrity": "sha512-DLP7eG82kMMk8lGqAvLkMagrdvgZzl9FFyZJQoE3HmpcC5r3mFQ61nFF/TqxfiJKEZUBsXoOdybeFI0sIbcaVA==",
+      "version": "4.21.3",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.21.3.tgz",
+      "integrity": "sha512-7HgSYPJdyHosOYLoMHBFA381hbwPkqBsT0a0RfUxifACOfNDUOgAPOZ2OZSqCZIqI++4FVvUHom8XIuWQENR3g==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -27936,9 +27936,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.21.2.tgz",
-      "integrity": "sha512-DLP7eG82kMMk8lGqAvLkMagrdvgZzl9FFyZJQoE3HmpcC5r3mFQ61nFF/TqxfiJKEZUBsXoOdybeFI0sIbcaVA==",
+      "version": "4.21.3",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.21.3.tgz",
+      "integrity": "sha512-7HgSYPJdyHosOYLoMHBFA381hbwPkqBsT0a0RfUxifACOfNDUOgAPOZ2OZSqCZIqI++4FVvUHom8XIuWQENR3g==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@uniswap/permit2-sdk": "^1.3.0",
     "@uniswap/router-sdk": "^2.0.2",
     "@uniswap/sdk-core": "^7.7.1",
-    "@uniswap/smart-order-router": "4.21.1",
+    "@uniswap/smart-order-router": "4.21.2",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^4.19.5",
     "@uniswap/v2-sdk": "^4.15.2",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@uniswap/permit2-sdk": "^1.3.0",
     "@uniswap/router-sdk": "^2.0.2",
     "@uniswap/sdk-core": "^7.7.1",
-    "@uniswap/smart-order-router": "4.21.2",
+    "@uniswap/smart-order-router": "4.21.3",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^4.19.5",
     "@uniswap/v2-sdk": "^4.15.2",

--- a/test/mocha/e2e/quote.test.ts
+++ b/test/mocha/e2e/quote.test.ts
@@ -27,11 +27,11 @@ import {
   V4_SEPOLIA_TEST_B,
   V4_SUPPORTED,
   WBTC_MAINNET,
-  WLD_WORLDCHAIN
+  WLD_WORLDCHAIN,
 } from '@uniswap/smart-order-router'
 import {
   UNIVERSAL_ROUTER_ADDRESS as UNIVERSAL_ROUTER_ADDRESS_BY_CHAIN,
-  UniversalRouterVersion
+  UniversalRouterVersion,
 } from '@uniswap/universal-router-sdk'
 import { fail } from 'assert'
 import axiosStatic, { AxiosResponse } from 'axios'

--- a/test/mocha/e2e/quote.test.ts
+++ b/test/mocha/e2e/quote.test.ts
@@ -715,20 +715,23 @@ describe('quote', function () {
             if (type == 'exactIn') {
               expect(tokenInBefore.subtract(tokenInAfter).toExact()).to.equal('1000000')
               checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(Ether.onChain(1), quote))
+
+              // This is now considered a large swap, so we expect it to skip cache (>= LARGE_SWAP_USD_THRESHOLD)
+              expect(response.data.hitsCachedRoutes).to.be.false
             } else {
               // Hard to test ETH balance due to gas costs for approval and swap. Just check tokenIn changes
               checkQuoteToken(tokenInBefore, tokenInAfter, CurrencyAmount.fromRawAmount(USDC_MAINNET, quote))
-            }
 
-            // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
-            // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
-            // if it's exactOut quote, we should always hit the cached routes.
-            // this is regardless of protocol version.
-            // the reason is because exact in quote always runs before exact out
-            // along with the native or wrapped native pool token address assertions previously
-            // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
-            // and native for v4 pool routes
-            expect(response.data.hitsCachedRoutes).to.be.true
+              // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
+              // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
+              // if it's exactOut quote, we should always hit the cached routes.
+              // this is regardless of protocol version.
+              // the reason is because exact in quote always runs before exact out
+              // along with the native or wrapped native pool token address assertions previously
+              // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
+              // and native for v4 pool routes
+              expect(response.data.hitsCachedRoutes).to.be.true
+            }
           })
 
           it(`erc20 -> eth large trade`, async () => {
@@ -2558,20 +2561,23 @@ describe('quote', function () {
               if (type == 'exactIn') {
                 expect(tokenInBefore.subtract(tokenInAfter).toExact()).to.equal('100')
                 checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(WETH9[1], data.quote))
+
+                // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
+                // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
+                // if it's exactOut quote, we should always hit the cached routes.
+                // this is regardless of protocol version.
+                // the reason is because exact in quote always runs before exact out
+                // along with the native or wrapped native pool token address assertions previously
+                // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
+                // and native for v4 pool routes
+                expect(response.data.hitsCachedRoutes).to.be.true
               } else {
                 expect(tokenOutAfter.subtract(tokenOutBefore).toExact()).to.equal('100')
                 checkQuoteToken(tokenInBefore, tokenInAfter, CurrencyAmount.fromRawAmount(USDC_MAINNET, data.quote))
-              }
 
-              // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
-              // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
-              // if it's exactOut quote, we should always hit the cached routes.
-              // this is regardless of protocol version.
-              // the reason is because exact in quote always runs before exact out
-              // along with the native or wrapped native pool token address assertions previously
-              // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
-              // and native for v4 pool routes
-              expect(response.data.hitsCachedRoutes).to.be.true
+                // This is now considered a large swap, so we expect it to skip cache (>= LARGE_SWAP_USD_THRESHOLD)
+                expect(response.data.hitsCachedRoutes).to.be.false
+              }
             })
 
             const uraRefactorInterimState = ['before', 'after']

--- a/test/mocha/e2e/quote.test.ts
+++ b/test/mocha/e2e/quote.test.ts
@@ -311,7 +311,7 @@ describe('quote', function () {
   }
 
   before(async function () {
-    this.timeout(40000)
+    this.timeout(400000)
     ;[alice] = await ethers.getSigners()
 
     // Make a dummy call to the API to get a block number to fork from.
@@ -791,15 +791,8 @@ describe('quote', function () {
               checkQuoteToken(tokenInBefore, tokenInAfter, CurrencyAmount.fromRawAmount(USDC_MAINNET, data.quote))
             }
 
-            // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
-            // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
-            // if it's exactOut quote, we should always hit the cached routes.
-            // this is regardless of protocol version.
-            // the reason is because exact in quote always runs before exact out
-            // along with the native or wrapped native pool token address assertions previously
-            // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
-            // and native for v4 pool routes
-            expect(response.data.hitsCachedRoutes).to.be.true
+            // This is now considered a large swap, so we expect it to skip cache (>= LARGE_SWAP_USD_THRESHOLD)
+            expect(response.data.hitsCachedRoutes).to.be.false
           })
 
           it(`erc20 -> eth large trade with permit`, async () => {
@@ -870,15 +863,8 @@ describe('quote', function () {
               checkQuoteToken(tokenInBefore, tokenInAfter, CurrencyAmount.fromRawAmount(USDC_MAINNET, data.quote))
             }
 
-            // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
-            // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
-            // if it's exactOut quote, we should always hit the cached routes.
-            // this is regardless of protocol version.
-            // the reason is because exact in quote always runs before exact out
-            // along with the native or wrapped native pool token address assertions previously
-            // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
-            // and native for v4 pool routes
-            expect(response.data.hitsCachedRoutes).to.be.true
+            // This is now considered a large swap, so we expect it to skip cache (>= LARGE_SWAP_USD_THRESHOLD)
+            expect(response.data.hitsCachedRoutes).to.be.false
           })
 
           it(`eth -> erc20`, async () => {
@@ -1021,20 +1007,23 @@ describe('quote', function () {
             if (type == 'exactIn') {
               expect(tokenInBefore.subtract(tokenInAfter).toExact()).to.equal('100')
               checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(DAI_MAINNET, data.quote))
+
+              // This is now considered a large swap, so we expect it to skip cache (>= LARGE_SWAP_USD_THRESHOLD)
+              expect(response.data.hitsCachedRoutes).to.be.false
             } else {
               expect(tokenOutAfter.subtract(tokenOutBefore).toExact()).to.equal('100')
               checkQuoteToken(tokenInBefore, tokenInAfter, CurrencyAmount.fromRawAmount(WETH9[1]!, data.quote))
-            }
 
-            // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
-            // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
-            // if it's exactOut quote, we should always hit the cached routes.
-            // this is regardless of protocol version.
-            // the reason is because exact in quote always runs before exact out
-            // along with the native or wrapped native pool token address assertions previously
-            // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
-            // and native for v4 pool routes
-            expect(response.data.hitsCachedRoutes).to.be.true
+              // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
+              // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
+              // if it's exactOut quote, we should always hit the cached routes.
+              // this is regardless of protocol version.
+              // the reason is because exact in quote always runs before exact out
+              // along with the native or wrapped native pool token address assertions previously
+              // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
+              // and native for v4 pool routes
+              expect(response.data.hitsCachedRoutes).to.be.true
+            }
           })
 
           it(`erc20 -> weth`, async () => {
@@ -1070,20 +1059,23 @@ describe('quote', function () {
             if (type == 'exactIn') {
               expect(tokenInBefore.subtract(tokenInAfter).toExact()).to.equal('100')
               checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(WETH9[1], data.quote))
+
+              // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
+              // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
+              // if it's exactOut quote, we should always hit the cached routes.
+              // this is regardless of protocol version.
+              // the reason is because exact in quote always runs before exact out
+              // along with the native or wrapped native pool token address assertions previously
+              // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
+              // and native for v4 pool routes
+              expect(response.data.hitsCachedRoutes).to.be.true
             } else {
               expect(tokenOutAfter.subtract(tokenOutBefore).toExact()).to.equal('100')
               checkQuoteToken(tokenInBefore, tokenInAfter, CurrencyAmount.fromRawAmount(USDC_MAINNET, data.quote))
-            }
 
-            // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
-            // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
-            // if it's exactOut quote, we should always hit the cached routes.
-            // this is regardless of protocol version.
-            // the reason is because exact in quote always runs before exact out
-            // along with the native or wrapped native pool token address assertions previously
-            // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
-            // and native for v4 pool routes
-            expect(response.data.hitsCachedRoutes).to.be.true
+              // This is now considered a large swap, so we expect it to skip cache (>= LARGE_SWAP_USD_THRESHOLD)
+              expect(response.data.hitsCachedRoutes).to.be.false
+            }
           })
 
           it(`eth -> usdc v4 only protocol`, async () => {
@@ -2365,15 +2357,8 @@ describe('quote', function () {
                 checkQuoteToken(tokenInBefore, tokenInAfter, CurrencyAmount.fromRawAmount(USDC_MAINNET, data.quote))
               }
 
-              // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
-              // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
-              // if it's exactOut quote, we should always hit the cached routes.
-              // this is regardless of protocol version.
-              // the reason is because exact in quote always runs before exact out
-              // along with the native or wrapped native pool token address assertions previously
-              // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
-              // and native for v4 pool routes
-              expect(response.data.hitsCachedRoutes).to.be.true
+              // This is now considered a large swap, so we expect it to skip cache (>= LARGE_SWAP_USD_THRESHOLD)
+              expect(response.data.hitsCachedRoutes).to.be.false
             })
 
             it(`eth -> erc20`, async () => {
@@ -2523,15 +2508,20 @@ describe('quote', function () {
                 checkQuoteToken(tokenInBefore, tokenInAfter, CurrencyAmount.fromRawAmount(WETH9[1]!, data.quote))
               }
 
-              // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
-              // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
-              // if it's exactOut quote, we should always hit the cached routes.
-              // this is regardless of protocol version.
-              // the reason is because exact in quote always runs before exact out
-              // along with the native or wrapped native pool token address assertions previously
-              // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
-              // and native for v4 pool routes
-              expect(response.data.hitsCachedRoutes).to.be.true
+              if (type === 'exactOut') {
+                // if it's exactIn quote, there's a slight chance the first quote request might be cache miss.
+                // but this is okay because each test case retries 3 times, so 2nd exactIn quote is def expected to hit cached routes.
+                // if it's exactOut quote, we should always hit the cached routes.
+                // this is regardless of protocol version.
+                // the reason is because exact in quote always runs before exact out
+                // along with the native or wrapped native pool token address assertions previously
+                // it ensures the cached routes will always cache wrapped native for v2,v3 pool routes
+                // and native for v4 pool routes
+                expect(response.data.hitsCachedRoutes).to.be.true
+              } else {
+                // This is now considered a large swap, so we expect it to skip cache (>= LARGE_SWAP_USD_THRESHOLD)
+                expect(response.data.hitsCachedRoutes).to.be.false
+              }
             })
 
             it(`erc20 -> weth`, async () => {

--- a/test/mocha/e2e/quote.test.ts
+++ b/test/mocha/e2e/quote.test.ts
@@ -311,7 +311,7 @@ describe('quote', function () {
   }
 
   before(async function () {
-    this.timeout(400000)
+    this.timeout(40000)
     ;[alice] = await ethers.getSigners()
 
     // Make a dummy call to the API to get a block number to fork from.

--- a/test/mocha/e2e/quote.test.ts
+++ b/test/mocha/e2e/quote.test.ts
@@ -28,7 +28,6 @@ import {
   V4_SUPPORTED,
   WBTC_MAINNET,
   WLD_WORLDCHAIN,
-  LARGE_SWAP_USD_THRESHOLD,
 } from '@uniswap/smart-order-router'
 import {
   UNIVERSAL_ROUTER_ADDRESS as UNIVERSAL_ROUTER_ADDRESS_BY_CHAIN,
@@ -53,6 +52,7 @@ import { getBalance, getBalanceAndApprove } from '../../utils/getBalanceAndAppro
 import { DAI_ON, getAmount, getAmountFromToken, UNI_MAINNET, USDC_ON, USDT_ON, WNATIVE_ON } from '../../utils/tokens'
 import { FLAT_PORTION, GREENLIST_TOKEN_PAIRS, Portion } from '../../test-utils/mocked-data'
 import { WRAPPED_NATIVE_CURRENCY } from '@uniswap/smart-order-router/build/main/index'
+import { LARGE_SWAP_USD_THRESHOLD } from '../../../lib/handlers/shared'
 
 const { ethers } = hre
 

--- a/test/mocha/e2e/quote.test.ts
+++ b/test/mocha/e2e/quote.test.ts
@@ -27,11 +27,11 @@ import {
   V4_SEPOLIA_TEST_B,
   V4_SUPPORTED,
   WBTC_MAINNET,
-  WLD_WORLDCHAIN,
+  WLD_WORLDCHAIN
 } from '@uniswap/smart-order-router'
 import {
   UNIVERSAL_ROUTER_ADDRESS as UNIVERSAL_ROUTER_ADDRESS_BY_CHAIN,
-  UniversalRouterVersion,
+  UniversalRouterVersion
 } from '@uniswap/universal-router-sdk'
 import { fail } from 'assert'
 import axiosStatic, { AxiosResponse } from 'axios'
@@ -237,9 +237,8 @@ describe('quote', function () {
   let block: number
   let curNonce: number = 0
   let nextPermitNonce: () => string = () => {
-    const nonce = curNonce.toString()
-    curNonce = curNonce + 1
-    return nonce
+    // We now revert hardfork state after each test, so we can use same nonce
+    return curNonce.toString()
   }
   let snapshotId: string
 

--- a/test/mocha/integ/graphql/graphql-token-price-fetcher.test.ts
+++ b/test/mocha/integ/graphql/graphql-token-price-fetcher.test.ts
@@ -1,0 +1,84 @@
+import sinon from 'sinon'
+import { ChainId, Token, WETH9 } from '@uniswap/sdk-core'
+import { expect } from 'chai'
+import dotenv from 'dotenv'
+import { GraphQLTokenPriceFetcher } from '../../../../lib/graphql/graphql-token-price-fetcher'
+import { MetricLoggerUnit } from '@uniswap/smart-order-router'
+import { UniGraphQLProvider } from '../../../../lib/graphql/graphql-provider'
+import { metric } from '@uniswap/smart-order-router/build/main/util/metric'
+
+dotenv.config()
+
+// Example tokens with known prices
+const BULLET = new Token(
+  ChainId.MAINNET,
+  '0x8ef32a03784c8Fd63bBf027251b9620865bD54B6',
+  8,
+  'BULLET',
+  'Bullet Game Betting Token'
+)
+
+const BITBOY = new Token(ChainId.MAINNET, '0x4a500ed6add5994569e66426588168705fcc9767', 8, 'BITBOY', 'BitBoy Fund')
+
+describe('integration test for GraphQLTokenPriceFetcher', () => {
+  let tokenPriceFetcher: GraphQLTokenPriceFetcher
+
+  beforeEach(() => {
+    const chain = ChainId.MAINNET
+    tokenPriceFetcher = new GraphQLTokenPriceFetcher(new UniGraphQLProvider(), chain)
+  })
+
+  it('Fetch WETH and BITBOY prices', async () => {
+    const tokenPriceMap = await tokenPriceFetcher.fetchPrices([WETH9[ChainId.MAINNET]!.address, BITBOY.address])
+
+    expect(tokenPriceMap[WETH9[ChainId.MAINNET]!.address]).to.not.be.undefined
+    expect(tokenPriceMap[WETH9[ChainId.MAINNET]!.address]?.price).to.not.be.undefined
+    expect(tokenPriceMap[BITBOY.address]).to.not.be.undefined
+    expect(tokenPriceMap[BITBOY.address]?.price).to.not.be.undefined
+  })
+
+  it('Fetch BULLET and BITBOY prices', async () => {
+    const spyGraphQLFetcher = sinon.spy(tokenPriceFetcher, 'fetchPrices')
+    const spyPutMetric = sinon.spy(metric, 'putMetric')
+
+    const tokenPriceMap = await tokenPriceFetcher.fetchPrices([BULLET.address, BITBOY.address])
+
+    expect(tokenPriceMap[BULLET.address]).to.not.be.undefined
+    expect(tokenPriceMap[BULLET.address]?.price).to.not.be.undefined
+    expect(tokenPriceMap[BITBOY.address]).to.not.be.undefined
+    expect(tokenPriceMap[BITBOY.address]?.price).to.not.be.undefined
+
+    expect(spyGraphQLFetcher.calledOnce).to.be.true
+    sinon.assert.calledWith(spyPutMetric, 'GraphQLTokenPriceFetcherFetchFeesSuccess', 1, MetricLoggerUnit.Count)
+
+    spyGraphQLFetcher.restore()
+    spyPutMetric.restore()
+  })
+
+  it('Should handle empty address list', async () => {
+    const tokenPriceMap = await tokenPriceFetcher.fetchPrices([])
+    expect(Object.keys(tokenPriceMap).length).to.equal(0)
+  })
+
+  it('Should handle invalid addresses gracefully - return 0 results', async () => {
+    const invalidAddress = '0x1234567890123456789012345678901234567890'
+    const tokenPriceMap = await tokenPriceFetcher.fetchPrices([invalidAddress])
+
+    expect(Object.keys(tokenPriceMap).length).to.equal(0)
+  })
+
+  it('Should emit failure metric on API error', async () => {
+    const spyPutMetric = sinon.spy(metric, 'putMetric')
+    const graphQLProvider = new UniGraphQLProvider()
+
+    // Force an error by stubbing the getTokensPrice method
+    sinon.stub(graphQLProvider, 'getTokensPrice').rejects(new Error('API Error'))
+
+    const errorPriceFetcher = new GraphQLTokenPriceFetcher(graphQLProvider, ChainId.MAINNET)
+    await errorPriceFetcher.fetchPrices([BULLET.address])
+
+    sinon.assert.calledWith(spyPutMetric, 'GraphQLTokenPriceFetcherFetchFeesFailure', 1, MetricLoggerUnit.Count)
+
+    spyPutMetric.restore()
+  })
+})


### PR DESCRIPTION
Ships https://github.com/Uniswap/smart-order-router/pull/860 (pending checkin)

**Note**: _had to update several e2e tests related to `hitsCachedRoutes`. Also had to introduce a hardhat fork snapshot/revert before/after each test to prevent tests failign due to pool liquidities changes after large swaps (large swaps now are more accurate, discovering more liquidity, altering more pools)_

Added e2e tests

<img width="622" alt="image" src="https://github.com/user-attachments/assets/d0d9cce4-9fd4-45f3-b5e6-6d4e74e55154" />

<img width="212" alt="image" src="https://github.com/user-attachments/assets/360e071b-9caa-497e-add5-6dda9a125cb9" />

