### PR TITLE
fix: lower v4 trade size during e2e tests

### DIFF
--- a/test/mocha/e2e/quote.test.ts
+++ b/test/mocha/e2e/quote.test.ts
@@ -3636,7 +3636,7 @@ describe('quote', function () {
               ? USDC_ON(chain)
               : USDC_NATIVE_SEPOLIA
             : erc2
-          const amount = chain === ChainId.SEPOLIA ? (type === 'exactIn' ? '0.00000000000001' : '0.000001') : '1'
+          const amount = chain === ChainId.SEPOLIA ? (type === 'exactIn' ? '0.00000000000001' : '0.000001') : '0.1'
 
           const quoteReq: QuoteQueryParams = {
             tokenInAddress: native,


### PR DESCRIPTION
1 ETH trade size can make no route https://app.warp.dev/block/GLd5t3E75KK04hqm5Q6MsP