### PR TITLE
fix: euler hooks factory provider null check

### DIFF
--- a/lib/cron/cache-pools.ts
+++ b/lib/cron/cache-pools.ts
@@ -46,7 +46,7 @@ const handler: ScheduledHandler = metricScope((metrics) => async (event: EventBr
   )!.provider
   const eulerHooksProvider = chainProtocols.find(
     (element) => element.protocol == protocol && element.chainId == chainId
-  )!.eulerHooksProvider
+  )?.eulerHooksProvider
   const log: Logger = bunyan.createLogger({
     name: 'RoutingLambda',
     serializers: bunyan.stdSerializers,

--- a/lib/cron/cache-pools.ts
+++ b/lib/cron/cache-pools.ts
@@ -45,7 +45,7 @@ const handler: ScheduledHandler = metricScope((metrics) => async (event: EventBr
     (element) => element.protocol == protocol && element.chainId == chainId
   )!.provider
   const eulerHooksProvider = chainProtocols.find(
-    (element) => element.protocol === Protocol.V4 && element.chainId === chainId
+    (element) => element.protocol == protocol && element.chainId == chainId
   )!.eulerHooksProvider
   const log: Logger = bunyan.createLogger({
     name: 'RoutingLambda',
@@ -277,28 +277,30 @@ const handler: ScheduledHandler = metricScope((metrics) => async (event: EventBr
         } as V4SubgraphPool,
       ]
 
-      const eulerHooks = await eulerHooksProvider?.getHooks()
-      if (eulerHooks) {
-        metric.putMetric('eulerHooks.length', eulerHooks.length)
+      if (eulerHooksProvider) {
+        const eulerHooks = await eulerHooksProvider?.getHooks()
+        if (eulerHooks) {
+          metric.putMetric('eulerHooks.length', eulerHooks.length)
 
-        const eulerPools = await Promise.all(
-          eulerHooks.map(async (eulerHook) => {
-            const pool = await eulerHooksProvider?.getPoolByHook(eulerHook.hook)
-            log.info(`eulerHooks pool ${JSON.stringify(pool)}`)
+          const eulerPools = await Promise.all(
+            eulerHooks.map(async (eulerHook) => {
+              const pool = await eulerHooksProvider?.getPoolByHook(eulerHook.hook)
+              log.info(`eulerHooks pool ${JSON.stringify(pool)}`)
 
-            // we need to inflate euler pool TVL from 0 to significant TVL, so that they have a chance to be picked up
-            ;(pool as V4SubgraphPool).tvlUSD = 1000
-            ;(pool as V4SubgraphPool).tvlETH = 5500000
+              // we need to inflate euler pool TVL from 0 to significant TVL, so that they have a chance to be picked up
+              ;(pool as V4SubgraphPool).tvlUSD = 1000
+              ;(pool as V4SubgraphPool).tvlETH = 5500000
 
-            return pool
+              return pool
+            })
+          )
+
+          eulerPools.forEach((pool) => {
+            if (pool) {
+              manuallyIncludedV4Pools.push(pool as V4SubgraphPool)
+            }
           })
-        )
-
-        eulerPools.forEach((pool) => {
-          if (pool) {
-            manuallyIncludedV4Pools.push(pool as V4SubgraphPool)
-          }
-        })
+        }
       }
 
       if (chainId === ChainId.MAINNET) {


### PR DESCRIPTION
we are seeing `TypeError: Cannot read properties of undefined (reading 'eulerHooksProvider')` on some subgraph. cron jobs, after https://github.com/Uniswap/routing-api/pull/1143. the reason is because not every subgraph pool cron job has the `eulerHooksFactoryProvider` instantiated, hence we need to have null check protection.

I tested on my personal aws account, and i no longer see erroring out:

![Screenshot 2025-07-01 at 3.26.50 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/748318c5-c63b-478e-bc36-dc86eb5cb7af.png)

