### PR TITLE
Allowlist LaunchlyBNBHooks on BNB Chain

### DIFF
--- a/lib/util/hooksAddressesAllowlist.ts
+++ b/lib/util/hooksAddressesAllowlist.ts
@@ -83,7 +83,7 @@ export const LIMIT_ORDER_HOOKS_ADDRESS_ON_BASE = '0x9d11f9505ca92f4b6983c1285d1a
 // example pool: https://app.uniswap.org/explore/pools/unichain/0x348860e4565d7e3eb53af800a8931b1465a7540cdb5fa7f4dfd1e4d0bb2aa7f8
 export const PANOPTIC_ORACLE_HOOK_ON_UNICHAIN = '0x79330fe369c32a03e3b8516aff35b44706e39080'
 
-export const LAUNCHLY_BNB_HOOKS_ADDRESS_ON_BNB = '0x450e0fbfa8f19bc7c35d57ff083adff7f1b980cc'
+export const LAUNCHLY_BNB_HOOKS_ADDRESS_ON_BNB = '0xe1B70E28A596972aFE25087c062F459a0F4B40CC'
 // https://linear.app/uniswap/issue/ROUTE-757/allowlist-fey-finance-hook
 export const FEY_ON_SEPOLIA = '0x932d55d7b86d27eedd0934503e49f5f362faa8cc'
 export const FEY_ON_BASE = '0x5b409184204b86f708d3aebb3cad3f02835f68cc'


### PR DESCRIPTION
This hook charges a 2% swap fee on every buy and sell involving native assets (e.g., ETH/WBNB) in the pool. It works at the beforeSwap and afterSwap hook stages to detect incoming and outgoing swap amounts. The calculated 2% fee is automatically deducted and sent to a fixed, immutable fee recipient address.

It does not modify pool state beyond fee collection, does not require custom input data, has no admin functions, and is fully non-upgradeable. The contract cannot withdraw or manage pool liquidity, cannot pause trading, and holds no privileged roles. Its only purpose is to take a fixed 2% fee on native asset swaps for revenue-sharing purposes.

https://app.uniswap.org/explore/pools/bnb/0xe2aa3053e7bacabab466bf2977aac7f31cf59f4c371b575f4e953aa8b21fb12d
