### PR TITLE
ROUTE-574 enable unichain

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -541,7 +541,7 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
           ]
 
           // https://linear.app/uniswap/issue/ROUTE-467/tenderly-simulation-during-caching-lambda
-          const deleteCacheEnabledChains = [ChainId.OPTIMISM]
+          const deleteCacheEnabledChains = [ChainId.OPTIMISM, ChainId.UNICHAIN]
           const mixedSupported = [ChainId.MAINNET, ChainId.SEPOLIA, ChainId.GOERLI]
 
           const cachedRoutesCacheInvalidationFixRolloutPercentage = NEW_CACHED_ROUTES_ROLLOUT_PERCENT[chainId]


### PR DESCRIPTION
Enabling cache invalidation during simulation failure for UniChain