### PR TITLE
fix: routing-api e2e test wallet with undelegation to unblock routing pipeline siyujiang/route-491-fix-routing-api-e2e-test-wallet-with-undelegation-to-unblock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@uniswap/router-sdk": "^2.0.2",
         "@uniswap/sdk-core": "^7.7.1",
         "@uniswap/smart-order-router": "4.21.11",
+        "@uniswap/smart-wallet-sdk": "^2.1.1",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^4.19.5",
         "@uniswap/v2-sdk": "^4.15.2",
@@ -112,6 +113,11 @@
         "typechain": "^5.0.0",
         "typescript": "^4.2.3"
       }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.0.tgz",
+      "integrity": "sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg=="
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.1",
@@ -2798,6 +2804,31 @@
         "node": ">=12"
       }
     },
+    "node_modules/@noble/curves": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.2.tgz",
+      "integrity": "sha512-vnI7V6lFNe0tLAuJMu+2sX+FcL14TaCWy1qiczg1VwRmPrpQCdq5ESXQMqUc2tluRNf6irBXrWbl1mGN8uaU/g==",
+      "dependencies": {
+        "@noble/hashes": "1.7.2"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.2.tgz",
+      "integrity": "sha512-biZ0NUSxyjLLqo6KxEJ1b+C2NAx0wtDoFvCaXHGgUkeHzf3Xc1xKumFKREuT7f7DARNZ/slvYUwFG6B0f2b6hQ==",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/hashes": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
@@ -4553,6 +4584,173 @@
       "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
       "engines": {
         "node": ">= 10.x"
+      }
+    },
+    "node_modules/@uniswap/smart-wallet-sdk": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-wallet-sdk/-/smart-wallet-sdk-2.1.1.tgz",
+      "integrity": "sha512-9koY9YTT6Txyaz/NR/u0ic5CLpZCA5hoDaIvtXxOkf8aCIIh7tDxclAwmF+iS1A+kTfhOFuBHHDyxyqQ0+Rtmg==",
+      "dependencies": {
+        "@uniswap/sdk-core": "^7.6.0",
+        "viem": "^2.23.5"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@uniswap/smart-wallet-sdk/node_modules/@noble/hashes": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.2.tgz",
+      "integrity": "sha512-biZ0NUSxyjLLqo6KxEJ1b+C2NAx0wtDoFvCaXHGgUkeHzf3Xc1xKumFKREuT7f7DARNZ/slvYUwFG6B0f2b6hQ==",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@uniswap/smart-wallet-sdk/node_modules/@scure/base": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.5.tgz",
+      "integrity": "sha512-9rE6EOVeIQzt5TSu4v+K523F8u6DhBsoZWPGKlnCshhlDhy0kJzUX4V+tr2dWmzF1GdekvThABoEQBGBQI7xZw==",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@uniswap/smart-wallet-sdk/node_modules/@scure/bip32": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.6.2.tgz",
+      "integrity": "sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw==",
+      "dependencies": {
+        "@noble/curves": "~1.8.1",
+        "@noble/hashes": "~1.7.1",
+        "@scure/base": "~1.2.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@uniswap/smart-wallet-sdk/node_modules/@scure/bip39": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.5.4.tgz",
+      "integrity": "sha512-TFM4ni0vKvCfBpohoh+/lY05i9gRbSwXWngAsF4CABQxoaOHijxuaZ2R6cStDQ5CHtHO9aGJTr4ksVJASRRyMA==",
+      "dependencies": {
+        "@noble/hashes": "~1.7.1",
+        "@scure/base": "~1.2.4"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@uniswap/smart-wallet-sdk/node_modules/abitype": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.8.tgz",
+      "integrity": "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3 >=3.22.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@uniswap/smart-wallet-sdk/node_modules/ox": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.6.9.tgz",
+      "integrity": "sha512-wi5ShvzE4eOcTwQVsIPdFr+8ycyX+5le/96iAJutaZAvCes1J0+RvpEPg5QDPDiaR0XQQAvZVl7AwqQcINuUug==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.10.1",
+        "@noble/curves": "^1.6.0",
+        "@noble/hashes": "^1.5.0",
+        "@scure/bip32": "^1.5.0",
+        "@scure/bip39": "^1.4.0",
+        "abitype": "^1.0.6",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@uniswap/smart-wallet-sdk/node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/@uniswap/smart-wallet-sdk/node_modules/viem": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.30.0.tgz",
+      "integrity": "sha512-hvO4l5JIOnYPL8imULoFQiVTSkebIqzGHmIfsdMfIHpAgBaCx8rJJH9cXAxQeWCqsFuTmjEj1cX912N7HSCgpQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "dependencies": {
+        "@noble/curves": "1.8.2",
+        "@noble/hashes": "1.7.2",
+        "@scure/bip32": "1.6.2",
+        "@scure/bip39": "1.5.4",
+        "abitype": "1.0.8",
+        "isows": "1.0.7",
+        "ox": "0.6.9",
+        "ws": "8.18.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@uniswap/smart-wallet-sdk/node_modules/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/@uniswap/swap-router-contracts": {
@@ -7604,6 +7802,11 @@
         "node": ">=6.5.0",
         "npm": ">=3"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "node_modules/events": {
       "version": "1.1.1",
@@ -18808,6 +19011,20 @@
       "resolved": "https://registry.npmjs.org/isnumber/-/isnumber-1.0.0.tgz",
       "integrity": "sha512-JLiSz/zsZcGFXPrB4I/AGBvtStkt+8QmksyZBZnVXnnK9XdTEyz0tX8CRYljtwYDuIuZzih6DpHQdi+3Q6zHPw=="
     },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
     "node_modules/isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -24690,6 +24907,11 @@
     }
   },
   "dependencies": {
+    "@adraffy/ens-normalize": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.0.tgz",
+      "integrity": "sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg=="
+    },
     "@ampproject/remapping": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
@@ -26649,6 +26871,21 @@
         "ajv-i18n": "4.1.0"
       }
     },
