### PR TITLE
chore: bump SOR to 4.21.8 - fix: base v3 subgraph filtering update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^2.0.2",
         "@uniswap/sdk-core": "^7.7.1",
-        "@uniswap/smart-order-router": "4.21.6",
+        "@uniswap/smart-order-router": "4.21.8",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^4.19.5",
         "@uniswap/v2-sdk": "^4.15.2",
@@ -4508,9 +4508,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "4.21.6",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.21.6.tgz",
-      "integrity": "sha512-6qfTTjjJ1lbS1qP1tGmn1HjGkvQ6FdnbZpY3/HVS09fRCOQxiu+9DAPuDnF72gij6n2CsSJYxPekOVZA9rGsbQ==",
+      "version": "4.21.8",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.21.8.tgz",
+      "integrity": "sha512-iJveZNi1HWN2M41oDNZy2es2tk29LRKyL6voNR06vltbEZmnbW8Jl3EpPZc2otKfa+ph6MT1DevETso9BQ81uA==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -27936,9 +27936,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "4.21.6",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.21.6.tgz",
-      "integrity": "sha512-6qfTTjjJ1lbS1qP1tGmn1HjGkvQ6FdnbZpY3/HVS09fRCOQxiu+9DAPuDnF72gij6n2CsSJYxPekOVZA9rGsbQ==",
+      "version": "4.21.8",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.21.8.tgz",
+      "integrity": "sha512-iJveZNi1HWN2M41oDNZy2es2tk29LRKyL6voNR06vltbEZmnbW8Jl3EpPZc2otKfa+ph6MT1DevETso9BQ81uA==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@uniswap/permit2-sdk": "^1.3.0",
     "@uniswap/router-sdk": "^2.0.2",
     "@uniswap/sdk-core": "^7.7.1",
-    "@uniswap/smart-order-router": "4.21.6",
+    "@uniswap/smart-order-router": "4.21.8",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^4.19.5",
     "@uniswap/v2-sdk": "^4.15.2",


### PR DESCRIPTION
Ship https://github.com/Uniswap/smart-order-router/pull/869