### PR TITLE
fix: make sure we don't quote against mixed route when it does not contain a v4 pool

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -543,16 +543,6 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
             ChainId.MAINNET,
             ChainId.SEPOLIA,
             ChainId.GOERLI,
-            ChainId.BASE,
-            ChainId.UNICHAIN,
-            ChainId.ARBITRUM_ONE,
-            ChainId.POLYGON,
-            ChainId.OPTIMISM,
-            ChainId.AVALANCHE,
-            ChainId.BNB,
-            ChainId.WORLDCHAIN,
-            ChainId.ZORA,
-            ChainId.SONEIUM,
           ]
 
           const cachedRoutesCacheInvalidationFixRolloutPercentage = NEW_CACHED_ROUTES_ROLLOUT_PERCENT[chainId]


### PR DESCRIPTION
fix: make sure we don't quote against mixed route when it does not contain a v4 pool.

when quoterAddressOverride does not have address, when mixed quote w/o v4 pool case, then we never quote against mixed w/o v4 pool. (https://github.com/Uniswap/smart-order-router/blob/main/src/providers/on-chain-quote-provider.ts#L433)