### PR TITLE
enable mixed routes across L2s

### DIFF
--- a/lib/handlers/injector-sor.ts
+++ b/lib/handlers/injector-sor.ts
@@ -573,7 +573,21 @@ export abstract class InjectorSOR<Router, QueryParams> extends Injector<
             ChainId.MONAD_TESTNET,
             ChainId.SONEIUM,
           ]
-          const mixedSupported = [ChainId.MAINNET, ChainId.SEPOLIA, ChainId.GOERLI, ChainId.OPTIMISM, ChainId.BASE]
+          const mixedSupported = [
+            ChainId.MAINNET,
+            ChainId.SEPOLIA,
+            ChainId.GOERLI,
+            ChainId.OPTIMISM,
+            ChainId.BASE,
+            ChainId.ARBITRUM_ONE,
+            ChainId.POLYGON,
+            ChainId.OPTIMISM,
+            ChainId.AVALANCHE,
+            ChainId.BNB,
+            ChainId.WORLDCHAIN,
+            ChainId.ZORA,
+            ChainId.SONEIUM,
+          ]
 
           const cachedRoutesCacheInvalidationFixRolloutPercentage = NEW_CACHED_ROUTES_ROLLOUT_PERCENT[chainId]
 


### PR DESCRIPTION
we see optimism and base have mixed routes working now, especially with base v3 jacob/eth against v4 zora creator pools and content pools, with v3 against v4 mixed cross liquidity candidate pools. we are enabling mixed routes to the rest of L2s.