### PR TITLE
[Hooks] Add VolumeDynamicFeeHook to Optimism hooks allowlist

### DIFF
--- a/lib/util/hooksAddressesAllowlist.ts
+++ b/lib/util/hooksAddressesAllowlist.ts
@@ -133,6 +133,9 @@ export const DELI_HOOK_CONSTANT_PRODUCT_ON_BASE = '0x95afbc0fccf974b41380f24e562
 // example pool: https://app.uniswap.org/explore/pools/optimism/0xa30abc0ccd08c0c16d28ccfaf15de692a1778775de9f6dea337fb9b490163b18
 export const FINDEX_HOOK_ON_OPTIMISM = '0xb35297543d357ef62df204d8c3bd0e96038cf440'
 
+// example pool: https://app.uniswap.org/explore/pools/optimism/0x226d6297e0a25f5c1441a73922f166f16be6963b7d86dfbb97faa9e31fa6974c
+export const VOLUME_DYNAMIC_FEE_HOOK_ON_OPTIMISM = '0x2c3254da64956f495356a482d51e7311347f5044'
+
 // example pool: https://app.uniswap.org/explore/pools/ethereum/0x26b73e77f7b2cfc05d28a8978b917eced1cdf7915862292cfbb507731d5120fd
 export const ACTION_HOOK_ON_MAINNET = '0x00bbc6fc07342cf80d14b60695cf0e1aa8de00cc'
 
@@ -268,7 +271,7 @@ export const HOOKS_ADDRESSES_ALLOWLIST: { [chain in ChainId]: Array<string> } = 
   ],
   [ChainId.GOERLI]: [ADDRESS_ZERO],
   [ChainId.SEPOLIA]: [ADDRESS_ZERO, extraHooksAddressesOnSepolia, FEY_ON_SEPOLIA],
-  [ChainId.OPTIMISM]: [ADDRESS_ZERO, WETH_HOOKS_ADDRESS_ON_OP_MAINNET, FINDEX_HOOK_ON_OPTIMISM],
+  [ChainId.OPTIMISM]: [ADDRESS_ZERO, WETH_HOOKS_ADDRESS_ON_OP_MAINNET, FINDEX_HOOK_ON_OPTIMISM, VOLUME_DYNAMIC_FEE_HOOK_ON_OPTIMISM],
   [ChainId.OPTIMISM_GOERLI]: [ADDRESS_ZERO],
   [ChainId.OPTIMISM_SEPOLIA]: [ADDRESS_ZERO],
   [ChainId.ARBITRUM_ONE]: [


### PR DESCRIPTION
## Summary
Add VolumeDynamicFeeHook to the Optimism hook allowlist used by routing.

## Hook purpose
VolumeDynamicFeeHook is a Uniswap v4 dynamic fee hook designed to provide bounded adaptive LP fee control with explicit onchain telemetry and transparent operational behavior.

## Contract details
- Chain: Optimism
- Hook address: 0x2c3254da64956f495356a482d51e7311347f5044
- Pool reference: 0x226d6297e0a25f5c1441a73922f166f16be6963b7d86dfbb97faa9e31fa6974c
- Source: https://github.com/Axel-DeFi/VolumeDynamicFeeHook
- Audit: https://github.com/Axel-DeFi/VolumeDynamicFeeHook/blob/main/docs/audit-v2.4.0-en.pdf

## Accounting
The hook uses `afterSwapReturnDelta` to collect a hook fee in `afterSwap`. The fee is derived from swap settlement data using a configurable `hookFeePercent` parameter (hard-capped at 10%, changes enforced by a 48-hour timelock). Collected fees are held as ERC6909 claims in PoolManager (`mint` on swap, `burn`+`take` on owner withdrawal). No `beforeSwapReturnDelta` or other custom accounting is used.

## Safety considerations
- The hook is live and publicly documented.
- Source code is public.
- Behavior is explicit and observable through onchain events.
- The hook is not proxy-upgradeable.
- Any owner-controlled configuration is bounded and implemented in fixed contract logic.
- State transitions and operational behavior are documented in the source repository.

## Production history
Previous versions of this hook have been running on Optimism for over a month without incidents. The current version (v2.4.0) is a redeployment with an updated audit.

## Rationale for allowlist inclusion
- The hook is intended to be safely routable in Uniswap Labs products on Optimism.
- It is attached to a production-oriented v4 pool.
- The implementation is public, reviewable, and documented.
- Allowlisting is requested to enable routing consideration for this hook on Optimism.

## Contact
axel.defi.404@gmail.com

## Checklist
- [x] Hook address is added in lowercase
- [x] Change is limited to the allowlist update
- [x] Source repository is public
- [x] Audit link is provided
- [x] Chain is Optimism