### PR TITLE
fix: add error logging for decimal parsing as well as fallback to 18 decimals

### DIFF
--- a/lib/util/v4HooksPoolsFiltering.ts
+++ b/lib/util/v4HooksPoolsFiltering.ts
@@ -40,7 +40,9 @@ function isHooksPoolRoutable(pool: V4SubgraphPool, chainId: ChainId): boolean {
         !isPoolFeeDynamic(tokenA, tokenB, pool))
     )
   } catch (e) {
-    log.error(`Error creating tokens for pool ${pool.id} on chain ${chainId}: ${e}`)
+    log.error(
+      `Error creating tokens for pool ${pool.id} on chain ${chainId} with token0 decimals ${pool.token0.decimals} token1 decimals ${pool.token1.decimals}: ${e}`
+    )
 
     // hardcode to 18 decimals since we cannot parse and pass the token invariant checks
     const tokenA: Currency =


### PR DESCRIPTION
we notice 4 zip files are stuck because of this decimal invariant:

```
    {
        "@timestamp": "2025-08-18 17:16:21.366",
        "@message": {
            "name": "RoutingLambda",
            "requestId": "fb2d5898-4a35-ccd9-09d3-e218de482890",
            "hostname": "169.254.58.197",
            "pid": 13,
            "level": 50,
            "err": {
                "message": "Invariant failed: DECIMALS",
                "name": "Error",
                "stack": "Error: Invariant failed: DECIMALS\n    at ixt (/var/task/index.js:1:28406)\n    at e.xae (/var/task/index.js:1:221586)\n    at new e (/var/task/index.js:1:222069)\n    at wI0 (/var/task/index.js:998:28679)\n    at /var/task/index.js:998:29118\n    at Array.forEach (<anonymous>)\n    at Hmt (/var/task/index.js:998:29103)\n    at /var/task/index.js:998:39764\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)"
            },
            "msg": "Failed to get pools for V4 on 1",
            "time": "2025-08-18T17:16:21.363Z",
            "v": 0
        }
    },
```

we are falling back to use 18 decimals