### PR TITLE
Add Liquid Protocol hook addresses (Base)

### DIFF
--- a/lib/util/hooksAddressesAllowlist.ts
+++ b/lib/util/hooksAddressesAllowlist.ts
@@ -199,6 +199,11 @@ export const GPX_HOOKS = '0x4519e2b040ff1b64fa03abe2aef0bc99d7cceaa8'
 // example pool: https://app.uniswap.org/explore/pools/base/0xD532BF016A98A1329B83507B376493B0AEBEF85C89AAF6B505A7070ECDD63CDF
 export const LIQUID_LAUNCH_HOOK_ON_BASE = '0xea9346e83952840e69beb36df365c4e68de0e080'
 
+// Liquid Protocol — dynamic and static fee hooks for token launches with MEV protection
+// example pool: https://app.uniswap.org/explore/pools/base/0x58ce3e14d82756224b34f1acaa15e4596d97a4762917a02092d606665e544669
+export const LIQUID_PROTOCOL_DYNAMIC_FEE_HOOK_ON_BASE = '0x80e2f7dc8c2c880bbc4bdf80a5fb0eb8b1db68cc'
+export const LIQUID_PROTOCOL_STATIC_FEE_HOOK_ON_BASE = '0x9811f10cd549c754fa9e5785989c422a762c28cc'
+
 // example pool: https://app.uniswap.org/explore/pools/base/0x20aab1b33d63b7d6fc95deed43dfdf986a23a2d82857025533d2c18e2fef9e4b
 export const ARRAKIS_PRIVATE_HOOK_ON_BASE = '0xf9527fb5a34ac6fbc579e4fbc3bf292ed57d4880'
 // example pool: https://app.uniswap.org/explore/pools/ethereum/0x8679ef619b4ae7a464f8c208df1c49f294df41a237671d98882b50554c20a5c8
@@ -346,6 +351,8 @@ export const HOOKS_ADDRESSES_ALLOWLIST: { [chain in ChainId]: Array<string> } = 
     BASEMEME_HOOK_ADDRESS_ON_BASE,
     AI_PROTOCOL_SWAP_FEE_HOOK_V1_ON_BASE,
     LIQUID_LAUNCH_HOOK_ON_BASE,
+    LIQUID_PROTOCOL_DYNAMIC_FEE_HOOK_ON_BASE,
+    LIQUID_PROTOCOL_STATIC_FEE_HOOK_ON_BASE,
     BVCC_DYNAMIC_FEE_HOOK_ON_BASE,
     CLAUNCH_HOOK_ON_BASE,
     SEEDIFY_SPARK_HOOK_ON_BASE,


### PR DESCRIPTION
## Summary

- Adds **Liquid Protocol** dynamic fee and static fee V4 hook addresses to the Base allowlist
- Dynamic Fee Hook: [`0x80e2f7dc8c2c880bbc4bdf80a5fb0eb8b1db68cc`](https://basescan.org/address/0x80E2F7dC8C2C880BbC4BDF80A5Fb0eB8B1DB68CC#code)
- Static Fee Hook: [`0x9811f10cd549c754fa9e5785989c422a762c28cc`](https://basescan.org/address/0x9811f10Cd549c754Fa9E5785989c422A762c28cc#code)

## About Liquid Protocol

[Liquid Protocol](https://liquid.fun) is a token launch platform on Base built on Uniswap V4. Features include:

- **Dynamic LP fees** — volatility-responsive fees (0.5% – 5%) via a custom dynamic fee hook
- **MEV protection** — parabolic descending fees (~67% → 5% over 30s) at pool creation
- **Permanent LP** — all liquidity locked forever in an LP Locker contract
- **Creator rewards** — configurable fee splits to up to 7 recipients
- **Pool extensions** — modular per-swap logic (vault, airdrop, dev buy, presale)

Both hooks extend the same base (`LiquidHookV2`) with `beforeInitialize`, `afterInitialize`, `beforeAddLiquidity`, `beforeSwap`, `afterSwap`, and `afterSwapReturnsDelta` flags.

## Verification

- Both contracts are **verified on Basescan** (links above)
- Pools are already **indexed in the Uniswap V4 API** (e.g., pool `0x58ce3e14d82756224b34f1acaa15e4596d97a4762917a02092d606665e544669`)
- Hook submissions also filed to [Uniswap/hooklist](https://github.com/Uniswap/hooklist/issues/325)

## Test plan

- [ ] Confirm hook addresses are lowercase and valid
- [ ] Verify pools with these hooks appear in routing results for Base
- [ ] Confirm no regressions in existing hook routing

🤖 Generated with [Claude Code](https://claude.com/claude-code)