+    "@noble/curves": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.2.tgz",
+      "integrity": "sha512-vnI7V6lFNe0tLAuJMu+2sX+FcL14TaCWy1qiczg1VwRmPrpQCdq5ESXQMqUc2tluRNf6irBXrWbl1mGN8uaU/g==",
+      "requires": {
+        "@noble/hashes": "1.7.2"
+      },
+      "dependencies": {
+        "@noble/hashes": {
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.2.tgz",
+          "integrity": "sha512-biZ0NUSxyjLLqo6KxEJ1b+C2NAx0wtDoFvCaXHGgUkeHzf3Xc1xKumFKREuT7f7DARNZ/slvYUwFG6B0f2b6hQ=="
+        }
+      }
+    },
     "@noble/hashes": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
@@ -27973,6 +28210,94 @@
           "version": "15.8.0",
           "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
           "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw=="
+        }
+      }
+    },
+    "@uniswap/smart-wallet-sdk": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-wallet-sdk/-/smart-wallet-sdk-2.1.1.tgz",
+      "integrity": "sha512-9koY9YTT6Txyaz/NR/u0ic5CLpZCA5hoDaIvtXxOkf8aCIIh7tDxclAwmF+iS1A+kTfhOFuBHHDyxyqQ0+Rtmg==",
+      "requires": {
+        "@uniswap/sdk-core": "^7.6.0",
+        "viem": "^2.23.5"
+      },
+      "dependencies": {
+        "@noble/hashes": {
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.2.tgz",
+          "integrity": "sha512-biZ0NUSxyjLLqo6KxEJ1b+C2NAx0wtDoFvCaXHGgUkeHzf3Xc1xKumFKREuT7f7DARNZ/slvYUwFG6B0f2b6hQ=="
+        },
+        "@scure/base": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.5.tgz",
+          "integrity": "sha512-9rE6EOVeIQzt5TSu4v+K523F8u6DhBsoZWPGKlnCshhlDhy0kJzUX4V+tr2dWmzF1GdekvThABoEQBGBQI7xZw=="
+        },
+        "@scure/bip32": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.6.2.tgz",
+          "integrity": "sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw==",
+          "requires": {
+            "@noble/curves": "~1.8.1",
+            "@noble/hashes": "~1.7.1",
+            "@scure/base": "~1.2.2"
+          }
+        },
+        "@scure/bip39": {
+          "version": "1.5.4",
+          "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.5.4.tgz",
+          "integrity": "sha512-TFM4ni0vKvCfBpohoh+/lY05i9gRbSwXWngAsF4CABQxoaOHijxuaZ2R6cStDQ5CHtHO9aGJTr4ksVJASRRyMA==",
+          "requires": {
+            "@noble/hashes": "~1.7.1",
+            "@scure/base": "~1.2.4"
+          }
+        },
+        "abitype": {
+          "version": "1.0.8",
+          "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.8.tgz",
+          "integrity": "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==",
+          "requires": {}
+        },
+        "ox": {
+          "version": "0.6.9",
+          "resolved": "https://registry.npmjs.org/ox/-/ox-0.6.9.tgz",
+          "integrity": "sha512-wi5ShvzE4eOcTwQVsIPdFr+8ycyX+5le/96iAJutaZAvCes1J0+RvpEPg5QDPDiaR0XQQAvZVl7AwqQcINuUug==",
+          "requires": {
+            "@adraffy/ens-normalize": "^1.10.1",
+            "@noble/curves": "^1.6.0",
+            "@noble/hashes": "^1.5.0",
+            "@scure/bip32": "^1.5.0",
+            "@scure/bip39": "^1.4.0",
+            "abitype": "^1.0.6",
+            "eventemitter3": "5.0.1"
+          }
+        },
+        "typescript": {
+          "version": "5.8.3",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+          "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+          "optional": true,
+          "peer": true
+        },
+        "viem": {
+          "version": "2.30.0",
+          "resolved": "https://registry.npmjs.org/viem/-/viem-2.30.0.tgz",
+          "integrity": "sha512-hvO4l5JIOnYPL8imULoFQiVTSkebIqzGHmIfsdMfIHpAgBaCx8rJJH9cXAxQeWCqsFuTmjEj1cX912N7HSCgpQ==",
+          "requires": {
+            "@noble/curves": "1.8.2",
+            "@noble/hashes": "1.7.2",
+            "@scure/bip32": "1.6.2",
+            "@scure/bip39": "1.5.4",
+            "abitype": "1.0.8",
+            "isows": "1.0.7",
+            "ox": "0.6.9",
+            "ws": "8.18.1"
+          }
+        },
+        "ws": {
+          "version": "8.18.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
+          "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+          "requires": {}
         }
       }
     },
