### PR TITLE
fix: bump up PoolCaching lambda version for new v4 base graph id

### DIFF
--- a/bin/stacks/routing-caching-stack.ts
+++ b/bin/stacks/routing-caching-stack.ts
@@ -133,7 +133,7 @@ export class RoutingCachingStack extends cdk.NestedStack {
           layers: [lambdaLayerVersion],
           tracing: aws_lambda.Tracing.ACTIVE,
           environment: {
-            VERSION: '2',
+            VERSION: '3',
             POOL_CACHE_BUCKET: this.poolCacheBucket.bucketName,
             POOL_CACHE_BUCKET_3: this.poolCacheBucket3.bucketName,
             POOL_CACHE_GZIP_KEY: this.poolCacheGzipKey,


### PR DESCRIPTION
only new v4 base graph id has been sync'ed at head. we need routing to point to graph head.