### PR TITLE
chore(alerts): add uniswap-ios to LOW_VOLUME_REQUEST_SOURCES

### DIFF
--- a/bin/stacks/routing-api-stack.ts
+++ b/bin/stacks/routing-api-stack.ts
@@ -36,7 +36,7 @@ export const LOW_VOLUME_CHAINS: Set<ChainId> = new Set([
 ])
 
 // For low volume request sources, we'll increase the evaluation periods to reduce triggering sensitivity.
-export const LOW_VOLUME_REQUEST_SOURCES: Set<string> = new Set(['uniswap-extension', 'uniswap-android'])
+export const LOW_VOLUME_REQUEST_SOURCES: Set<string> = new Set(['uniswap-extension', 'uniswap-android', 'uniswap-ios'])
 
 export class RoutingAPIStack extends cdk.Stack {
   public readonly url: CfnOutput


### PR DESCRIPTION
Add `uniswap-ios` to LOW_VOLUME_REQUEST_SOURCES.
This will make iOS alerts less sensitive, similarly to android as we've noticed over-triggering