@@ -30292,6 +30617,11 @@
         "is-hex-prefixed": "1.0.0",
         "strip-hex-prefix": "1.0.0"
       }
+    },
+    "eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "events": {
       "version": "1.1.1",
@@ -38793,6 +39123,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isnumber/-/isnumber-1.0.0.tgz",
       "integrity": "sha512-JLiSz/zsZcGFXPrB4I/AGBvtStkt+8QmksyZBZnVXnnK9XdTEyz0tX8CRYljtwYDuIuZzih6DpHQdi+3Q6zHPw=="
+    },
+    "isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "requires": {}
     },
     "isstream": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "@uniswap/router-sdk": "^2.0.2",
     "@uniswap/sdk-core": "^7.7.1",
     "@uniswap/smart-order-router": "4.21.11",
+    "@uniswap/smart-wallet-sdk": "^2.1.1",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^4.19.5",
     "@uniswap/v2-sdk": "^4.15.2",

--- a/test/mocha/e2e/quote.test.ts
+++ b/test/mocha/e2e/quote.test.ts
@@ -52,6 +52,7 @@ import { getBalance, getBalanceAndApprove } from '../../utils/getBalanceAndAppro
 import { DAI_ON, getAmount, getAmountFromToken, UNI_MAINNET, USDC_ON, USDT_ON, WNATIVE_ON } from '../../utils/tokens'
 import { FLAT_PORTION, GREENLIST_TOKEN_PAIRS, Portion } from '../../test-utils/mocked-data'
 import { WRAPPED_NATIVE_CURRENCY } from '@uniswap/smart-order-router/build/main/index'
+import { getFirstNonDelegatedSigner } from '../../utils/getFirstNonDelegatedSigner'
 
 const { ethers } = hre
 
