### PR TITLE
chore: Bumping up version to 4.21.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^2.0.2",
         "@uniswap/sdk-core": "^7.7.1",
-        "@uniswap/smart-order-router": "4.21.14",
+        "@uniswap/smart-order-router": "4.21.16",
         "@uniswap/smart-wallet-sdk": "^2.1.1",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^4.19.5",
@@ -4539,9 +4539,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "4.21.14",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.21.14.tgz",
-      "integrity": "sha512-SpKiz6YxIv638itvBlJPCXfuLiATkvBhaa0/bsatI0c757kf0nefnO+x9a4UHdW5jOpkGLEeo0aOn1dvI4oJ+w==",
+      "version": "4.21.16",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.21.16.tgz",
+      "integrity": "sha512-BRQQoS/Rqa1CPgS2w8z5pzD5H4hySncH5X27uwkGCZxX0/zyP4PWW8d0MnQ0vV0P0WRlVOGKEnayVxfHKefZtA==",
       "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
@@ -28174,9 +28174,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "4.21.14",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.21.14.tgz",
-      "integrity": "sha512-SpKiz6YxIv638itvBlJPCXfuLiATkvBhaa0/bsatI0c757kf0nefnO+x9a4UHdW5jOpkGLEeo0aOn1dvI4oJ+w==",
+      "version": "4.21.16",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.21.16.tgz",
+      "integrity": "sha512-BRQQoS/Rqa1CPgS2w8z5pzD5H4hySncH5X27uwkGCZxX0/zyP4PWW8d0MnQ0vV0P0WRlVOGKEnayVxfHKefZtA==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@uniswap/permit2-sdk": "^1.3.0",
     "@uniswap/router-sdk": "^2.0.2",
     "@uniswap/sdk-core": "^7.7.1",
-    "@uniswap/smart-order-router": "4.21.14",
+    "@uniswap/smart-order-router": "4.21.16",
     "@uniswap/smart-wallet-sdk": "^2.1.1",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^4.19.5",


### PR DESCRIPTION
Bumping up version to 4.21.16

releasing: https://github.com/Uniswap/routing-api/pull/1116