### PR TITLE
chore: bump sor to 4.21.2 - fix: bypass cache when HOOK_INCLUSIVE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^2.0.2",
         "@uniswap/sdk-core": "^7.7.1",
-        "@uniswap/smart-order-router": "4.21.1",
+        "@uniswap/smart-order-router": "4.21.2",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^4.19.5",
         "@uniswap/v2-sdk": "^4.15.2",
@@ -4508,9 +4508,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.21.1.tgz",
-      "integrity": "sha512-5d6T1FBUJ7AfqnkADNGE/VW8HmfVv2pzCWxZv5ZvIl2hdLV7MrahwmzZhi0RLZ6OfQvnk29EH0vbZTB2/C1TXw==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.21.2.tgz",
+      "integrity": "sha512-DLP7eG82kMMk8lGqAvLkMagrdvgZzl9FFyZJQoE3HmpcC5r3mFQ61nFF/TqxfiJKEZUBsXoOdybeFI0sIbcaVA==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -27936,9 +27936,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.21.1.tgz",
-      "integrity": "sha512-5d6T1FBUJ7AfqnkADNGE/VW8HmfVv2pzCWxZv5ZvIl2hdLV7MrahwmzZhi0RLZ6OfQvnk29EH0vbZTB2/C1TXw==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.21.2.tgz",
+      "integrity": "sha512-DLP7eG82kMMk8lGqAvLkMagrdvgZzl9FFyZJQoE3HmpcC5r3mFQ61nFF/TqxfiJKEZUBsXoOdybeFI0sIbcaVA==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@uniswap/permit2-sdk": "^1.3.0",
     "@uniswap/router-sdk": "^2.0.2",
     "@uniswap/sdk-core": "^7.7.1",
-    "@uniswap/smart-order-router": "4.21.1",
+    "@uniswap/smart-order-router": "4.21.2",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^4.19.5",
     "@uniswap/v2-sdk": "^4.15.2",


### PR DESCRIPTION
only bypass cache when HOOKS_INCLUSIVE. 