### PR TITLE
ROUTE-531 allow updated Aegis on UniChain

### DIFF
--- a/lib/util/hooksAddressesAllowlist.ts
+++ b/lib/util/hooksAddressesAllowlist.ts
@@ -24,6 +24,8 @@ export const MEV_TAX_TEST_IN_PROD_ON_UNICHAIN = '0xb9a17e66db950e00822c2b833d6bb
 export const RENZO_ON_UNICHAIN = '0x09dea99d714a3a19378e3d80d1ad22ca46085080'
 // example pool: https://app.uniswap.org/explore/pools/unichain/0x0e3a702c43b613fe8c635e375ca4f0b8d4870526c1e6f795d379f0fb6041ed91
 export const AEGIS_ON_UNICHAIN = '0x27bfccf7fdd8215ce5dd86c2a36651d05c8450cc'
+// exmaple pool: https://app.uniswap.org/explore/pools/unichain/0x410723c1949069324d0f6013dba28829c4a0562f7c81d0f7cb79ded668691e1f
+export const UPDATED_AEGIS_ON_UNICHAIN = '0xa0b0d2d00fd544d8e0887f1a3cedd6e24baf10cc'
 
 // we do not allow v4 pools with non-zero hook address to be routed through in the initial v4 launch.
 // this is the ultimate safeguard in the routing subgraph pool cron job.
@@ -76,7 +78,13 @@ export const HOOKS_ADDRESSES_ALLOWLIST: { [chain in ChainId]: Array<string> } = 
   [ChainId.ZKSYNC]: [ADDRESS_ZERO],
   [ChainId.WORLDCHAIN]: [ADDRESS_ZERO],
   [ChainId.UNICHAIN_SEPOLIA]: [ADDRESS_ZERO],
-  [ChainId.UNICHAIN]: [ADDRESS_ZERO, MEV_TAX_TEST_IN_PROD_ON_UNICHAIN, RENZO_ON_UNICHAIN, AEGIS_ON_UNICHAIN],
+  [ChainId.UNICHAIN]: [
+    ADDRESS_ZERO,
+    MEV_TAX_TEST_IN_PROD_ON_UNICHAIN,
+    RENZO_ON_UNICHAIN,
+    AEGIS_ON_UNICHAIN,
+    UPDATED_AEGIS_ON_UNICHAIN,
+  ],
   [ChainId.MONAD_TESTNET]: [ADDRESS_ZERO],
   [ChainId.SONEIUM]: [ADDRESS_ZERO],
 }


### PR DESCRIPTION
Allowing updated Aegis on UniChain

Tested locally:
```
❯ curl 'https://56wjv9zdd9.execute-api.us-east-2.amazonaws.com/prod/quote?amount=1000000000000&deadline=1800&enableFeeOnTransferFeeFetching=true&enableUniversalRouter=true&portionBips=25&portionRecipient=0x000000fee13a103A10D593b9AE06b3e05F2E7E1c&protocols=v4&quoteSpeed=standard&recipient=0xc7C6b256ea29207B6E0b05FDaFAEc8B667615BD8&simulateFromAddress=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266&slippageTolerance=0.5&source=uniswap-web&tokenOutAddress=0x0555E30da8f98308EdB960aa94C0Db47230d2B9c&tokenInChainId=130&tokenInAddress=ETH&tokenOutChainId=130&type=exactIn&enableDebug=true&hooksOptions=HOOKS_ONLY' \
        -H 'x-universal-router-version: 2.0'
{"methodParameters":{"calldata":"0x3593564c000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000006848673c0000000000000000000000000000000000000000000000000000000000000003100604000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000044000000000000000000000000000000000000000000000000000000000000004c000000000000000000000000000000000000000000000000000000000000003c0000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000003070b0e000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000022000000000000000000000000000000000000000000000000000000000000002a000000000000000000000000000000000000000000000000000000000000001a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000e8d4a510000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000200000000000000000000000000555e30da8f98308edb960aa94c0db47230d2b9c0000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000000003c000000000000000000000000a0b0d2d00fd544d8e0887f1a3cedd6e24baf10cc00000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000600000000000000000000000000555e30da8f98308edb960aa94c0db47230d2b9c0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000555e30da8f98308edb960aa94c0db47230d2b9c000000000000000000000000000000fee13a103a10d593b9ae06b3e05f2e7e1c000000000000000000000000000000000000000000000000000000000000001900000000000000000000000000000000000000000000000000000000000000600000000000000000000000000555e30da8f98308edb960aa94c0db47230d2b9c000000000000000000000000c7c6b256ea29207b6e0b05fdafaec8b667615bd80000000000000000000000000000000000000000000000000000000000000000","value":"0xe8d4a51000","to":"0xef740bf23acae26f6492b10de645d6b98dc8eaf3"},"blockNumber":"18825325","amount":"1000000000000","amountDecimals":"0.000001","quote":"2","quoteDecimals":"0.00000002","quoteGasAdjusted":"1","quoteGasAdjustedDecimals":"0.00000001","quoteGasAndPortionAdjusted":"1","quoteGasAndPortionAdjustedDecimals":"0.00000001","gasUseEstimateQuote":"0","gasUseEstimateQuoteDecimals":"0","gasUseEstimate":"206471","gasUseEstimateUSD":"0.000384961074839153","simulationStatus":"INSUFFICIENT_BALANCE","simulationError":false,"gasPriceWei":"538500","route":[[{"type":"v4-pool","address":"0x410723c1949069324d0f6013dba28829c4a0562f7c81d0f7cb79ded668691e1f","tokenIn":{"chainId":130,"decimals":"18","address":"0x0000000000000000000000000000000000000000","symbol":"ETH"},"tokenOut":{"chainId":130,"decimals":"8","address":"0x0555E30da8f98308EdB960aa94C0Db47230d2B9c","symbol":"WBTC"},"fee":"8388608","tickSpacing":"60","hooks":"0xa0b0d2d00fd544d8e0887f1a3cedd6e24baf10cc","liquidity":"10271897261784742","sqrtRatioX96":"125566546423925594942199","tickCurrent":"-267114","amountIn":"1000000000000","amountOut":"1"}]],"routeString":"[V4] 100.00% = ETH -- 838.8608% [0x410723c1949069324d0f6013dba28829c4a0562f7c81d0f7cb79ded668691e1f]WBTC","quoteId":"f7e2d","hitsCachedRoutes":false,"portionBips":25,"portionRecipient":"0x000000fee13a103A10D593b9AE06b3e05F2E7E1c","portionAmount":"0","portionAmountDecimals":"0","priceImpact":"20.58"}% 
```