### PR TITLE
fix: add alchemy subgraph key to IPFS caching lambda

### DIFF
--- a/bin/stacks/routing-caching-stack.ts
+++ b/bin/stacks/routing-caching-stack.ts
@@ -213,6 +213,7 @@ export class RoutingCachingStack extends cdk.NestedStack {
           HOSTED_ZONE: hosted_zone!,
           STAGE: stage,
           REDEPLOY: '1',
+          ALCHEMY_QUERY_KEY_2: alchemyQueryKey2!,
         },
       })
 
@@ -246,6 +247,7 @@ export class RoutingCachingStack extends cdk.NestedStack {
           PINATA_API_SECRET: pinata_secret!,
           STAGE: stage,
           REDEPLOY: '1',
+          ALCHEMY_QUERY_KEY_2: alchemyQueryKey2!,
         },
       })
 


### PR DESCRIPTION
IPFS caching job stuck because subgraph alchemy provider missing alchemy API KEY in the lambda env var, see https://uniswapteam.slack.com/archives/C08TV5WJL07/p1749654860726899