### PR TITLE
fix: pass enableUniversalRouter flag on async caching call

### DIFF
--- a/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
+++ b/lib/handlers/router-entities/route-caching/dynamo-route-caching-provider.ts
@@ -452,6 +452,7 @@ export class DynamoRouteCachingProvider extends IRouteCachingProvider {
         cachedRoutesRouteIds: serializeRouteIds(cachedRoutesRouteIds),
         enableDebug: alphaRouterConfig?.enableDebug,
         swapOptions: swapOptions?.simulate?.fromAddress,
+        enableUniversalRouter: true,
       },
     }
 


### PR DESCRIPTION
Fixes https://linear.app/uniswap/issue/ROUTE-627
We have a caching bug where V4 pools are not cached from async invocation due to missing `enableUniversalRouter` flag.