### PR TITLE
chore: bump sor to 4.21.11 - fix: ROUTE-486 Route BtcAcc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^2.0.2",
         "@uniswap/sdk-core": "^7.7.1",
-        "@uniswap/smart-order-router": "4.21.10",
+        "@uniswap/smart-order-router": "4.21.11",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^4.19.5",
         "@uniswap/v2-sdk": "^4.15.2",
@@ -4508,9 +4508,10 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "4.21.10",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.21.10.tgz",
-      "integrity": "sha512-RJ2+NJsrlvDbatOqVzlJyqEfLya11AiVZDM4HPPTHyDwQkqK077iRiBS8+/uMIR6u89ZzE0vcg0qy2gLNEFqlQ==",
+      "version": "4.21.11",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.21.11.tgz",
+      "integrity": "sha512-p/13WfZxxrNIPP+N/iFUcxMwWBMXC9napjURjlYf2xUKEl2yh6oPhigNgFEeaBUG+ATdLbo5SiBERbtBcFlDwQ==",
+      "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -27936,9 +27937,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "4.21.10",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.21.10.tgz",
-      "integrity": "sha512-RJ2+NJsrlvDbatOqVzlJyqEfLya11AiVZDM4HPPTHyDwQkqK077iRiBS8+/uMIR6u89ZzE0vcg0qy2gLNEFqlQ==",
+      "version": "4.21.11",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.21.11.tgz",
+      "integrity": "sha512-p/13WfZxxrNIPP+N/iFUcxMwWBMXC9napjURjlYf2xUKEl2yh6oPhigNgFEeaBUG+ATdLbo5SiBERbtBcFlDwQ==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@uniswap/permit2-sdk": "^1.3.0",
     "@uniswap/router-sdk": "^2.0.2",
     "@uniswap/sdk-core": "^7.7.1",
-    "@uniswap/smart-order-router": "4.21.10",
+    "@uniswap/smart-order-router": "4.21.11",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^4.19.5",
     "@uniswap/v2-sdk": "^4.15.2",


### PR DESCRIPTION
https://github.com/Uniswap/smart-order-router/pull/874

