### PR TITLE
chore: bump sor to 4.22.3 - fix: mixed route quoter encoding should be consistent 06-27-fix_router-sdk_pass_in_usemixedrouterquotev2_boolean_flag_siyujiang_route-476-turn-mixed-routes-back-on-for-l2

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -542,8 +542,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
 
           // https://linear.app/uniswap/issue/ROUTE-467/tenderly-simulation-during-caching-lambda
           const deleteCacheEnabledChains = [ChainId.OPTIMISM]
-
-          const mixedSupported = [ChainId.MAINNET, ChainId.SEPOLIA, ChainId.GOERLI]
+          const mixedSupported = [ChainId.MAINNET, ChainId.SEPOLIA, ChainId.GOERLI, ChainId.OPTIMISM]
 
           const cachedRoutesCacheInvalidationFixRolloutPercentage = NEW_CACHED_ROUTES_ROLLOUT_PERCENT[chainId]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,11 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^2.0.2",
         "@uniswap/sdk-core": "^7.7.1",
+<<<<<<< HEAD
         "@uniswap/smart-order-router": "4.22.5",
+=======
+        "@uniswap/smart-order-router": "4.22.3",
+>>>>>>> 25a86cd5 (chore: bump sor to 4.22.3 - fix: mixed route quoter encoding should be consistent)
         "@uniswap/smart-wallet-sdk": "^2.1.1",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^4.19.5",
@@ -4510,7 +4514,10 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@uniswap/router-sdk/-/router-sdk-2.0.4.tgz",
       "integrity": "sha512-MxCtD+g+2pzzd9rZ6HKTdv1ZK2mLjREoDRNAp9+F961zCCVhgJr9L1/6Hour27/xxCyljwmG83Zn1cSS054giw==",
+<<<<<<< HEAD
       "license": "MIT",
+=======
+>>>>>>> 25a86cd5 (chore: bump sor to 4.22.3 - fix: mixed route quoter encoding should be consistent)
       "dependencies": {
         "@ethersproject/abi": "^5.5.0",
         "@uniswap/sdk-core": "^7.7.2",
@@ -4540,10 +4547,16 @@
       }
     },
     "node_modules/@uniswap/smart-order-router": {
+<<<<<<< HEAD
       "version": "4.22.5",
       "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.22.5.tgz",
       "integrity": "sha512-40gHmgbiizjKy/yEE4qXReNJLOpJw+z4OzEi2J1ijZaRZKNqqo1n48xRttm46HHjrIvFslYQH1XgeFXqd5uTwQ==",
       "license": "GPL",
+=======
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.22.3.tgz",
+      "integrity": "sha512-S4SKr4FQWx75PMiL9qy9pKeB9tNKWglM4NOrd8zxsg/S+H8KeW36mMiWJRcKuE8S5kf8UcHl7vI9VuDVvfVkZw==",
+>>>>>>> 25a86cd5 (chore: bump sor to 4.22.3 - fix: mixed route quoter encoding should be consistent)
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,11 +29,7 @@
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^2.0.2",
         "@uniswap/sdk-core": "^7.7.1",
-<<<<<<< HEAD
         "@uniswap/smart-order-router": "4.22.5",
-=======
-        "@uniswap/smart-order-router": "4.22.3",
->>>>>>> 25a86cd5 (chore: bump sor to 4.22.3 - fix: mixed route quoter encoding should be consistent)
         "@uniswap/smart-wallet-sdk": "^2.1.1",
         "@uniswap/token-lists": "^1.0.0-beta.33",
         "@uniswap/universal-router-sdk": "^4.19.5",
@@ -4548,6 +4544,7 @@
     },
     "node_modules/@uniswap/smart-order-router": {
 <<<<<<< HEAD
+<<<<<<< HEAD
       "version": "4.22.5",
       "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.22.5.tgz",
       "integrity": "sha512-40gHmgbiizjKy/yEE4qXReNJLOpJw+z4OzEi2J1ijZaRZKNqqo1n48xRttm46HHjrIvFslYQH1XgeFXqd5uTwQ==",
@@ -4557,6 +4554,11 @@
       "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.22.3.tgz",
       "integrity": "sha512-S4SKr4FQWx75PMiL9qy9pKeB9tNKWglM4NOrd8zxsg/S+H8KeW36mMiWJRcKuE8S5kf8UcHl7vI9VuDVvfVkZw==",
 >>>>>>> 25a86cd5 (chore: bump sor to 4.22.3 - fix: mixed route quoter encoding should be consistent)
+=======
+      "version": "4.22.5",
+      "resolved": "https://registry.npmjs.org/@uniswap/smart-order-router/-/smart-order-router-4.22.5.tgz",
+      "integrity": "sha512-40gHmgbiizjKy/yEE4qXReNJLOpJw+z4OzEi2J1ijZaRZKNqqo1n48xRttm46HHjrIvFslYQH1XgeFXqd5uTwQ==",
+>>>>>>> c8459acc (bump sor)
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@types/brotli": "^1.3.4",


### PR DESCRIPTION
release https://github.com/Uniswap/smart-order-router/pull/895