@@ -311,7 +312,7 @@ describe('quote', function () {
 
   before(async function () {
     this.timeout(40000)
-    ;[alice] = await ethers.getSigners()
+    alice = getFirstNonDelegatedSigner(await ethers.getSigners())
 
     // Make a dummy call to the API to get a block number to fork from.
     const quoteReq: QuoteQueryParams = {

--- a/test/mocha/e2e/quote.test.ts
+++ b/test/mocha/e2e/quote.test.ts
@@ -312,7 +312,7 @@ describe('quote', function () {
 
   before(async function () {
     this.timeout(40000)
-    alice = getFirstNonDelegatedSigner(await ethers.getSigners())
+    alice = await getFirstNonDelegatedSigner(await ethers.getSigners())
 
     // Make a dummy call to the API to get a block number to fork from.
     const quoteReq: QuoteQueryParams = {

--- a/test/utils/forkAndFund.ts
+++ b/test/utils/forkAndFund.ts
@@ -62,12 +62,6 @@ export const resetAndFundAtBlock = async (
       const whale = WHALES[i]
       const whaleAccount = ethers.provider.getSigner(whale)
       try {
-        // Send native ETH from hardhat alice test address, so that whale accounts have sufficient ETH to pay for gas
-        await alice.sendTransaction({
-          to: whale,
-          value: ethers.utils.parseEther('0.1'), // Sends exactly 0.1 ether
-        })
-
         const whaleToken: Erc20 = Erc20__factory.connect(currency.wrapped.address, whaleAccount)
 
         await whaleToken.transfer(alice.address, ethers.utils.parseUnits(amount, currency.decimals))
@@ -76,7 +70,7 @@ export const resetAndFundAtBlock = async (
       } catch (err) {
         if (i == WHALES.length - 1) {
           throw new Error(
-            `Could not fund ${amount} ${currency.symbol} from any whales. Original error ${JSON.stringify(err)}`
+            `Could not fund ${amount} ${currency.symbol} from any whales ${whale}. Original error ${JSON.stringify(err)} ${i}`
           )
         }
       }

--- a/test/utils/forkAndFund.ts
+++ b/test/utils/forkAndFund.ts
@@ -70,7 +70,9 @@ export const resetAndFundAtBlock = async (
       } catch (err) {
         if (i == WHALES.length - 1) {
           throw new Error(
-            `Could not fund ${amount} ${currency.symbol} from any whales ${whale}. Original error ${JSON.stringify(err)} ${i}`
+            `Could not fund ${amount} ${currency.symbol} from any whales ${whale}. Original error ${JSON.stringify(
+              err
+            )} ${i}`
           )
         }
       }

--- a/test/utils/getCurrentDelegationAddress.ts
+++ b/test/utils/getCurrentDelegationAddress.ts
@@ -1,0 +1,14 @@
+import { DELEGATION_MAGIC_PREFIX } from '@uniswap/smart-wallet-sdk'
+
+// copy paste from https://github.com/Uniswap/external-api/blob/73dd547047b70dc6a394cb6972a9192c864d9b98/lib/util/delegation.ts#L12
+export const getCurrentDelegationAddress = (code: string | null): string | null => {
+  if (!code) {
+    return null
+  }
+  // Check if the code matches our 7702 contract prefix
+  if (code.startsWith(DELEGATION_MAGIC_PREFIX)) {
+    // Remove the magic prefix and return the rest of the code
+    return ('0x' + code.slice(DELEGATION_MAGIC_PREFIX.length)).toLowerCase()
+  }
+  return null
+}

--- a/test/utils/getFirstNonDelegatedSigner.ts
+++ b/test/utils/getFirstNonDelegatedSigner.ts
@@ -1,0 +1,24 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+import { getCurrentDelegationAddress } from './getCurrentDelegationAddress'
+import { StaticJsonRpcProvider } from '@ethersproject/providers'
+
+const l1RpcProvider = new StaticJsonRpcProvider(process.env.ARCHIVE_NODE_RPC, 1)
+
+// modified from https://github.com/Uniswap/external-api/blob/1283bababf5a61bb64ccae0401c4f25dc3fa36d2/lib/handlers/wallet-delegation/WalletCheckDelegationHandler.ts#L38
+// we are hoping that under test mnemonic from hardhat,
+// there are still test wallets that are not delegated, out of all 20 test wallets
+export const getFirstNonDelegatedSigner = async (signers: SignerWithAddress[]): Promise<SignerWithAddress> => {
+  let firstNonDelegatedSigner: SignerWithAddress | undefined;
+  
+  for (const signer of signers) {
+    const code = await l1RpcProvider.getCode(signer.address)
+    if (getCurrentDelegationAddress(code) === null) {
+      firstNonDelegatedSigner = signer;
+      break;
+    }
+  }
+
+  console.log(`first non-delegated test wallet is ${JSON.stringify(firstNonDelegatedSigner)}`)
+
+  return firstNonDelegatedSigner ?? signers[0]
+}

--- a/test/utils/getFirstNonDelegatedSigner.ts
+++ b/test/utils/getFirstNonDelegatedSigner.ts
@@ -8,13 +8,13 @@ const l1RpcProvider = new StaticJsonRpcProvider(process.env.ARCHIVE_NODE_RPC, 1)
 // we are hoping that under test mnemonic from hardhat,
 // there are still test wallets that are not delegated, out of all 20 test wallets
 export const getFirstNonDelegatedSigner = async (signers: SignerWithAddress[]): Promise<SignerWithAddress> => {
-  let firstNonDelegatedSigner: SignerWithAddress | undefined;
-  
+  let firstNonDelegatedSigner: SignerWithAddress | undefined
+
   for (const signer of signers) {
     const code = await l1RpcProvider.getCode(signer.address)
     if (getCurrentDelegationAddress(code) === null) {
-      firstNonDelegatedSigner = signer;
-      break;
+      firstNonDelegatedSigner = signer
+      break
     }
   }
 


### PR DESCRIPTION
routing pipeline is blocked. the reason is because hardhat uses test mnemonic, that has the first test wallet delegated to a random CA wallet.

all tests passed https://app.warp.dev/block/vtMxraNKZKSPSzsPOIJ3jU.