### PR TITLE
fix: bump sor 4.21.17 - filter out direct v3 pool with rebase token breaking routing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^2.0.2",
         "@uniswap/sdk-core": "^7.7.1",
-        "@uniswap/smart-order-router": "4.21.16",
+        "@uniswap/smart-order-router": "4.21.17",
         "@uniswap/smart-wallet-sdk": "^2.1.1",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^4.19.5",
@@ -4539,10 +4539,9 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
-      "version": "4.21.16",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.21.16.tgz",
-      "integrity": "sha512-BRQQoS/Rqa1CPgS2w8z5pzD5H4hySncH5X27uwkGCZxX0/zyP4PWW8d0MnQ0vV0P0WRlVOGKEnayVxfHKefZtA==",
-      "license": "GPL",
+      "version": "4.21.17",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.21.17.tgz",
+      "integrity": "sha512-XqEmk3J+6ohiG3BKUmf+lq+BFVPxIQj0eU3CZJLpXeLEyp5Ny6fe8a87hHA6kB5tFiTfzLPMtkPjKtwHy+W5oQ==",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",
@@ -28174,9 +28173,9 @@
       }
     },
     "@uniswap/smart-order-router": {
-      "version": "4.21.16",
-      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.21.16.tgz",
-      "integrity": "sha512-BRQQoS/Rqa1CPgS2w8z5pzD5H4hySncH5X27uwkGCZxX0/zyP4PWW8d0MnQ0vV0P0WRlVOGKEnayVxfHKefZtA==",
+      "version": "4.21.17",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.21.17.tgz",
+      "integrity": "sha512-XqEmk3J+6ohiG3BKUmf+lq+BFVPxIQj0eU3CZJLpXeLEyp5Ny6fe8a87hHA6kB5tFiTfzLPMtkPjKtwHy+W5oQ==",
       "requires": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@uniswap/permit2-sdk": "^1.3.0",
     "@uniswap/router-sdk": "^2.0.2",
     "@uniswap/sdk-core": "^7.7.1",
-    "@uniswap/smart-order-router": "4.21.16",
+    "@uniswap/smart-order-router": "4.21.17",
     "@uniswap/smart-wallet-sdk": "^2.1.1",
     "@uniswap/token-lists": "^1.0.0-beta.33",
     "@uniswap/universal-router-sdk": "^4.19.5",


### PR DESCRIPTION
ship https://github.com/Uniswap/smart-order-router/pull/882
